### PR TITLE
feat: adding snmp profiles for netgear readynas and ucd-mib

### DIFF
--- a/profiles/kentik_snmp/_general/ucd-mib.yml
+++ b/profiles/kentik_snmp/_general/ucd-mib.yml
@@ -1,0 +1,130 @@
+# Alternative MIB for host-resources-mib used on some older devices
+# http://oid-info.com/get/1.3.6.1.4.1.2021
+
+metrics:
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.3.0
+      name: memTotalSwap
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.4.0
+      name: memAvailSwap
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.5.0
+      name: memTotalReal
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.6.0
+      name: memAvailReal
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.11.0
+      name: memTotalFree
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.12.0
+      name: memMinimumSwap
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.13.0
+      name: memShared
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.14.0
+      name: memBuffer
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.15.0
+      name: memCached
+  - MIB: UCD-SNMP-MIB
+    table:
+      OID: 1.3.6.1.4.1.2021.10
+      name: laTable
+    symbols:
+      - OID: 1.3.6.1.4.1.2021.10.1.2
+        name: laNames
+      - OID: 1.3.6.1.4.1.2021.10.1.3
+        name: laLoad
+      - OID: 1.3.6.1.4.1.2021.10.1.4
+        name: laConfig
+      - OID: 1.3.6.1.4.1.2021.10.1.5
+        name: laLoadInt
+      - OID: 1.3.6.1.4.1.2021.10.1.6
+        name: laLoadFloat
+      - OID: 1.3.6.1.4.1.2021.10.1.100
+        name: laErrorFlag
+      - OID: 1.3.6.1.4.1.2021.10.1.101
+        name: laErrMessage
+    metric_tags:
+      - tag: la_index
+        column:
+          OID: 1.3.6.1.4.1.2021.10.1.1
+          name: laIndex
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.3.0
+      name: ssSwapIn
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.4.0
+      name: ssSwapOut
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.5.0
+      name: ssIOSent
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.6.0
+      name: ssIOReceive
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.7.0
+      name: ssSysInterrupts
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.8.0
+      name: ssSysContext
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.9.0
+      name: ssCpuUser
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.10.0
+      name: ssCpuSystem
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.11.11.0
+      name: ssCpuIdle
+  - MIB: UCD-DISKIO-MIB
+    table:
+      OID: 1.3.6.1.4.1.2021.13.15.1.1
+      name: diskIOTable
+    symbols:
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.2
+        name: diskIODevice
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.3
+        name: diskIONRead
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.4
+        name: diskIONWritten
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.5
+        name: diskIOReads
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.6
+        name: diskIOWrites
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.9
+        name: diskIOLA1
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.10
+        name: diskIOLA5
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.11
+        name: diskIOLA15
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.12
+        name: diskIONReadX
+      - OID: 1.3.6.1.4.1.2021.13.15.1.1.13
+        name: diskIONWrittenX
+    metric_tags:
+      - tag: diskIO_index
+        column:
+          OID: 1.3.6.1.4.1.2021.13.15.1.1.1
+          name: diskIOIndex

--- a/profiles/kentik_snmp/netgear/readynas.yml
+++ b/profiles/kentik_snmp/netgear/readynas.yml
@@ -1,0 +1,109 @@
+# http://oid-info.com/get/1.3.6.1.4.1.4526.22
+---
+extends:
+  - system-mib.yml
+  - if-mib.yml
+
+sysobjectid: 1.3.6.1.4.1.4526.*
+
+metrics:
+  - MIB: READYNASOS-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.4526.22.1.0
+      name: nasMgrSoftwareVersion
+  - MIB: READYNASOS-MIB
+    table:
+      OID: 1.3.6.1.4.1.4526.22.3
+      name: diskTable
+    symbols:
+      - OID: 1.3.6.1.4.1.4526.22.3.1.2
+        name: diskID
+      - OID: 1.3.6.1.4.1.4526.22.3.1.3
+        name: diskSlotName
+      - OID: 1.3.6.1.4.1.4526.22.3.1.4
+        name: diskSerial
+      - OID: 1.3.6.1.4.1.4526.22.3.1.5
+        name: diskModel
+      - OID: 1.3.6.1.4.1.4526.22.3.1.6
+        name: ataError
+      - OID: 1.3.6.1.4.1.4526.22.3.1.7
+        name: diskCapacity
+      - OID: 1.3.6.1.4.1.4526.22.3.1.8
+        name: diskInterface
+      - OID: 1.3.6.1.4.1.4526.22.3.1.9
+        name: diskState
+      - OID: 1.3.6.1.4.1.4526.22.3.1.10
+        name: diskTemperature
+    metric_tags:
+      - tag: disk_index
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.1
+          name: diskEntry
+  - MIB: READYNASOS-MIB
+    table:
+      OID: 1.3.6.1.4.1.4526.22.4
+      name: fanTable
+    symbols:
+      - OID: 1.3.6.1.4.1.4526.22.4.1.2
+        name: fanRPM
+      - OID: 1.3.6.1.4.1.4526.22.4.1.3
+        name: fanStatus
+      - OID: 1.3.6.1.4.1.4526.22.4.1.4
+        name: fanType
+    metric_tags:
+      - tag: fan_index
+        column:
+          OID: 1.3.6.1.4.1.4526.22.4.1.1
+          name: fanEntry
+  - MIB: READYNASOS-MIB
+    table:
+      OID: 1.3.6.1.4.1.4526.22.5
+      name: temperatureTable
+    symbols:
+      - OID: 1.3.6.1.4.1.4526.22.5.1.2
+        name: temperatureValue
+      - OID: 1.3.6.1.4.1.4526.22.5.1.3
+        name: temperatureType
+      - OID: 1.3.6.1.4.1.4526.22.5.1.4
+        name: temperatureMin
+      - OID: 1.3.6.1.4.1.4526.22.5.1.5
+        name: temperatureMax
+    metric_tags:
+      - tag: temperature_index
+        column:
+          OID: 1.3.6.1.4.1.4526.22.5.1.1
+          name: temperatureEntry
+  - MIB: READYNASOS-MIB
+    table:
+      OID: 1.3.6.1.4.1.4526.22.7
+      name: volumeTable
+    symbols:
+      - OID: 1.3.6.1.4.1.4526.22.7.1.2
+        name: volumeName
+      - OID: 1.3.6.1.4.1.4526.22.7.1.3
+        name: volumeRAIDLevel
+      - OID: 1.3.6.1.4.1.4526.22.7.1.4
+        name: volumeStatus
+      - OID: 1.3.6.1.4.1.4526.22.7.1.5
+        name: volumeSize
+      - OID: 1.3.6.1.4.1.4526.22.7.1.6
+        name: volumeFreeSpace
+    metric_tags:
+      - tag: volume_index
+        column:
+          OID: 1.3.6.1.4.1.4526.22.7.1.1
+          name: volumeEntry
+  - MIB: READYNASOS-MIB
+    table:
+      OID: 1.3.6.1.4.1.4526.22.8
+      name: psuTable
+    symbols:
+      - OID: 1.3.6.1.4.1.4526.22.8.1.2
+        name: psuDesc
+      - OID: 1.3.6.1.4.1.4526.22.8.1.3
+        name: psuStatus
+    metric_tags:
+      - tag: psu_index
+        column:
+          OID: 1.3.6.1.4.1.4526.22.8.1.1
+          name: psuEntry

--- a/profiles/kentik_snmp/netgear/readynas.yml
+++ b/profiles/kentik_snmp/netgear/readynas.yml
@@ -3,6 +3,7 @@
 extends:
   - system-mib.yml
   - if-mib.yml
+  - ucd-mib.yml
 
 sysobjectid: 1.3.6.1.4.1.4526.*
 


### PR DESCRIPTION
adding SNMP profiles to support Netgear ReadyNAS OS devices; based on SNMP walk from ReadyNAS 5.7.2.1