### PR TITLE
Ability to work with device metadata table

### DIFF
--- a/profiles/kentik_snmp/netgear/readynas.yml
+++ b/profiles/kentik_snmp/netgear/readynas.yml
@@ -17,14 +17,6 @@ metrics:
       OID: 1.3.6.1.4.1.4526.22.3
       name: diskTable
     symbols:
-      - OID: 1.3.6.1.4.1.4526.22.3.1.2
-        name: diskID
-      - OID: 1.3.6.1.4.1.4526.22.3.1.3
-        name: diskSlotName
-      - OID: 1.3.6.1.4.1.4526.22.3.1.4
-        name: diskSerial
-      - OID: 1.3.6.1.4.1.4526.22.3.1.5
-        name: diskModel
       - OID: 1.3.6.1.4.1.4526.22.3.1.6
         name: ataError
       - OID: 1.3.6.1.4.1.4526.22.3.1.7
@@ -40,6 +32,22 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.4526.22.3.1.1
           name: diskEntry
+      - tag: disk_id
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.2
+          name: diskID
+      - tag: disk_slot_name
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.3
+          name: diskSlotName
+      - tag: disk_serial
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.4
+          name: diskSerial
+      - tag: disk_model
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.5
+          name: diskModel
   - MIB: READYNASOS-MIB
     table:
       OID: 1.3.6.1.4.1.4526.22.4


### PR DESCRIPTION
Adds the ability to run over a table of device metadata. 

Also tweaking the readynas yaml profile to take advantage of this. 