### PR TITLE
Moving diskInterface from a metric to metadata

### DIFF
--- a/profiles/kentik_snmp/netgear/readynas.yml
+++ b/profiles/kentik_snmp/netgear/readynas.yml
@@ -21,8 +21,6 @@ metrics:
         name: ataError
       - OID: 1.3.6.1.4.1.4526.22.3.1.7
         name: diskCapacity
-      - OID: 1.3.6.1.4.1.4526.22.3.1.8
-        name: diskInterface
       - OID: 1.3.6.1.4.1.4526.22.3.1.9
         name: diskState
       - OID: 1.3.6.1.4.1.4526.22.3.1.10
@@ -48,6 +46,10 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.4526.22.3.1.5
           name: diskModel
+      - tag: disk_interface
+        column:
+          OID: 1.3.6.1.4.1.4526.22.3.1.8
+          name: diskInterface
   - MIB: READYNASOS-MIB
     table:
       OID: 1.3.6.1.4.1.4526.22.4


### PR DESCRIPTION
```
.1.3.6.1.4.1.4526.22.3.1.8.4 = STRING: "SATA"
```