### PR TITLE
chore: updating CPU and Memory OIDs for Aruba

### DIFF
--- a/profiles/kentik_snmp/aruba/aruba.yml
+++ b/profiles/kentik_snmp/aruba/aruba.yml
@@ -33,34 +33,16 @@ metrics:
           OID: 1.3.6.1.4.1.14823.2.2.1.2.1.18.1.1
           name: sysExtPowerSupplyIndex
   - MIB: WLSX-SYSTEMEXT-MIB
-    table:
-      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13
-      name: wlsxSysExtProcessorTable
-    symbols:
-      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13.1.3
-        name: sysExtProcessorLoad
-    metric_tags:
-      - tag: processor_index
-        column:
-          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13.1.1
-          name: sysExtProcessorID
-  - MIB: WLSX-SYSTEMEXT-MIB
-    table:
-      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1
-      name: wlsxSysExtMemoryTable
-    symbols:
-      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.2
-        name: sysExtMemorySize
-      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.3
-        name: sysExtMemoryUsed
-      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.4
-        name: sysExtMemoryFree
-    metric_tags:
-      - tag: memory_index
-        column:
-          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.1
-          name: sysExtMemoryIndex
-  - MIB: WLSX-SYSTEMEXT-MIB
     symbol:
       OID: 1.3.6.1.4.1.14823.2.2.1.2.1.32.0
       name: wlsxSysExtPacketLossPercent
+  - MIB: WLSX-SYSTEMEXT-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.30.0
+      name: wlsxSysExtCpuUsedPercent
+      tag: CPU
+  - MIB: WLSX-SYSTEMEXT-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.31.0
+      name: wlsxSysExtMemoryUsedPercent
+      tag: MemoryUtilization


### PR DESCRIPTION
removing table dependencies in favor of direct OIDs