### PR TITLE
chore: adding enum to apc ups profile

### DIFF
--- a/config/profiles/kentik_snmp/apc/apc_ups.yml
+++ b/config/profiles/kentik_snmp/apc/apc_ups.yml
@@ -18,6 +18,9 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.2.2.4.0
       name: upsAdvBatteryReplaceIndicator
+      enum:
+        noBatteryNeedsReplacing: 1
+        batteryNeedsReplacing: 2
   - MIB: PowerNet-MIB_UPS
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.2.2.3.0
@@ -46,6 +49,15 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.3.2.5.0
       name: upsAdvInputLineFailCause
+      enum:
+        noTransfer: 1
+        highLineVoltage: 2
+        brownout: 3
+        blackout: 4
+        smallMomentarySag: 5
+        deepMomentarySag: 6
+        smallMomentarySpike: 7
+        largeMomentarySpike: 8
   - MIB: PowerNet-MIB_UPS
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.4.2.3.0
@@ -58,6 +70,11 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.7.2.3.0
       name: upsAdvTestDiagnosticsResults
+      enum:
+        ok: 1
+        failed: 2
+        invalidTest: 3
+        testInProgress: 4
   - MIB: PowerNet-MIB_UPS
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0


### PR DESCRIPTION
adding several enumerations to the APC UPS profile