### PR TITLE
fix: moving enum to proper location

### DIFF
--- a/config/profiles/kentik_snmp/_general/bgp4-mib.yml
+++ b/config/profiles/kentik_snmp/_general/bgp4-mib.yml
@@ -17,7 +17,6 @@ metrics:
         name: bgpPeerRemoteAs
       - OID: 1.3.6.1.2.1.15.3.1.2
         name: bgpPeerState
-      - OID: 1.3.6.1.2.1.15.3.1.10
         enum:
           idle: 1
           connect: 2
@@ -25,6 +24,7 @@ metrics:
           opensent: 4
           openconfirm: 5
           established: 6
+      - OID: 1.3.6.1.2.1.15.3.1.10
         name: bgpPeerInUpdates
       - OID: 1.3.6.1.2.1.15.3.1.11
         name: bgpPeerOutUpdates


### PR DESCRIPTION
enum for `bgpPeerState` was erroneously on the wrong OID