### PR TITLE
Adding ability to white list snmp metrics by attribute. (#57)

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -483,6 +483,12 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 		f.Debugf("Missing interface metadata for %s", in.DeviceName)
 	}
 
+	if drop, ok := attr[kt.DropMetric]; ok {
+		if drop.(bool) {
+			return nil // This Metric isn't in the white list so lets drop it.
+		}
+	}
+
 	ms := make([]NRMetric, 0, len(metrics))
 	for m, name := range metrics {
 		if _, ok := in.CustomBigInt[m]; ok {

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -117,6 +117,20 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]string
 				}
 			}
 		}
+
+		// Finally, drop any values which do not match the whitelist.
+		if lastMetadata.MatchAttr != nil {
+			for k, re := range lastMetadata.MatchAttr {
+				if v, ok := attr[k]; ok {
+					if strv, ok := v.(string); ok {
+						attr[kt.DropMetric] = !re.MatchString(strv)
+						if attr[kt.DropMetric] == false {
+							break // Only keep going if we did not match. All matches are OR-d together.
+						}
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -167,6 +181,7 @@ func SetMetadata(in *kt.JCHF) *kt.LastMetadata {
 		}
 	}
 	lm.Tables = in.CustomTables
+	lm.MatchAttr = in.MatchAttr
 
 	return &lm
 }

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -122,6 +122,11 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 			in.CustomStr[field] = fmsg.Type.String()
 		case "TimeReceived":
 			in.Timestamp = int64(fmsg.TimeReceived)
+			// Verify this is MS. If not, make it MS.
+			if in.Timestamp < 999999999999 {
+				// Assume seconds and multiply
+				in.Timestamp = in.Timestamp * 1000
+			}
 		case "SequenceNum":
 			in.CustomBigInt[field] = int64(fmsg.SequenceNum)
 		case "SamplingRate":

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -112,6 +112,7 @@ type SnmpDeviceConfig struct {
 	PollTimeSec            int               `yaml:"poll_time_sec"`
 	TimeoutMS              int               `yaml:"timeout_ms"`
 	Retries                int               `yaml:"retries"`
+	MatchAttr              map[string]string `yaml:"match_attributes"`
 }
 
 type SnmpTrapConfig struct {
@@ -219,6 +220,7 @@ type LastMetadata struct {
 	DeviceInfo    map[string]interface{}
 	InterfaceInfo map[IfaceID]map[string]interface{}
 	Tables        map[string]DeviceTableMetadata
+	MatchAttr     map[string]*regexp.Regexp
 }
 
 func (lm *LastMetadata) Size() int {

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -1,6 +1,7 @@
 package kt
 
 import (
+	"regexp"
 	"strconv"
 	"time"
 )
@@ -31,6 +32,7 @@ const (
 	IndexVar         = "Index"
 	StringPrefix     = "ks_"
 	PrivateIP        = "Private IP"
+	DropMetric       = "DropMetric"
 )
 
 type OutputType string
@@ -160,6 +162,7 @@ type JCHF struct {
 	hasSetAvro              bool
 	CustomMetrics           map[string]string              `json:"-"`
 	CustomTables            map[string]DeviceTableMetadata `json:"-"`
+	MatchAttr               map[string]*regexp.Regexp      `json:"-"`
 }
 
 func NewJCHF() *JCHF {

--- a/pkg/util/rule/rule_test.go
+++ b/pkg/util/rule/rule_test.go
@@ -17,6 +17,7 @@ func TestIsInternal(t *testing.T) {
 		"2001:d01:abcd::/64": true,
 		"10.2.1.3":           true,
 		"172.16.0.1":         true,
+		"10.19.38.78":        true,
 		"foo":                false,
 	}
 
@@ -28,6 +29,7 @@ func TestIsInternal(t *testing.T) {
 		"10.2.1.3":           4294967294,
 		"172.16.0.1":         3,
 		"foo":                3,
+		"10.19.38.78":        23,
 	}
 
 	for ip, isInternal := range tests {


### PR DESCRIPTION
Whitelist snmp attributes.

```
match_attributes: <when>
  if_Description: <matches>^igb <OR> <matches>^eth
  <OR>
  if_Alias: <matches>*foo*
```

Forcing flow timestamp to MS if its not.

