### PR TITLE
Fix tsak (#59)

### DIFF
--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -61,6 +61,9 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		}
 		attrMap[attr] = re
 	}
+	if !conf.MonitorAdminShut { // This one is common and so is set explicitly.
+		attrMap["if_ifAdminStatus"] = regexp.MustCompile("1")
+	}
 	if len(attrMap) > 0 {
 		log.Infof("Added %d Match Attribute(s)", len(attrMap))
 	}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -113,6 +113,7 @@ type SnmpDeviceConfig struct {
 	TimeoutMS              int               `yaml:"timeout_ms"`
 	Retries                int               `yaml:"retries"`
 	MatchAttr              map[string]string `yaml:"match_attributes"`
+	MonitorAdminShut       bool              `yaml:"monitor_admin_shut"`
 }
 
 type SnmpTrapConfig struct {


### PR DESCRIPTION
* Fixing snmp for the tsak mock tool.

*Defaulting to not send in snmp from down interfaces (monitor_admin_shut).