### PR TITLE
Taking out service_name attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/*
 
 ## This is downloaded at build time
 config/GeoLite2-Country.mmdb
+config/GeoLite2-ASN.mmdb

--- a/config/snmp-win.yaml
+++ b/config/snmp-win.yaml
@@ -1,0 +1,28 @@
+devices:
+trap:
+  listen: 127.0.0.1:162
+  community: hello
+  version: ""
+  transport: ""
+discovery:
+  cidrs:
+  - 10.10.0.0/24
+  debug: false
+  ports:
+  - 161
+  default_communities:
+  - public
+  default_v3: null
+  add_devices: true
+  add_mibs: false
+  threads: 4
+  replace_devices: true
+global:
+  poll_time_sec: 60
+  drop_if_outside_poll: false
+  mib_profile_dir: c:/Program Files (x86)/KTranslate/config/profiles
+  mibs_db: c:/Program Files (x86)/KTranslate/config/mibs.db
+  mibs_enabled:
+  - IF-MIB
+  timeout_ms: 3000
+  retries: 0

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -99,12 +99,12 @@ func (kc *KTranslate) getProviderType(dst *kt.JCHF) kt.Provider {
 
 	udr, ok := dst.CustomStr[UDR_TYPE]
 	if !ok { // Return this right away.
-		return kt.ProviderRouter
+		return kt.ProviderFlowDevice
 	}
 
 	// Or maybe its a host.
 	if udr == "kprobe" || udr == "kappa" {
-		return kt.ProviderHost
+		return kt.ProviderFlowDevice
 	}
 
 	// Else, if its synth, return this.
@@ -117,8 +117,8 @@ func (kc *KTranslate) getProviderType(dst *kt.JCHF) kt.Provider {
 		return kt.ProviderVPC
 	}
 
-	// Default to router.
-	return kt.ProviderRouter
+	// Default to provider.
+	return kt.ProviderFlowDevice
 }
 
 func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]string, regioncache map[uint32]string, dst *kt.JCHF, src *Flow, currentTS int64, tagcache map[uint64]string) error {

--- a/pkg/formats/json/json.go
+++ b/pkg/formats/json/json.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 
+	"github.com/kentik/ktranslate/pkg/formats/util"
 	"github.com/kentik/ktranslate/pkg/kt"
 	"github.com/kentik/ktranslate/pkg/rollup"
 
@@ -165,6 +166,9 @@ func strip(in map[string]interface{}) {
 			if tv == 0 {
 				delete(in, k)
 			}
+		}
+		if _, ok := util.DroppedAttrs[k]; ok {
+			delete(in, k)
 		}
 	}
 	in["instrumentation.provider"] = kt.InstProvider  // Let them know who sent this.

--- a/pkg/formats/json/json_test.go
+++ b/pkg/formats/json/json_test.go
@@ -59,6 +59,7 @@ func TestSeriToJsonFlatten(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(len(kt.InputTesting), len(out))
 	for i, _ := range out {
-		assert.Equal(kt.InputTesting[i].Timestamp, out[i]["timestamp"])
+		assert.Equal(kt.InputTesting[i].SrcAddr, out[i]["src_addr"])
+		assert.Equal(int(0), int(out[i]["timestamp"].(int64)))
 	}
 }

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -28,6 +28,7 @@ var (
 		"appl_latency_ms":         true,
 		"server_nw_latency_ms":    true,
 		"connection_id":           true,
+		"service_name":            true,
 	}
 )
 

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -147,6 +147,9 @@ func (dm *DeviceMetrics) convertDMToCHF(dmrs []*deviceMetricRow) []*kt.JCHF {
 		for k, v := range dm.conf.UserTags {
 			dst.CustomStr[k] = v
 		}
+		if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
+			dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
+		}
 
 		if dmr.juniperOperatingDRAMSize > 0 {
 			dst.CustomBigInt["juniperOperatingDRAMSize"] = dmr.juniperOperatingDRAMSize
@@ -317,6 +320,9 @@ func (dm *DeviceMetrics) pollFromConfig(server *gosnmp.GoSNMP) ([]*kt.JCHF, erro
 		for k, v := range dm.conf.UserTags {
 			dst.CustomStr[k] = v
 		}
+		if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
+			dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
+		}
 
 		// Memory can be compound value so need to do it here if present but not already set.
 		if _, ok := dst.CustomBigInt["MemoryUtilization"]; !ok {
@@ -349,6 +355,9 @@ func (dm *DeviceMetrics) pollFromConfig(server *gosnmp.GoSNMP) ([]*kt.JCHF, erro
 		dst.CustomMetrics = metricsFound // Add this in so that we know what metrics to pull out down the road.
 		for k, v := range dm.conf.UserTags {
 			dst.CustomStr[k] = v
+		}
+		if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
+			dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
 		}
 		flows = append(flows, dst)
 	}

--- a/pkg/inputs/snmp/metrics/interface_metrics.go
+++ b/pkg/inputs/snmp/metrics/interface_metrics.go
@@ -226,6 +226,9 @@ func (im *InterfaceMetrics) convertToCHF(deltas map[string]map[string]uint64) []
 		for k, v := range im.conf.UserTags {
 			dst.CustomStr[k] = v
 		}
+		if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
+			dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
+		}
 
 		metrics := map[string]string{}
 		for k, v := range cs {

--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -46,7 +46,7 @@ func NewMibDB(mibpath string, profileDir string, log logger.ContextL) (*MibDB, e
 
 	if mibpath != "" {
 		log.Infof("Loading db from %s", mibpath)
-		db, err := leveldb.OpenFile(mibpath, &opt.Options{})
+		db, err := leveldb.OpenFile(mibpath, &opt.Options{ReadOnly: true})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -191,12 +191,12 @@ func launchSnmp(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpD
 	// We need two of these, to avoid concurrent access by the two pollers.
 	// gosnmp isn't real clear on its approach to concurrency, but it seems
 	// like maintaining separate GoSNMP structs for the two goroutines is safe.
-	metadataServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, log)
+	metadataServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
 	if err != nil {
 		log.Warnf("Init Issue starting SNMP interface component -- %v", err)
 		return err
 	}
-	metricsServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, log)
+	metricsServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
 	if err != nil {
 		log.Warnf("Init Issue starting SNMP interface component -- %v", err)
 		return err

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -29,17 +29,22 @@ var (
 	dumpMibTable = flag.Bool("snmp_dump_mibs", false, "If true, dump the list of possible mibs on start.")
 	flowOnly     = flag.Bool("snmp_flow_only", false, "If true, don't poll snmp devices.")
 	jsonToYaml   = flag.String("snmp_json2yaml", "", "If set, convert the passed in json file to a yaml profile.")
+	snmpWalk     = flag.String("snmp_do_walk", "", "If set, try to perform a snmp walk against the targeted device.")
 )
 
 func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL) error {
 	// Do this once here just to see if we need to exit right away.
-	conf, _, _, err := initSnmp(ctx, snmpFile, log)
+	conf, connectTimeout, retries, err := initSnmp(ctx, snmpFile, log)
 	if err != nil || conf == nil || conf.Global == nil { // If no global, we're turning off all snmp polling.
 		return err
 	}
 
 	if *jsonToYaml != "" { // If this flag is set, convert a passed in json mib file to a yaml profile and call it a day.
 		return mibs.ConvertJson2Yaml(*jsonToYaml, log)
+	}
+
+	if *snmpWalk != "" { // If this flag is set, do just a snmp walk on the targeted device and exit.
+		return snmp_util.DoWalk(*snmpWalk, conf, connectTimeout, retries, log)
 	}
 
 	// Load a mibdb if we have one.

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -135,7 +135,10 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		}
 	} else {
 		dst.DeviceName = addr.IP.String()
-		dst.Provider = kt.ProviderRouter
+		dst.Provider = kt.ProviderDefault
+	}
+	if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
+		dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
 	}
 
 	for _, v := range packet.Variables {

--- a/pkg/inputs/snmp/util/adaptor.go
+++ b/pkg/inputs/snmp/util/adaptor.go
@@ -77,7 +77,7 @@ func (l logWrapper) Printf(format string, v ...interface{}) {
 	l.printf(format, v...)
 }
 
-func InitSNMP(device *kt.SnmpDeviceConfig, connectTimeout time.Duration, retries int, log logger.ContextL) (*gosnmp.GoSNMP, error) {
+func InitSNMP(device *kt.SnmpDeviceConfig, connectTimeout time.Duration, retries int, posit string, log logger.ContextL) (*gosnmp.GoSNMP, error) {
 
 	if (device.Community == "" && device.V3 == nil) || device.DeviceIP == "" {
 		return nil, fmt.Errorf("community or server IP not set")
@@ -112,10 +112,10 @@ func InitSNMP(device *kt.SnmpDeviceConfig, connectTimeout time.Duration, retries
 	if device.V3 == nil {
 		server.Community = device.Community
 		if device.UseV1 {
-			log.Infof("Running with SNMP v1")
+			log.Infof("%s Running with SNMP v1", posit)
 			server.Version = gosnmp.Version1
 		} else {
-			log.Infof("Running with SNMP v2c")
+			log.Infof("%s Running with SNMP v2c", posit)
 			server.Version = gosnmp.Version2c
 		}
 	} else {
@@ -124,7 +124,7 @@ func InitSNMP(device *kt.SnmpDeviceConfig, connectTimeout time.Duration, retries
 			return nil, err
 		}
 
-		log.Infof("Running with SNMP v3")
+		log.Infof("%s Running with SNMP v3", posit)
 		server.Version = gosnmp.Version3
 		server.ContextEngineID = contextEngineID
 		server.ContextName = contextName

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -69,7 +69,8 @@ const (
 	CollectorName = "ktranslate"
 	SnmpCollector = "snmp"
 
-	SendBatchDuration = 1 * time.Second
+	SendBatchDuration     = 1 * time.Second
+	DefaultProfileMessage = "Missing matched profile. See overview page for details."
 )
 
 type IntId uint64


### PR DESCRIPTION
Adding a warning for snmp default profile.

Removes `service_name` if it comes in to keep away from a NR bug.

Adds the string ```profile_message: Missing matched profile. See overview page for details. for default profiles.```

Adds a small snmp yaml file configured to windows. 
