### PR TITLE
feat: adding broacade fc switch profile

### DIFF
--- a/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml
+++ b/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml
@@ -1,0 +1,63 @@
+# http://www.circitor.fr/Mibs/Html/F/FIBRE-CHANNEL-FE-MIB.php
+---
+
+extends: 
+  - system-mib.yml
+  - if-mib.yml
+
+sysobjectid: 1.3.6.1.4.1.1588.2.1.1.*
+
+metrics:
+  - MIB: RESOURCE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.1588.2.1.1.1.26.1.0
+      name: swCpuUsage
+      tag: CPU
+  - MIB: RESOURCE-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.1588.2.1.1.1.26.6.0
+      name: swMemUsage
+      tag: MemoryUtilization
+  - MIB: FIBRE-CHANNEL-FE-MIB
+    table:
+      OID: 1.3.6.1.2.1.75.1.2.1
+      name: fcFxPortStatusTable
+    symbols:
+      - OID: 1.3.6.1.2.1.75.1.2.1.1.3
+        name: fcFxPortOperMode
+        enum:
+          unknown: 1
+          fPort: 2
+          flPort: 3
+      - OID: 1.3.6.1.2.1.75.1.2.1.1.4
+        name: fcFxPortAdminMode
+        enum:
+          fPort: 2
+          flPort: 3
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.75.1.2.1.1.1
+          name: 
+        tag: port_index
+
+  - MIB: FIBRE-CHANNEL-FE-MIB
+    table:
+      OID: 1.3.6.1.2.1.75.1.2.2
+      name: fcFxPortPhysTable
+    symbols:
+      - OID: 1.3.6.1.2.1.75.1.2.2.1.1
+        name: fcFxPortPhysAdminStatus
+        enum:
+          online: 1
+          offline: 2
+          testing: 3
+      - OID: 1.3.6.1.2.1.75.1.2.2.1.2
+        name: fcFxPortPhysOperStatus
+        enum:
+          online: 1
+          offline: 2
+          testing: 3
+          linkFailure: 4
+    metric_tags:
+      - index: 1
+        tag: port_index


### PR DESCRIPTION
adding new snmp profile for brocade switch

@i3149 - can you please add a new value for fibre-channel on the provider evaluation?

`provider: kentik-fibre-channel` 

