### PR TITLE
Fixing brocade fc profile

### DIFF
--- a/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml
+++ b/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml
@@ -1,7 +1,7 @@
 # http://www.circitor.fr/Mibs/Html/F/FIBRE-CHANNEL-FE-MIB.php
 ---
 
-extends: 
+extends:
   - system-mib.yml
   - if-mib.yml
 
@@ -37,7 +37,7 @@ metrics:
     metric_tags:
       - column:
           OID: 1.3.6.1.2.1.75.1.2.1.1.1
-          name: 
+          name: portIndex
         tag: port_index
 
   - MIB: FIBRE-CHANNEL-FE-MIB


### PR DESCRIPTION
Small bug where the missing name triggers an error:

```
2021-08-03T17:01:18.129 ktranslate(557004) [Warn] KTranslate Possibly corrupted metadata table? brocade-fc-switch.yml {{1.3.6.1.2.1.75.1.2.1.1.1  map[]  } port_index  0}
```