### PR TITLE
Fix multi ip

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -202,10 +202,6 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 		device.Provider = provider
 	}
 
-	if device.DeviceName == "CN56GV70C7" {
-		device.DeviceName = "CN56GV703W"
-	}
-
 	mux.Lock()
 	defer mux.Unlock()
 	foundDevices[result.Host.String()] = &device

--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -158,7 +158,11 @@ func getTable(log logger.ContextL, g *gosnmp.GoSNMP, oid string, mib *kt.Mib, md
 
 		switch variable.Type {
 		case gosnmp.OctetString:
-			md.Tables[idx].Customs[oidName] = string(variable.Value.([]byte))
+			value := string(variable.Value.([]byte))
+			if mib.Conversion != "" { // Adjust for any hard coded values here.
+				value = snmp_util.GetFromConv(variable, mib.Conversion, log)
+			}
+			md.Tables[idx].Customs[oidName] = value
 		case gosnmp.IPAddress: // Does this work?
 			switch val := variable.Value.(type) {
 			case string:

--- a/pkg/inputs/snmp/metadata/interface_metadata.go
+++ b/pkg/inputs/snmp/metadata/interface_metadata.go
@@ -415,11 +415,7 @@ func (im *InterfaceMetadata) Poll(server *gosnmp.GoSNMP) (map[string]*kt.Interfa
 				case SNMP_ifPhysAddress:
 					switch variable.Type {
 					case gosnmp.OctetString:
-						b := variable.Value.([]byte)
-						if len(b) > 0 {
-							value := "0x" + hex.EncodeToString(b)
-							data.ExtraInfo[SNMP_ifPhysAddress] = value
-						}
+						data.ExtraInfo[SNMP_ifPhysAddress] = snmp_util.GetFromConv(variable, "hwaddr", im.log)
 					}
 				case SNMP_ifLastChange:
 					val := gosnmp.ToBigInt(variable.Value).Uint64()

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -270,6 +270,9 @@ func (dm *DeviceMetrics) pollFromConfig(server *gosnmp.GoSNMP) ([]*kt.JCHF, erro
 		switch variable.Type {
 		case gosnmp.OctetString, gosnmp.BitString:
 			value := string(variable.Value.([]byte))
+			if mib.Conversion != "" { // Adjust for any hard coded values here.
+				value = snmp_util.GetFromConv(variable, mib.Conversion, dm.log)
+			}
 			if mib.Enum != nil {
 				dmr.customStr[kt.StringPrefix+oidName] = value // Save the string valued field as an attribute.
 				if val, ok := mib.Enum[strings.ToLower(value)]; ok {

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -13,11 +13,12 @@ import (
 )
 
 type OID struct {
-	Oid  string           `yaml:"OID,omitempty"`
-	Name string           `yaml:"name,omitempty"`
-	Enum map[string]int64 `yaml:"enum,omitempty"`
-	Tag  string           `yaml:"tag,omitempty"`
-	Desc string           `yaml:"description,omitempty"`
+	Oid        string           `yaml:"OID,omitempty"`
+	Name       string           `yaml:"name,omitempty"`
+	Enum       map[string]int64 `yaml:"enum,omitempty"`
+	Tag        string           `yaml:"tag,omitempty"`
+	Desc       string           `yaml:"description,omitempty"`
+	Conversion string           `yaml:"conversion,omitempty"`
 }
 
 type Tag struct {
@@ -294,11 +295,12 @@ func (p *Profile) GetMetrics(enabledMibs []string) (map[string]*kt.Mib, map[stri
 		// TODO -- so we want to collase Symbol and Symbols?
 		if metric.Symbol.Oid != "" {
 			mib := &kt.Mib{
-				Oid:  metric.Symbol.Oid,
-				Name: metric.Symbol.Name,
-				Type: otype,
-				Enum: metric.Symbol.Enum,
-				Tag:  metric.Symbol.Tag,
+				Oid:        metric.Symbol.Oid,
+				Name:       metric.Symbol.Name,
+				Type:       otype,
+				Enum:       metric.Symbol.Enum,
+				Tag:        metric.Symbol.Tag,
+				Conversion: metric.Symbol.Conversion,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -316,11 +318,12 @@ func (p *Profile) GetMetrics(enabledMibs []string) (map[string]*kt.Mib, map[stri
 
 		for _, s := range metric.Symbols {
 			mib := &kt.Mib{
-				Oid:  s.Oid,
-				Name: s.Name,
-				Type: otype,
-				Enum: s.Enum,
-				Tag:  s.Tag,
+				Oid:        s.Oid,
+				Name:       s.Name,
+				Type:       otype,
+				Enum:       s.Enum,
+				Tag:        s.Tag,
+				Conversion: s.Conversion,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -367,10 +370,11 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 	for _, tag := range p.MetricTags {
 		if tag.Column.Oid != "" {
 			mib := &kt.Mib{
-				Oid:  tag.Column.Oid,
-				Name: tag.Column.Name,
-				Type: kt.String,
-				Tag:  tag.Tag,
+				Oid:        tag.Column.Oid,
+				Name:       tag.Column.Name,
+				Type:       kt.String,
+				Tag:        tag.Tag,
+				Conversion: tag.Column.Conversion,
 			}
 			deviceMetadata[tag.Column.Oid] = mib
 		}
@@ -390,10 +394,11 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 		for _, t := range metric.MetricTags {
 			if t.Column.Oid != "" {
 				mib := &kt.Mib{
-					Oid:  t.Column.Oid,
-					Name: t.Column.Name,
-					Type: kt.String,
-					Tag:  t.Tag,
+					Oid:        t.Column.Oid,
+					Name:       t.Column.Name,
+					Type:       kt.String,
+					Tag:        t.Tag,
+					Conversion: t.Column.Conversion,
 				}
 				if strings.HasPrefix(t.Column.Name, "if") {
 					interfaceMetadata[t.Column.Oid] = mib

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -24,11 +24,13 @@ import (
 )
 
 var (
-	mibdb        *mibs.MibDB // Global singleton instance here.
-	dumpMibTable = flag.Bool("snmp_dump_mibs", false, "If true, dump the list of possible mibs on start.")
-	flowOnly     = flag.Bool("snmp_flow_only", false, "If true, don't poll snmp devices.")
-	jsonToYaml   = flag.String("snmp_json2yaml", "", "If set, convert the passed in json file to a yaml profile.")
-	snmpWalk     = flag.String("snmp_do_walk", "", "If set, try to perform a snmp walk against the targeted device.")
+	mibdb          *mibs.MibDB // Global singleton instance here.
+	dumpMibTable   = flag.Bool("snmp_dump_mibs", false, "If true, dump the list of possible mibs on start.")
+	flowOnly       = flag.Bool("snmp_flow_only", false, "If true, don't poll snmp devices.")
+	jsonToYaml     = flag.String("snmp_json2yaml", "", "If set, convert the passed in json file to a yaml profile.")
+	snmpWalk       = flag.String("snmp_do_walk", "", "If set, try to perform a snmp walk against the targeted device.")
+	snmpWalkOid    = flag.String("snmp_walk_oid", ".1.3.6.1", "Walk this oid if -snmp_do_walk is set.")
+	snmpWalkFormat = flag.String("snmp_walk_format", "", "use this format for walked values if -snmp_do_walk is set.")
 )
 
 func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL) error {
@@ -43,7 +45,7 @@ func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 	}
 
 	if *snmpWalk != "" { // If this flag is set, do just a snmp walk on the targeted device and exit.
-		return snmp_util.DoWalk(*snmpWalk, conf, connectTimeout, retries, log)
+		return snmp_util.DoWalk(*snmpWalk, *snmpWalkOid, *snmpWalkFormat, conf, connectTimeout, retries, log)
 	}
 
 	// Load a mibdb if we have one.

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -167,11 +167,10 @@ func GetDeviceManufacturer(server snmpWalker, log logger.ContextL) string {
 	return deviceManufacturer
 }
 
-func PrettyPrint(pdu gosnmp.SnmpPDU, log logger.ContextL) string {
+func PrettyPrint(pdu gosnmp.SnmpPDU, format string, log logger.ContextL) string {
 	switch pdu.Type {
 	case gosnmp.OctetString:
-		src := pdu.Value.([]byte)
-		return string(src)
+		return GetFromConv(pdu, format, log)
 	case gosnmp.IPAddress:
 		return pdu.Value.(string)
 	case gosnmp.ObjectIdentifier:
@@ -183,7 +182,7 @@ func PrettyPrint(pdu gosnmp.SnmpPDU, log logger.ContextL) string {
 }
 
 // Does a walk of the targeted device and exits.
-func DoWalk(device string, conf *kt.SnmpConfig, connectTimeout time.Duration, retries int, log logger.ContextL) error {
+func DoWalk(device string, baseOid string, format string, conf *kt.SnmpConfig, connectTimeout time.Duration, retries int, log logger.ContextL) error {
 	dconf := conf.Devices[device]
 	if dconf == nil {
 		return fmt.Errorf("No such device found in snmp config: %s", device)
@@ -194,13 +193,13 @@ func DoWalk(device string, conf *kt.SnmpConfig, connectTimeout time.Duration, re
 		return err
 	}
 
-	res, err := WalkOID(".1.3.6.1", server, log, "")
+	res, err := WalkOID(baseOid, server, log, "")
 	if err != nil {
 		return err
 	}
 
 	for _, variable := range res {
-		log.Infof("%s snmpwalk result: %s = %v: %s", device, variable.Name, variable.Type, PrettyPrint(variable, log))
+		log.Infof("%s snmpwalk result: %s = %v: %s", device, variable.Name, variable.Type, PrettyPrint(variable, format, log))
 	}
 
 	time.Sleep(200 * time.Millisecond)

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -204,13 +204,14 @@ const (
 )
 
 type Mib struct {
-	Oid     string
-	Name    string
-	Type    Oidtype
-	Extra   string
-	Tag     string
-	Enum    map[string]int64
-	EnumRev map[int64]string
+	Oid        string
+	Name       string
+	Type       Oidtype
+	Extra      string
+	Tag        string
+	Enum       map[string]int64
+	EnumRev    map[int64]string
+	Conversion string
 }
 
 func (mb Mib) String() string {


### PR DESCRIPTION
#84 -- handles this fairly gracefully.
Handles binary encoded ints as string. 

For example: 

```
  - MIB: Foo
    symbol:
      OID: 1.3.6.1.4.1.8072.1.2.1.1.4.0.12.1.3.6.1.4.1.2021.13.15.1.1.3
      name: test
      conversion: hextoint:BigEndian:uint16
```

Will correctly return this value as a uint16. 