### PR TITLE
fix: typo in CPU OID on nexus profile

### DIFF
--- a/config/profiles/kentik_snmp/cisco/cisco-nexus.yml
+++ b/config/profiles/kentik_snmp/cisco/cisco-nexus.yml
@@ -72,7 +72,7 @@ sysobjectid:
 metrics:
   - MIB: CISCO-SYSTEM-EXT-MIB
     symbol:
-      OID: 1.3.6.1.4.1.9.9.305.1.1.1
+      OID: 1.3.6.1.4.1.9.9.305.1.1.1.0
       name: cseSysCPUUtilization
       tag: CPU
   - MIB: CISCO-SYSTEM-EXT-MIB


### PR DESCRIPTION
missing trailing 0 on scalar oid