### PR TITLE
Adding a guard to error if a sysoid is present in two profiles

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -187,6 +188,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 				device.DiscoveredMibs[i] = m
 				i++
 			}
+			sort.Strings(device.DiscoveredMibs) // Put them in a common ordering.
 		}
 	}
 

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -444,8 +444,12 @@ func (mdb *MibDB) parseMibFromYml(fname string, file os.DirEntry, extends map[st
 		if strings.HasPrefix(sysid, ".") {
 			sysid = sysid[1:] // Strip this out if we start with .
 		}
-		mdb.profiles[sysid] = &t
-		mdb.log.Debugf("Adding profile for %s: %s %s", sysid, t.Device.Vendor, t.From)
+		if op, ok := mdb.profiles[sysid]; !ok {
+			mdb.profiles[sysid] = &t
+			mdb.log.Debugf("Adding profile for %s: %s %s", sysid, t.Device.Vendor, t.From)
+		} else {
+			mdb.log.Errorf("Profile for %s already exists. New file %s, Old file %s", sysid, t.From, op.From)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I think this is what we want to do? I'm not actually sure. Right now making `1.3.6.1.4.1.9.1.1348` go into the cisco-call manager profiles. 