### PR TITLE
Guarding to prevent empty metric from being sent in

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -447,6 +447,10 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 
 	ms := make([]NRMetric, 0, len(metrics))
 	for m, name := range metrics {
+		if m == "" {
+			f.Errorf("Missing metric name, skipping %v", attr)
+			continue
+		}
 		if _, ok := in.CustomBigInt[m]; ok {
 			attrNew := copyAttrForSnmp(attr, m, name)
 			ms = append(ms, NRMetric{
@@ -479,6 +483,10 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 
 	ms := make([]NRMetric, 0, len(metrics))
 	for m, name := range metrics {
+		if m == "" {
+			f.Errorf("Missing metric name, skipping %v", attr)
+			continue
+		}
 		if _, ok := in.CustomBigInt[m]; ok {
 			attrNew := copyAttrForSnmp(attr, m, name)
 			ms = append(ms, NRMetric{

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -316,6 +316,10 @@ func (p *Profile) GetMetrics(enabledMibs []string) (map[string]*kt.Mib, map[stri
 				mib.Enum[strings.ToLower(k)] = v
 				mib.EnumRev[v] = k
 			}
+			if mib.Name == "" {
+				p.Warnf("Skipping mib with no name: %v", mib)
+				continue
+			}
 			if strings.HasPrefix(metric.Symbol.Name, "if") {
 				interfaceMetrics[metric.Symbol.Oid] = mib
 			} else {
@@ -339,6 +343,10 @@ func (p *Profile) GetMetrics(enabledMibs []string) (map[string]*kt.Mib, map[stri
 			for k, v := range mib.Enum {
 				mib.Enum[strings.ToLower(k)] = v
 				mib.EnumRev[v] = k
+			}
+			if mib.Name == "" {
+				p.Warnf("Skipping mib with no name: %v", mib)
+				continue
 			}
 			if strings.HasPrefix(s.Name, "if") {
 				interfaceMetrics[s.Oid] = mib


### PR DESCRIPTION
Fixing case where empty metrics can be sent in via SNMP. 