### PR TITLE
Dynamic instrumentation.name values

### DIFF
--- a/config/snmp-base.yaml
+++ b/config/snmp-base.yaml
@@ -1,6 +1,6 @@
 devices:
 trap:
-  listen: 127.0.0.1:162
+  listen: 127.0.0.1:1620
   community: hello
   version: ""
   transport: ""

--- a/config/snmp-win.yaml
+++ b/config/snmp-win.yaml
@@ -1,6 +1,6 @@
 devices:
 trap:
-  listen: 127.0.0.1:162
+  listen: 127.0.0.1:1620
   community: hello
   version: ""
   transport: ""

--- a/ktranslate.wxs
+++ b/ktranslate.wxs
@@ -56,6 +56,11 @@
                 <File Id="filCC765DB29D59E91AD84875370FB175D8" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/aruba/aruba.yml"/>
               </Component>
             </Directory>
+            <Directory Id="dir5424FE08AFD387F438440DA4CC5DCE55" Name="brocade">
+              <Component Id="cmp4463D2D7EF2E64D60B7165ED2C67921D" Guid="*">
+                <File Id="filF4A69B1D861A111861A00CBC726BEC45" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml"/>
+              </Component>
+            </Directory>
             <Directory Id="dir184326711F224C33A87911F499EC71C2" Name="apc">
               <Component Id="cmp73E19C142A042AAFF0DCE76003EFFEBB" Guid="*">
                 <File Id="fil223E3A8C3D00473AD3A5C3E7BB0A916C" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/apc/apc_ups.yml"/>
@@ -79,9 +84,17 @@
                 <File Id="fil963DD98235B75B78B64CCDB266A63EF9" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/generic/base.yml"/>
               </Component>
             </Directory>
+            <Directory Id="dirE120CB3AFB969BA1D1607DE3F0262F3D" Name="dell">
+              <Component Id="cmp93DFEBCE84E7942A476C36A274F90591" Guid="*">
+                <File Id="filEC5959567D8BA8F7AE7CAF0DF0A78AE6" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/dell/idrac.yml"/>
+              </Component>
+            </Directory>
             <Directory Id="dir339464D2982D6915DE83ABB5613157A1" Name="netgear">
               <Component Id="cmpD09A243C955CAF9F43EA7377874B6D13" Guid="*">
                 <File Id="filF01A5BC256064004B2D3CBD33FDCAC66" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/netgear/readynas.yml"/>
+              </Component>
+              <Component Id="cmp6A788D7A9CFF37ACBD09B30D33572D3A" Guid="*">
+                <File Id="filEADCA998EDCA37F70BA3DA5D65AC48A5" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/netgear/netgear-generic.yml"/>
               </Component>
             </Directory>
             <Directory Id="dirA24188538623D1A47393C1E3E3BDA301" Name="checkpoint">
@@ -228,6 +241,7 @@
         <Feature Id="MainApplication" Title="Main Application" Level="1">
           <ComponentRef Id="ktranslate.exe" />
         <ComponentRef Id="cmpB46AF4C0CF9C68FA9C458C1219F7C1D1" />
+              <ComponentRef Id="cmp4463D2D7EF2E64D60B7165ED2C67921D" />
               <ComponentRef Id="cmp6052E2C43A4DDBA643B6A03B0C5D3B39" />
               <ComponentRef Id="cmp73E19C142A042AAFF0DCE76003EFFEBB" />
               <ComponentRef Id="cmpC1F0A78F692AF501FBC57AA044D2BCF1" />
@@ -274,6 +288,8 @@
         <ComponentRef Id="cmp7EA4396B8D9EC67B7910D8A242FFCF57" />
         <ComponentRef Id="cmpB7CB43E39FFEAC4402F746BD2B4A43D4" />
         <ComponentRef Id="cmp34171BB83455309CBC625CC7B8309AD4" />
+        <ComponentRef Id="cmp93DFEBCE84E7942A476C36A274F90591" />
+        <ComponentRef Id="cmp6A788D7A9CFF37ACBD09B30D33572D3A" />
         </Feature>
 
     </Product>

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -54,8 +54,8 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		log:              log,
 		metrics:          metrics,
 		server:           server,
-		interfaceMetrics: NewInterfaceMetrics(gconf, conf, metrics, interfaceMetricMibs, log),
-		deviceMetrics:    NewDeviceMetrics(gconf, conf, metrics, deviceMetricMibs, log),
+		interfaceMetrics: NewInterfaceMetrics(gconf, conf, metrics, interfaceMetricMibs, profile, log),
+		deviceMetrics:    NewDeviceMetrics(gconf, conf, metrics, deviceMetricMibs, profile, log),
 		counterTimeSec:   counterTimeSec,
 		dropIfOutside:    dropIfOutside,
 	}

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -54,6 +54,17 @@ type Profile struct {
 	extended        bool
 }
 
+func (p *Profile) GetProfileName() string {
+	if p == nil {
+		return "snmp"
+	}
+	pts := strings.Split(p.From, ".")
+	if pts[0] != "" {
+		return pts[0]
+	}
+	return "snmp"
+}
+
 func (p *Profile) extend(extends map[string]*Profile) error {
 	if p.extended { // Don't extend multiple times, also halt recursion.
 		return nil

--- a/pkg/inputs/snmp/mibs/profile_test.go
+++ b/pkg/inputs/snmp/mibs/profile_test.go
@@ -67,3 +67,18 @@ func TestPrune(t *testing.T) {
 	prune(mibs)
 	assert.Equal(t, 3, len(mibs))
 }
+
+func TestProfileName(t *testing.T) {
+	tests := map[string][]*Profile{
+		"foo-test": []*Profile{&Profile{From: "foo-test.yml"}},
+		"snmp":     []*Profile{nil, &Profile{}},
+		"noone":    []*Profile{&Profile{From: "noone"}},
+	}
+
+	for expected, profiles := range tests {
+		for _, profile := range profiles {
+			res := profile.GetProfileName()
+			assert.Equal(t, expected, res)
+		}
+	}
+}

--- a/pkg/inputs/snmp/mibs/pymib.go
+++ b/pkg/inputs/snmp/mibs/pymib.go
@@ -141,12 +141,20 @@ func ConvertJson2Yaml(file string, log logger.ContextL) error {
 		}
 	}
 
+	// Remove any metrics with no metrics (just tags). Needed because otherwise validation will fail.
+	gm := []MIB{}
+	for _, metric := range finals {
+		if metric.Symbol.Oid != "" || len(metric.Symbols) > 0 {
+			gm = append(gm, metric)
+		}
+	}
+
 	// Sort the mibs.
-	sort.Sort(MibList(finals))
+	sort.Sort(MibList(gm))
 
 	// Make a profile.
 	pro := Profile{
-		Metrics:     finals,
+		Metrics:     gm,
 		Sysobjectid: sysoids,
 		ContextL:    log,
 		From:        name,

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -171,9 +171,10 @@ type JCHF struct {
 }
 
 type MetricInfo struct {
-	Oid  string `json:"-"`
-	Mib  string `json:"-"`
-	Name string `json:"-"`
+	Oid     string `json:"-"`
+	Mib     string `json:"-"`
+	Name    string `json:"-"`
+	Profile string `json:"-"`
 }
 
 func NewJCHF() *JCHF {


### PR DESCRIPTION
Setting `instrumentation.name` based on what profile is found for SNMP.

Also changing default snmp trap to 1620 to avoid need for root on Linux and updated windows build file. 