### PR TITLE
Allowing override of instrumentationName on a per device basis

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -51,7 +51,7 @@ func NewDeviceMetrics(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, met
 		log:         log,
 		conf:        conf,
 		metrics:     metrics,
-		profileName: profile.GetProfileName(),
+		profileName: profile.GetProfileName(conf.InstrumentationName),
 	}
 }
 

--- a/pkg/inputs/snmp/metrics/interface_metrics.go
+++ b/pkg/inputs/snmp/metrics/interface_metrics.go
@@ -94,7 +94,7 @@ func NewInterfaceMetrics(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, 
 		nameOidMap:  nameOidMap,
 		oidMibMap:   profileMetrics,
 		intValues:   make(map[string]*counters.CounterSet),
-		profileName: profile.GetProfileName(),
+		profileName: profile.GetProfileName(conf.InstrumentationName),
 	}
 }
 

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -54,7 +54,11 @@ type Profile struct {
 	extended        bool
 }
 
-func (p *Profile) GetProfileName() string {
+func (p *Profile) GetProfileName(override string) string {
+	if override != "" { // This can override what is set as the profile name.
+		return override
+	}
+
 	if p == nil {
 		return "snmp"
 	}

--- a/pkg/inputs/snmp/mibs/profile_test.go
+++ b/pkg/inputs/snmp/mibs/profile_test.go
@@ -73,11 +73,15 @@ func TestProfileName(t *testing.T) {
 		"foo-test": []*Profile{&Profile{From: "foo-test.yml"}},
 		"snmp":     []*Profile{nil, &Profile{}},
 		"noone":    []*Profile{&Profile{From: "noone"}},
+		"override": []*Profile{&Profile{From: "lalalalala"}},
+	}
+	overrides := map[string]string{
+		"override": "override",
 	}
 
 	for expected, profiles := range tests {
 		for _, profile := range profiles {
-			res := profile.GetProfileName()
+			res := profile.GetProfileName(overrides[expected])
 			assert.Equal(t, expected, res)
 		}
 	}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -115,6 +115,7 @@ type SnmpDeviceConfig struct {
 	MatchAttr              map[string]string `yaml:"match_attributes"`
 	MonitorAdminShut       bool              `yaml:"monitor_admin_shut"`
 	NoUseBulkWalkAll       bool              `yaml:"no_use_bulkwalkall"`
+	InstrumentationName    string            `yaml:"instrumentationName"`
 }
 
 type SnmpTrapConfig struct {


### PR DESCRIPTION
set a custom `instrumentation.name` value by setting `instrumentationName` in the device snmp config. 