### PR TITLE
Fix for `match_attributes` not working

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -121,15 +121,27 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.Met
 
 		// Finally, drop any values which do not match the whitelist.
 		if lastMetadata.MatchAttr != nil {
+			dropOnAdminStatus := false
 			for k, re := range lastMetadata.MatchAttr {
 				if v, ok := attr[k]; ok {
 					if strv, ok := v.(string); ok {
-						attr[kt.DropMetric] = !re.MatchString(strv)
-						if attr[kt.DropMetric] == false {
-							break // Only keep going if we did not match. All matches are OR-d together.
+						if k == kt.AdminStatus { // If admin status is causing us to drop, drop right away.
+							dropOnAdminStatus = !re.MatchString(strv)
+							if dropOnAdminStatus == true {
+								break
+							}
+						} else { // Otherwise, OR all the matches together.
+							attr[kt.DropMetric] = !re.MatchString(strv)
+							if attr[kt.DropMetric] == false {
+								break // Only keep going if we did not match. All matches are OR-d together.
+							}
 						}
 					}
 				}
+			}
+			// This is special cased as an AND to any other attributes.
+			if dropOnAdminStatus {
+				attr[kt.DropMetric] = true
 			}
 		}
 	}

--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -78,7 +78,11 @@ func GetDeviceMetadata(log logger.ContextL, server *gosnmp.GoSNMP, deviceMetadat
 		if !ok {
 			thing, ok := SNMP_device_metadata_oids.Get(oidVal)
 			if !ok {
-				log.Errorf("SNMP Device Metadata: Unknown oid retrieved: %v", oidVal)
+				if oidVal == ".1.3.6.1.6.3.15.1.1.3.0" { // This is a bad v3 config.
+					log.Errorf("User found who is not known to the SNMP engine. Likely this is an invalid v3 config.")
+				} else {
+					log.Errorf("SNMP Device Metadata: Unknown oid retrieved: %v %v", oidVal, value)
+				}
 				continue
 			}
 			oidName = thing.(string)

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -65,7 +65,7 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		attrMap[attr] = re
 	}
 	if !conf.MonitorAdminShut { // This one is common and so is set explicitly.
-		attrMap[kt.StringPrefix+"ifAdminStatus"] = regexp.MustCompile("up")
+		attrMap[kt.AdminStatus] = regexp.MustCompile("up")
 	}
 	if len(attrMap) > 0 {
 		log.Infof("Added %d Match Attribute(s)", len(attrMap))

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -34,6 +34,7 @@ const (
 	StringPrefix     = "ks_"
 	PrivateIP        = "Private IP"
 	DropMetric       = "DropMetric"
+	AdminStatus      = StringPrefix + "ifAdminStatus"
 )
 
 type OutputType string


### PR DESCRIPTION
Fixing match_attributes. These should now work fine, with and without wrapping in ". 

Also updating the error message for a broken v3 config. 