### PR TITLE
snmp health metric

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -140,7 +140,7 @@ func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 	for _, device := range conf.Devices {
 		if device.Provider == "" {
 			// Default provider to something we can work with.
-			device.Provider = kt.ProviderRouter
+			device.Provider = kt.ProviderDefault
 		}
 		if *flowOnly || device.FlowOnly {
 			continue

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -184,6 +184,13 @@ const (
 	SNMP_BAD  = 2
 )
 
+var (
+	SNMP_STATUS_MAP = map[int64]string{
+		1: "GOOD",
+		2: "BAD",
+	}
+)
+
 func NewSnmpDeviceMetric(registry go_metrics.Registry, deviceName string) *SnmpDeviceMetric {
 	sm := SnmpDeviceMetric{
 		DeviceMetrics:    go_metrics.GetOrRegisterMeter("device_metrics^device_name="+deviceName, registry),


### PR DESCRIPTION
Adds a seperate metric which is just for snmp health. Looks like:

```
    "metrics": [
      {
        "name": "kentik.snmp.PollingHealth",
        "type": "gauge",
        "value": 1,
        "attributes": {
          "provider": "kentik-router",
          "PollingHealth": "GOOD",
          "device_name": "bart",
          "objectIdentifier": "computed",
          "mib-name": "computed",
          "instrumentation.name": "base",
          "eventType": "KSnmpDeviceMetric"
        }
      }
    ],
```

Also fixes 1 case where provider defaults to router and not default. 