### PR TITLE
Use match_attributes to filter on device level attributes also

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -444,6 +444,12 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 		f.Debugf("Missing device metadata for %s", in.DeviceName)
 	}
 
+	if drop, ok := attr[kt.DropMetric]; ok {
+		if drop.(bool) {
+			return nil // This Metric isn't in the white list so lets drop it.
+		}
+	}
+
 	ms := make([]NRMetric, 0, len(metrics))
 	for m, name := range metrics {
 		if m == "" {

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -161,6 +161,41 @@ func TestSetAttrDrop(t *testing.T) {
 			},
 			false, // Keep because aaa matches and admin is up.
 		},
+		{
+			map[string]interface{}{
+				kt.AdminStatus: "up",
+			},
+			kt.NewJCHF().SetIFPorts(20),
+			map[string]kt.MetricInfo{},
+			kt.LastMetadata{
+				MatchAttr: map[string]*regexp.Regexp{
+					"if_Description": regexp.MustCompile("igb3"),
+					kt.AdminStatus:   regexp.MustCompile("up"),
+					"device_name":    regexp.MustCompile("bart"),
+				},
+				InterfaceInfo: map[kt.IfaceID]map[string]interface{}{
+					20: map[string]interface{}{
+						"Description": "igb2",
+					},
+				},
+			},
+			true, // Drop because desc doesn't match.
+		},
+		{
+			map[string]interface{}{
+				"mib-name": "UDP-MIB",
+			},
+			kt.NewJCHF(),
+			map[string]kt.MetricInfo{},
+			kt.LastMetadata{
+				MatchAttr: map[string]*regexp.Regexp{
+					"if_Description": regexp.MustCompile("igb3"),
+					kt.AdminStatus:   regexp.MustCompile("up"),
+					"mib-name":       regexp.MustCompile("UDP"),
+				},
+			},
+			false, // keep because mib-name matches and no admin status.
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -66,14 +66,19 @@ func TestSetAttrDrop(t *testing.T) {
 		{
 			map[string]interface{}{
 				kt.AdminStatus: "down",
-				"foo":          "bar",
+				"fooXX":        "bar",
 			},
-			kt.NewJCHF(),
+			kt.NewJCHF().SetIFPorts(10),
 			map[string]kt.MetricInfo{},
 			kt.LastMetadata{
 				MatchAttr: map[string]*regexp.Regexp{
-					"foo":          regexp.MustCompile("bar"),
+					"fooXX":        regexp.MustCompile("bar"),
 					kt.AdminStatus: regexp.MustCompile("up"),
+				},
+				InterfaceInfo: map[kt.IfaceID]map[string]interface{}{
+					10: map[string]interface{}{
+						"Description": "myIfDesc",
+					},
 				},
 			},
 			true,
@@ -103,7 +108,7 @@ func TestSetAttrDrop(t *testing.T) {
 			map[string]kt.MetricInfo{},
 			kt.LastMetadata{
 				MatchAttr: map[string]*regexp.Regexp{
-					"foo":          regexp.MustCompile("abar"),
+					"fooAAA":       regexp.MustCompile("abar"),
 					kt.AdminStatus: regexp.MustCompile("up"),
 				},
 			},

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -292,6 +292,12 @@ func (j *JCHF) SetMap() {
 	j.avroSet = map[string]interface{}{}
 }
 
+func (j *JCHF) SetIFPorts(p IfaceID) *JCHF {
+	j.OutputPort = p
+	j.InputPort = p
+	return j
+}
+
 type AgentId IntId
 
 func NewAgentId(id string) AgentId {


### PR DESCRIPTION
This PR extends the `match_attributes` section to allow filtering on any attribute, not just interface level ones. 