### PR TITLE
Build Windows Version on Main Push

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -1,0 +1,60 @@
+name: Publish Windows
+
+on:
+  push:
+    branches:
+      - pye-build-windows
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Set Version
+        run: |
+           echo KENTIK_KTRANSLATE_VERSION=`date +"kt-%Y-%m-%d-${GITHUB_RUN_ID}"` >> $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.8'
+
+      - name: Install dependencies
+        run: sudo apt-get install make libpcap-dev golint wixl wixl-data
+
+      - name: Install MM DBs
+        run: |
+          MM_DOWNLOAD_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+
+      - name: Install SNMP Profiles
+        uses: actions/checkout@main
+        with:
+          repository: kentik/snmp-profiles
+          path: ./config/profiles
+
+      - name: Run build
+        run: |
+          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
+          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make windows
+
+      - name: Run vet & lint
+        run: |
+          go vet .
+          golint .
+
+      - name: Run testing
+        run: make test
+
+      - name: Build MSI File
+        run: |
+          wixl --define Version=${{ env.KENTIK_KTRANSLATE_VERSION }} --define Platform=x86 --define Path=./ --output ktranslate.msi ktranslate.wxs
+
+      - name: Publish msi
+        uses: actions/upload-artifact@v2
+        with:
+          name: ktranslate.msi
+          path: ktranslate.msi

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -41,6 +41,10 @@ jobs:
           echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
           KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make windows
 
+      - name: Build MSI File
+        run: |
+          wixl --define Version=${{ env.KENTIK_KTRANSLATE_VERSION }} --define Platform=x86 --define Path=./ --output ktranslate.msi ktranslate.wxs
+
       - name: Run vet & lint
         run: |
           go vet .
@@ -48,10 +52,6 @@ jobs:
 
       - name: Run testing
         run: make test
-
-      - name: Build MSI File
-        run: |
-          wixl --define Version=${{ env.KENTIK_KTRANSLATE_VERSION }} --define Platform=x86 --define Path=./ --output ktranslate.msi ktranslate.wxs
 
       - name: Publish msi
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -1,9 +1,12 @@
 name: Publish Windows
 
 on:
+  repository_dispatch:
+    types: [new-snmp-profiles]
+
   push:
     branches:
-      - pye-build-windows
+      - main
 
 jobs:
   build:
@@ -36,15 +39,6 @@ jobs:
           repository: kentik/snmp-profiles
           path: ./config/profiles
 
-      - name: Run build
-        run: |
-          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
-          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make windows
-
-      - name: Build MSI File
-        run: |
-          wixl --define Version=${{ env.KENTIK_KTRANSLATE_VERSION }} --define Platform=x86 --define Path=./ --output ktranslate.msi ktranslate.wxs
-
       - name: Run vet & lint
         run: |
           go vet .
@@ -53,7 +47,16 @@ jobs:
       - name: Run testing
         run: make test
 
-      - name: Publish msi
+      - name: Run build
+        run: |
+          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
+          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make windows
+
+      - name: Build MSI
+        run: |
+          wixl --define Version=${{ env.KENTIK_KTRANSLATE_VERSION }} --define Platform=x86 --define Path=./ --output ktranslate.msi ktranslate.wxs
+
+      - name: Publish MSI
         uses: actions/upload-artifact@v2
         with:
           name: ktranslate.msi

--- a/config/snmp-win.yaml
+++ b/config/snmp-win.yaml
@@ -18,7 +18,7 @@ discovery:
   threads: 4
   replace_devices: true
 global:
-  poll_time_sec: 60
+  poll_time_sec: 300
   drop_if_outside_poll: false
   mib_profile_dir: c:/Program Files (x86)/KTranslate/config/profiles
   mibs_db: c:/Program Files (x86)/KTranslate/config/mibs.db

--- a/ktranslate.wxs
+++ b/ktranslate.wxs
@@ -86,7 +86,7 @@
             </Directory>
             <Directory Id="dirE120CB3AFB969BA1D1607DE3F0262F3D" Name="dell">
               <Component Id="cmp93DFEBCE84E7942A476C36A274F90591" Guid="*">
-                <File Id="filEC5959567D8BA8F7AE7CAF0DF0A78AE6" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/dell/idrac.yml"/>
+                <File Id="filEC5959567D8BA8F7AE7CAF0DF0A78AE6" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/dell/dell-idrac.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir339464D2982D6915DE83ABB5613157A1" Name="netgear">

--- a/ktranslate.wxs
+++ b/ktranslate.wxs
@@ -53,133 +53,133 @@
           <Directory Id="dir28FD6080C90E52C7CB77407C226603C0" Name="kentik_snmp">
             <Directory Id="dir1E6698C62FBC01016305A15F9C5B64C4" Name="aruba">
               <Component Id="cmp6052E2C43A4DDBA643B6A03B0C5D3B39" Guid="*">
-                <File Id="filCC765DB29D59E91AD84875370FB175D8" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/aruba/aruba.yml"/>
+                <File Id="filCC765DB29D59E91AD84875370FB175D8" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/aruba/aruba.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir5424FE08AFD387F438440DA4CC5DCE55" Name="brocade">
               <Component Id="cmp4463D2D7EF2E64D60B7165ED2C67921D" Guid="*">
-                <File Id="filF4A69B1D861A111861A00CBC726BEC45" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/brocade/brocade-fc-switch.yml"/>
+                <File Id="filF4A69B1D861A111861A00CBC726BEC45" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/brocade/brocade-fc-switch.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir184326711F224C33A87911F499EC71C2" Name="apc">
               <Component Id="cmp73E19C142A042AAFF0DCE76003EFFEBB" Guid="*">
-                <File Id="fil223E3A8C3D00473AD3A5C3E7BB0A916C" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/apc/apc_ups.yml"/>
+                <File Id="fil223E3A8C3D00473AD3A5C3E7BB0A916C" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/apc/apc_ups.yml"/>
               </Component>
               <Component Id="cmpC1F0A78F692AF501FBC57AA044D2BCF1" Guid="*">
-                <File Id="fil63FC864B2F6B5BEF432C240D41866A20" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/apc/apc_pdu.yml"/>
+                <File Id="fil63FC864B2F6B5BEF432C240D41866A20" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/apc/apc_pdu.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir1D7240CAA66C43B49C7FD489664FE2AC" Name="arista">
               <Component Id="cmp6A3288CBECB5E924DA386D6E0880DEEB" Guid="*">
-                <File Id="fil3BA83C57769EA26FA62ACB43140F8DF2" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/arista/arista.yml"/>
+                <File Id="fil3BA83C57769EA26FA62ACB43140F8DF2" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/arista/arista.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir4B2A30EC9537DC963F6811FD20843F24" Name="palo_alto">
               <Component Id="cmp4238105B0191D6208C85F1D98442D634" Guid="*">
-                <File Id="fil7712FE87EFDEFE8A44C16C608033B5DC" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/palo_alto/palo-alto.yml"/>
+                <File Id="fil7712FE87EFDEFE8A44C16C608033B5DC" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/palo_alto/palo-alto.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir1F534DC01680B64C8309F078F0D8FAC7" Name="generic">
               <Component Id="cmpD89DB4AD050FD3A8B93A667E5F30FAA0" Guid="*">
-                <File Id="fil963DD98235B75B78B64CCDB266A63EF9" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/generic/base.yml"/>
+                <File Id="fil963DD98235B75B78B64CCDB266A63EF9" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/generic/base.yml"/>
               </Component>
             </Directory>
             <Directory Id="dirE120CB3AFB969BA1D1607DE3F0262F3D" Name="dell">
               <Component Id="cmp93DFEBCE84E7942A476C36A274F90591" Guid="*">
-                <File Id="filEC5959567D8BA8F7AE7CAF0DF0A78AE6" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/dell/idrac.yml"/>
+                <File Id="filEC5959567D8BA8F7AE7CAF0DF0A78AE6" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/dell/idrac.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir339464D2982D6915DE83ABB5613157A1" Name="netgear">
               <Component Id="cmpD09A243C955CAF9F43EA7377874B6D13" Guid="*">
-                <File Id="filF01A5BC256064004B2D3CBD33FDCAC66" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/netgear/readynas.yml"/>
+                <File Id="filF01A5BC256064004B2D3CBD33FDCAC66" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/netgear/readynas.yml"/>
               </Component>
               <Component Id="cmp6A788D7A9CFF37ACBD09B30D33572D3A" Guid="*">
-                <File Id="filEADCA998EDCA37F70BA3DA5D65AC48A5" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/netgear/netgear-generic.yml"/>
+                <File Id="filEADCA998EDCA37F70BA3DA5D65AC48A5" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/netgear/netgear-generic.yml"/>
               </Component>
             </Directory>
             <Directory Id="dirA24188538623D1A47393C1E3E3BDA301" Name="checkpoint">
               <Component Id="cmp797BDC5B5A66F93A7B18E1BE8DB9E238" Guid="*">
-                <File Id="filA85352CFBC89C654DD39444A01AEDC35" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/checkpoint/checkpoint-firewall.yml"/>
+                <File Id="filA85352CFBC89C654DD39444A01AEDC35" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/checkpoint/checkpoint-firewall.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir687CA4426C67D6371521B213DB292D2F" Name="meraki">
               <Component Id="cmp03F819610CDED003705FDD444C14AE13" Guid="*">
-                <File Id="filCB97030BBABE59A994BEACF984DBF674" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/meraki/meraki-cloud-controller.yml"/>
+                <File Id="filCB97030BBABE59A994BEACF984DBF674" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/meraki/meraki-cloud-controller.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir9D414E0E99932ACFADEAE5F3E8CC57A0" Name="juniper">
               <Component Id="cmp80F6FEFCDE6F6443916B2099D6959E75" Guid="*">
-                <File Id="filE9F7A3BC5385432AA4A5F86A7C300C6A" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/juniper/juniper-ex-switches.yml"/>
+                <File Id="filE9F7A3BC5385432AA4A5F86A7C300C6A" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/juniper/juniper-ex-switches.yml"/>
               </Component>
               <Component Id="cmp42BFCA69C939ABD66F7367646BDF5507" Guid="*">
-                <File Id="fil536E59DBF98106D22BFA7DE2F7CAA8B7" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/juniper/juniper-mx-router.yml"/>
+                <File Id="fil536E59DBF98106D22BFA7DE2F7CAA8B7" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/juniper/juniper-mx-router.yml"/>
               </Component>
               <Component Id="cmp0E270C834B5343DAE68EE6331222C8FD" Guid="*">
-                <File Id="fil69C6F1258F17A1A51C71814101470C7E" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/juniper/juniper-srx-firewalls.yml"/>
+                <File Id="fil69C6F1258F17A1A51C71814101470C7E" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/juniper/juniper-srx-firewalls.yml"/>
               </Component>
               <Component Id="cmpCFFEECE3A0A4E1B0BD94F0FFAE2EF2C0" Guid="*">
-                <File Id="fil7AD49A25CFF4502AD47EFD6E31599EF8" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/juniper/juniper-all-devices.yml"/>
+                <File Id="fil7AD49A25CFF4502AD47EFD6E31599EF8" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/juniper/juniper-all-devices.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir629A5AC9E39AEEC83B0A27E8E335EED1" Name="fortinet">
               <Component Id="cmp947E9C4D3005D312DDBA8BB4066B9C21" Guid="*">
-                <File Id="fil0A3B03085A7E6F14BFA6B8BD30C4A6F9" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml"/>
+                <File Id="fil0A3B03085A7E6F14BFA6B8BD30C4A6F9" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/fortinet/fortinet-fortigate.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir1364A6EE0EF1D1FA2E53EDE8C735D0AC" Name="cisco">
               <Component Id="cmp47ED26114E23EF1409B3AC1CA30FBDE7" Guid="*">
-                <File Id="filC87224585D73240A9CB2A82C56BC4534" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/cisco/cisco-catalyst.yml"/>
+                <File Id="filC87224585D73240A9CB2A82C56BC4534" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/cisco/cisco-catalyst.yml"/>
               </Component>
               <Component Id="cmp33845F0824F0F4638F471E8EDB7E2479" Guid="*">
-                <File Id="filC59E0B1A3CA7F22B1B7E9B782EAEFA38" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/cisco/cisco-nexus.yml"/>
+                <File Id="filC59E0B1A3CA7F22B1B7E9B782EAEFA38" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/cisco/cisco-nexus.yml"/>
               </Component>
               <Component Id="cmp9491191D1F2EB97EC25C72024212A0F3" Guid="*">
-                <File Id="filC725B2143A1EC4E28B59F7270A679217" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/cisco/cisco-all-devices.yml"/>
+                <File Id="filC725B2143A1EC4E28B59F7270A679217" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/cisco/cisco-all-devices.yml"/>
               </Component>
               <Component Id="cmpAB3DABB1932B4C86C1FE69DD8A2A7F0B" Guid="*">
-                <File Id="fil494590872A1CDBE54D886FA123BADD4F" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/cisco/cisco-voice.yml"/>
+                <File Id="fil494590872A1CDBE54D886FA123BADD4F" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/cisco/cisco-voice.yml"/>
               </Component>
               <Component Id="cmpDA669FCFABF587E481382B81053C2177" Guid="*">
-                <File Id="fil2C0FC07BAFB2659F60BEB5D0537506B2" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/cisco/cisco-asa.yml"/>
+                <File Id="fil2C0FC07BAFB2659F60BEB5D0537506B2" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/cisco/cisco-asa.yml"/>
               </Component>
             </Directory>
             <Directory Id="dirD542915A1B717DC64940220C1FED5619" Name="_general">
               <Component Id="cmpAE41B02D048A2CFD4926AE3BF66B99D2" Guid="*">
-                <File Id="filD8895A3104939768FE4249282ADBA922" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/tcp-mib.yml"/>
+                <File Id="filD8895A3104939768FE4249282ADBA922" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/tcp-mib.yml"/>
               </Component>
               <Component Id="cmp7F631DF175133573D03BF9B29B44F85E" Guid="*">
-                <File Id="fil3C953414ECC0F6A3E188963436028479" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/bgp4-mib.yml"/>
+                <File Id="fil3C953414ECC0F6A3E188963436028479" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/bgp4-mib.yml"/>
               </Component>
               <Component Id="cmpE769CA5EAACE421F33CB5A2C710D3C94" Guid="*">
-                <File Id="filE686E2AF48C0D1C9443674E39D48CE65" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/ucd-mib.yml"/>
+                <File Id="filE686E2AF48C0D1C9443674E39D48CE65" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/ucd-mib.yml"/>
               </Component>
               <Component Id="cmp310C6E43747EC79268692E7F0F7B4FC4" Guid="*">
-                <File Id="filAE8BD10E61A01ABD55AD97AAA053C5C4" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/if-mib.yml"/>
+                <File Id="filAE8BD10E61A01ABD55AD97AAA053C5C4" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/if-mib.yml"/>
               </Component>
               <Component Id="cmp8E24325912E48675630009BAE6484B56" Guid="*">
-                <File Id="filF30319C092FEB96BBE1020C66E0D7848" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/system-mib.yml"/>
+                <File Id="filF30319C092FEB96BBE1020C66E0D7848" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/system-mib.yml"/>
               </Component>
               <Component Id="cmpF68651D2EA20D16853D978AF876A73CA" Guid="*">
-                <File Id="fil187ABEA48F45CACBF534AD2396E6A3A5" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/udp-mib.yml"/>
+                <File Id="fil187ABEA48F45CACBF534AD2396E6A3A5" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/udp-mib.yml"/>
               </Component>
               <Component Id="cmp4712DA84DB706C829FB535BFC3A49416" Guid="*">
-                <File Id="fil41C94D006F2EDB4FC0A9CBEB4FC89E20" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/ip-mib.yml"/>
+                <File Id="fil41C94D006F2EDB4FC0A9CBEB4FC89E20" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/ip-mib.yml"/>
               </Component>
               <Component Id="cmp71DC9A3B1A4B6FAA7DE748F5212CC1A0" Guid="*">
-                <File Id="filE831AA68CED99C4B695D626F9D6D87FA" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/host-resources-mib.yml"/>
+                <File Id="filE831AA68CED99C4B695D626F9D6D87FA" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/host-resources-mib.yml"/>
               </Component>
               <Component Id="cmp03C88EEF9204D5003FAB783161477DF7" Guid="*">
-                <File Id="filCC970C03CF92B1CD376E93C9E8EB3578" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/_general/ospf-mib.yml"/>
+                <File Id="filCC970C03CF92B1CD376E93C9E8EB3578" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/_general/ospf-mib.yml"/>
               </Component>
             </Directory>
             <Directory Id="dir8E600D3E5E0235D29BC9C91D4B84E614" Name="netapp">
               <Component Id="cmp626A56F4B1F4A4283FBA8A5F0FAED47E" Guid="*">
-                <File Id="fil9542905B5C561ECAD1F3BB768316C9E4" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/netapp/netapp-cluster.yml"/>
+                <File Id="fil9542905B5C561ECAD1F3BB768316C9E4" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/netapp/netapp-cluster.yml"/>
               </Component>
             </Directory>
             <Directory Id="dirB28BD61F73CDC79856834CB35C63F6BE" Name="isilon">
               <Component Id="cmp354CC5099EA5863B101694798A000A65" Guid="*">
-                <File Id="fil2AA7DB19CC85A18876CA9C298949913F" KeyPath="yes" Source="$(var.Path)/config/profiles/kentik_snmp/isilon/isilon.yml"/>
+                <File Id="fil2AA7DB19CC85A18876CA9C298949913F" KeyPath="yes" Source="$(var.Path)/config/profiles/profiles/kentik_snmp/isilon/isilon.yml"/>
               </Component>
             </Directory>
           </Directory>


### PR DESCRIPTION
This creates a `ktranslate.msi` file as a build artifact on each main merge or snmp profile update. 

Note: Windows support is still experimental and not supported. 
