### PR TITLE
Building arm64 docker image also

### DIFF
--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -57,6 +57,11 @@ jobs:
           repository: kentik/snmp-profiles
           path: ./config/profiles
 
+      - name: Run build
+        run: |
+          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
+          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make arm
+
       - name: Run vet & lint
         run: |
           go vet .
@@ -64,11 +69,6 @@ jobs:
 
       - name: Run testing
         run: make test
-
-      - name: Run build
-        run: |
-          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
-          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make arm
 
       - name: Build and Publish Docker
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Publish docker image - arm64
         run: |
-	  docker pull arm64v8/ubuntu:20.04
-	  docker build -t kentik/ktranslate:v2arm64 -f DockerfileArm64 .
+          docker pull arm64v8/ubuntu:20.04
+          docker build -t kentik/ktranslate:v2arm64 -f DockerfileArm64 .
           docker push kentik/ktranslate:v2arm64
 
       - name: Publish binary

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -57,6 +57,14 @@ jobs:
           repository: kentik/snmp-profiles
           path: ./config/profiles
 
+      - name: Run vet & lint
+        run: |
+          go vet .
+          golint .
+
+      - name: Run testing
+        run: make test
+
       - name: Run build
         run: |
           echo ${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -1,0 +1,75 @@
+name: Publish Production - Arm64
+
+on:
+  repository_dispatch:
+    types: [new-snmp-profiles]
+
+  push:
+    branches:
+      - pye-build-aarch64
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Set Version
+        run: |
+           echo KENTIK_KTRANSLATE_VERSION=`date +"kt-%Y-%m-%d-${GITHUB_RUN_ID}"` >> $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.8'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: sudo apt-get install make libpcap-dev golint
+
+      - name: Install MM DBs
+        run: |
+          MM_DOWNLOAD_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+
+      - name: Install SNMP Profiles
+        uses: actions/checkout@main
+        with:
+          repository: kentik/snmp-profiles
+          path: ./config/profiles
+
+      - name: Run build
+        run: |
+          echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
+          KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make arm
+
+      - name: Publish docker image - arm64
+        run: |
+	  docker pull arm64v8/ubuntu:20.04
+	  docker build -t kentik/ktranslate:v2arm64 -f DockerfileArm64 .
+          docker push kentik/ktranslate:v2arm64
+
+      - name: Publish binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: ktranslate
+          path: bin/ktranslate

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -62,11 +62,15 @@ jobs:
           echo ${{ env.KENTIK_KTRANSLATE_VERSION }}
           KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }} make arm
 
-      - name: Publish docker image - arm64
-        run: |
-          docker pull arm64v8/ubuntu:20.04
-          docker build -t kentik/ktranslate:v2arm64 -f DockerfileArm64 .
-          docker push kentik/ktranslate:v2arm64
+      - name: Build and Publish Docker
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./DockerfileArm64
+          platforms: linux/arm64
+          push: true
+          tags: kentik/ktranslate:v2arm64
 
       - name: Publish binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install dependencies
-        run: sudo apt-get install make libpcap-dev golint
+        run: sudo apt-get install make libpcap-dev golint gcc-aarch64-linux-gnu
 
       - name: Install MM DBs
         run: |

--- a/.github/workflows/publish-arm64.yml
+++ b/.github/workflows/publish-arm64.yml
@@ -6,7 +6,7 @@ on:
 
   push:
     branches:
-      - pye-build-aarch64
+      - main
 
 jobs:
   build:

--- a/DockerfileArm64
+++ b/DockerfileArm64
@@ -18,6 +18,9 @@ COPY --chown=ktranslate:ktranslate config/ /etc/ktranslate/
 RUN set -eux; ln -sv ktranslate/profiles ktranslate/mibs.db /etc/; ls -l /etc/profiles/ /etc/mibs.db/
 RUN set -eux; ln -sv /etc/ktranslate/mibs.db /etc/mib.db; ls -l /etc/mib.db/
 
+# Fix libpcap to work with how we built things.
+RUN set -eux; ln -sv /ln -s /usr/lib/aarch64-linux-gnu/libpcap.so.1.9.1 /usr/lib/aarch64-linux-gnu/libpcap.so.1; ls -l /usr/lib/aarch64-linux-gnu/libpcap.so.1
+
 COPY bin/ktranslate /usr/local/bin/
 
 USER ktranslate

--- a/DockerfileArm64
+++ b/DockerfileArm64
@@ -1,0 +1,26 @@
+FROM arm64v8/ubuntu:20.04
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		libpcap0.8 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+	groupadd --gid 1000 ktranslate; \
+	useradd --home-dir /etc/ktranslate --gid ktranslate --no-create-home --uid 1000 ktranslate
+
+COPY --chown=ktranslate:ktranslate config/ /etc/ktranslate/
+
+# add backwards compatibility symlinks for folks using an snmp.yml from the older image (and "ls" to verify the symlinks are correct and working)
+RUN set -eux; ln -sv ktranslate/profiles ktranslate/mibs.db /etc/; ls -l /etc/profiles/ /etc/mibs.db/
+RUN set -eux; ln -sv /etc/ktranslate/mibs.db /etc/mib.db; ls -l /etc/mib.db/
+
+COPY bin/ktranslate /usr/local/bin/
+
+USER ktranslate
+ENTRYPOINT ["ktranslate", "-listen", "0.0.0.0:8082", "-mapping", "/etc/ktranslate/config.json", "-geo", "/etc/ktranslate/GeoLite2-Country.mmdb", "-udrs", "/etc/ktranslate/udr.csv", "-api_devices", "/etc/ktranslate/devices.json", "-asn", "/etc/ktranslate/GeoLite2-ASN.mmdb", "-log_level", "info"]
+
+EXPOSE 8082

--- a/DockerfileArm64
+++ b/DockerfileArm64
@@ -19,7 +19,7 @@ RUN set -eux; ln -sv ktranslate/profiles ktranslate/mibs.db /etc/; ls -l /etc/pr
 RUN set -eux; ln -sv /etc/ktranslate/mibs.db /etc/mib.db; ls -l /etc/mib.db/
 
 # Fix libpcap to work with how we built things.
-RUN set -eux; ln -sv /ln -s /usr/lib/aarch64-linux-gnu/libpcap.so.1.9.1 /usr/lib/aarch64-linux-gnu/libpcap.so.1; ls -l /usr/lib/aarch64-linux-gnu/libpcap.so.1
+RUN set -eux; ln -sv /usr/lib/aarch64-linux-gnu/libpcap.so.1.9.1 /usr/lib/aarch64-linux-gnu/libpcap.so.1; ls -l /usr/lib/aarch64-linux-gnu/libpcap.so.1
 
 COPY bin/ktranslate /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ windows:
 .PHONY: arm
 arm:
 	go generate ./cmd/version
-	CGO_LDFLAGS="-L./lib" CGO_ENABLED=1 CC_FOR_TARGET=gcc-aarch64-linux-gnu CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build -o bin/ktranslate-arm ./cmd/ktranslate
+	CGO_LDFLAGS="-L./lib" CGO_ENABLED=1 CC_FOR_TARGET=gcc-aarch64-linux-gnu CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o bin/ktranslate ./cmd/ktranslate
 
 .PHONY: test
 test:


### PR DESCRIPTION
This builds the `kentik/ktranslate:v2arm64` docker image. It runs on arm severs, verified on AWS. 

What do you think? Should the docker tag / image be something else? 