### PR TITLE
Allow optional output file for snmp disco

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -31,6 +31,7 @@ var (
 	snmpWalk       = flag.String("snmp_do_walk", "", "If set, try to perform a snmp walk against the targeted device.")
 	snmpWalkOid    = flag.String("snmp_walk_oid", ".1.3.6.1.2.1", "Walk this oid if -snmp_do_walk is set.")
 	snmpWalkFormat = flag.String("snmp_walk_format", "", "use this format for walked values if -snmp_do_walk is set.")
+	snmpOutFile    = flag.String("snmp_out_file", "", "If set, write updated snmp file here.")
 )
 
 func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL) error {


### PR DESCRIPTION
Quick one to allow a separate file to be written from snmp disco instead of overwriting the `-snmp=` file. 

Issue #135.

Also fixes a bug where existing devices would be reported as new each time in disco.   