### PR TITLE
Prevent Crashing when a device with no Sysoid is discovered

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -393,6 +393,7 @@ func (f *NRMFormat) fromKSynth(in *kt.JCHF) []NRMetric {
 				"max":   uint64(lost),
 			},
 			Attributes: attr,
+			Interval:   60 * 1000000,
 		})
 	}
 

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -221,7 +221,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 			device.DeviceOids = mibs
 		}
 		// Use the profile's provider if it is set.
-		if mibProfile.Provider != "" {
+		if mibProfile != nil && mibProfile.Provider != "" {
 			device.Provider = mibProfile.Provider
 		} else {
 			device.Provider = provider


### PR DESCRIPTION
Fixes #141 . The device is discovered as a generic-device without any mibs. Doesn't do much, but also doesn't crash. 