### PR TITLE
Adding option in discovery yaml to turn off dedup based on engine id

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -283,7 +283,7 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 
 	// Remove any duplicate devices based on Engine ID here.
 	for dip, d := range conf.Devices {
-		if d.EngineID != "" {
+		if !conf.Disco.NoDedup && d.EngineID != "" {
 			if _, ok := byEngineID[d.EngineID]; ok {
 				// Someone else has this engine ID. Delete this device.
 				log.Warnf("Removing device %s because of duplicate EngineID %s.", d.DeviceName, d.EngineID)

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -142,6 +142,7 @@ type SnmpDiscoConfig struct {
 	Threads            int           `yaml:"threads"`
 	ReplaceDevices     bool          `yaml:"replace_devices"`
 	AddFromMibDB       bool          `yaml:"add_from_mibdb"`
+	NoDedup            bool          `yaml:"no_dedup_engine_id,omitempty"`
 	CidrOrig           string        `yaml:"-"`
 }
 


### PR DESCRIPTION
Sometimes faked snmp engines can share the same engine id. 

Adding an option in yaml to turn off dedup on discovery of devices with common engine id. 