### PR TITLE
Fixing a bug where table metadata mixes across tables

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -73,10 +73,7 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.Met
 			}
 			if table, ok := lastMetadata.Tables[idx]; ok {
 				for k, v := range table.Customs {
-					attr[k] = v
-				}
-				for k, v := range table.CustomInts {
-					attr[k] = v
+					attr[k] = v.GetValue()
 				}
 			}
 			// If the index is longer, see if there's a parent table to look into also.
@@ -85,10 +82,7 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.Met
 				parent := strings.Join(pts[0:len(pts)-1], ".")
 				if table, ok := lastMetadata.Tables[parent]; ok {
 					for k, v := range table.Customs {
-						attr[k] = v
-					}
-					for k, v := range table.CustomInts {
-						attr[k] = v
+						attr[k] = v.GetValue()
 					}
 				}
 			}

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -208,13 +208,8 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 			dst.CustomTables = dd.DeviceMetricsMetadata.Tables
 
 			for _, table := range dst.CustomTables {
-				if table.TableName != "" {
-					for k, _ := range table.Customs {
-						dst.CustomMetrics[k] = kt.MetricInfo{Table: table.TableName}
-					}
-					for k, _ := range table.CustomInts {
-						dst.CustomMetrics[k] = kt.MetricInfo{Table: table.TableName}
-					}
+				for k, v := range table.Customs {
+					dst.CustomMetrics[k] = kt.MetricInfo{Table: v.TableName}
 				}
 			}
 		}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -22,16 +22,33 @@ type DeviceData struct {
 }
 
 type DeviceTableMetadata struct {
-	Customs    map[string]string
-	CustomInts map[string]int64
-	TableName  string
+	Customs map[string]MetaValue
 }
 
-func NewDeviceTableMetadata(table string) DeviceTableMetadata {
+type MetaValue struct {
+	TableName string
+	StringVal string
+	IntVal    int64
+}
+
+func (mv *MetaValue) GetValue() interface{} {
+	if mv.IntVal != 0 {
+		return mv.IntVal
+	}
+	return mv.StringVal
+}
+
+func NewDeviceTableMetadata() DeviceTableMetadata {
 	return DeviceTableMetadata{
-		Customs:    map[string]string{},
-		CustomInts: map[string]int64{},
-		TableName:  table,
+		Customs: map[string]MetaValue{},
+	}
+}
+
+func NewMetaValue(table string, sv string, iv int64) MetaValue {
+	return MetaValue{
+		TableName: table,
+		StringVal: sv,
+		IntVal:    iv,
 	}
 }
 


### PR DESCRIPTION
There is a case where device level metadata will be added to the wrong metrics if they share a common index. 

This moves the table name out from index level to metadata point level. 