### PR TITLE
Add build-args to publish actions

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -62,8 +62,10 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: kentik/ktranslate:${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:latest
+          build_args: |
+            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
           secrets: |
-            "MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}"
+            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
 
       - name: Publish binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -59,6 +59,8 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: kentik/ktranslate:staging
+          build_args: |
+            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
           secrets: |
             "MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}"
 


### PR DESCRIPTION
This adds `build-args` to the publish actions.