### PR TITLE
Allowing snmp profiles to specify match attributes as well

### DIFF
--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -271,6 +271,7 @@ type Mib struct {
 	Mib        string
 	Table      string
 	PollDur    time.Duration
+	MatchAttr  map[string]*regexp.Regexp
 	lastPoll   time.Time
 }
 


### PR DESCRIPTION
Lets you do things like 

```
    metric_tags:
      - column:
          OID: 1.3.6.1.4.1.6574.2.1.1.1
          name: diskIndex
      - column:
          OID: 1.3.6.1.4.1.6574.2.1.1.2
          name: diskID
          match_attributes:
            - "^Disk 1"
```

This will filter all metrics which have a diskID attribute, passing through only those which are `Disk 1`.
