### PR TITLE
Allowing a (very raw) version of custom ipfix templates to be used

### DIFF
--- a/pkg/inputs/flow/flow.go
+++ b/pkg/inputs/flow/flow.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 
 	go_metrics "github.com/kentik/go-metrics"
 
@@ -24,7 +25,9 @@ const (
 	Netflow5            = "netflow5"
 	Netflow9            = "netflow9"
 
-	defaultFields = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel"
+	// These can be any of
+	fullFieldList = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel,CustomInteger1,CustomInteger2,CustomBytes1,CustomBytes2"
+	defaultFields = "TimeReceived,SamplingRate,Bytes,Packets,SrcAddr,DstAddr,Proto,SrcPort,DstPort,InIf,OutIf,SrcVlan,DstVlan,TCPFlags,SrcAS,DstAS"
 )
 
 var (
@@ -32,8 +35,9 @@ var (
 	Port          = flag.Int("nf.port", 9995, "Sflow/NetFlow/IPFIX listening port")
 	Reuse         = flag.Bool("nf.reuserport", false, "Enable so_reuseport for Sflow/NetFlow/IPFIX")
 	Workers       = flag.Int("nf.workers", 1, "Number of workers per flow collector")
-	MessageFields = flag.String("nf.message.fields", defaultFields, "The list of fields to include in flow messages")
+	MessageFields = flag.String("nf.message.fields", defaultFields, "The list of fields to include in flow messages. Can be any of "+fullFieldList)
 	PromPath      = flag.String("nf.prom.listen", "", "Run a promethues metrics collector here")
+	MappingFile   = flag.String("nf.mapping", "", "Configuration file for custom netflow mappings")
 )
 
 func NewFlowSource(ctx context.Context, proto FlowSource, maxBatchSize int, log logger.Underlying, registry go_metrics.Registry, jchfChan chan []*kt.JCHF, apic *api.KentikApi) (*KentikDriver, error) {
@@ -48,11 +52,28 @@ func NewFlowSource(ctx context.Context, proto FlowSource, maxBatchSize int, log 
 		}
 	}()
 
+	// Allow processing of custom ipfix templates here.
+	var config utils.ProducerConfig
+	if *MappingFile != "" {
+		f, err := os.Open(*MappingFile)
+		if err != nil {
+			kt.Errorf("Cannot load netflow mapping file: %v", err)
+			return nil, err
+		}
+		config, err = utils.LoadMapping(f)
+		f.Close()
+		if err != nil {
+			kt.Errorf("Invalid yaml for netflow mapping file: %v", err)
+			return nil, err
+		}
+	}
+
 	switch proto {
 	case Ipfix, Netflow9:
 		sNF := &utils.StateNetFlow{
 			Format: kt,
 			Logger: &KentikLog{l: kt},
+			Config: config,
 		}
 		go func() { // Let this run, returning flow into the kentik transport struct
 			err := sNF.FlowRoutine(*Workers, *Addr, *Port, *Reuse)
@@ -65,6 +86,7 @@ func NewFlowSource(ctx context.Context, proto FlowSource, maxBatchSize int, log 
 		sSF := &utils.StateSFlow{
 			Format: kt,
 			Logger: &KentikLog{l: kt},
+			Config: config,
 		}
 		go func() { // Let this run, returning flow into the kentik transport struct
 			err := sSF.FlowRoutine(*Workers, *Addr, *Port, *Reuse)

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -236,6 +236,14 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 			in.CustomBigInt[field] = int64(fmsg.MPLSLastTTL)
 		case "MPLSLastLabel":
 			in.CustomBigInt[field] = int64(fmsg.MPLSLastLabel)
+		case "CustomInteger1":
+			in.CustomBigInt[field] = int64(fmsg.CustomInteger1)
+		case "CustomInteger2":
+			in.CustomBigInt[field] = int64(fmsg.CustomInteger2)
+		case "CustomBytes1":
+			in.CustomStr[field] = fmt.Sprintf("%.2x", fmsg.CustomBytes1)
+		case "CustomBytes2":
+			in.CustomStr[field] = fmt.Sprintf("%.2x", fmsg.CustomBytes2)
 		}
 	}
 


### PR DESCRIPTION
Enables things like

```
netflowv9:
  mapping:
    - field: 7
      destination: CustomInteger1
    - field: 11
      destination: CustomInteger2
sflow:
  mapping:
    - layer: 4 # Layer 4: TCP or UDP
      offset: 0 # Source port
      length: 16 # 2 bytes
      destination: CustomInteger1
    - layer: 4
      offset: 16 # Destination port
      length: 16 # 2 bytes
      destination: CustomInteger2
```
To pass along arbitrary values. 

Also removing non common flow fields from the default field set to speed up processing. 

