### PR TITLE
Allowing a profile file called traps.yaml which defines trap values

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -521,7 +521,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 1000000) // Convert into bits here, from megabits.
 					if uptimeSpeed > 0 {
-						attrNew := copyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, nil)
+						attrNew := copyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName])
 						if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 							ms = append(ms, NRMetric{
 								Name:       "kentik.snmp.IfInUtilization",
@@ -539,7 +539,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 1000000) // Convert into bits here, from megabits.
 					if uptimeSpeed > 0 {
-						attrNew := copyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, nil)
+						attrNew := copyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName])
 						if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 							ms = append(ms, NRMetric{
 								Name:       "kentik.snmp.IfOutUtilization",

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kentik/ktranslate/pkg/api"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	snmp_util "github.com/kentik/ktranslate/pkg/inputs/snmp/util"
 	"github.com/kentik/ktranslate/pkg/kt"
 	"github.com/kentik/ktranslate/pkg/util/ic"
 
@@ -104,7 +105,11 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 		in.CompanyId = dev.CompanyID
 		in.SampleRate = dev.SampleRate
 		for k, v := range dev.UserTags {
-			in.CustomStr[k] = v
+			key := k
+			if !strings.HasPrefix(key, snmp_util.NRUserTagPrefix) {
+				key = snmp_util.NRUserTagPrefix + k
+			}
+			in.CustomStr[key] = v
 		}
 	} else {
 		in.DeviceName = net.IP(fmsg.SamplerAddress).String()

--- a/pkg/inputs/snmp/metrics/interface_metrics.go
+++ b/pkg/inputs/snmp/metrics/interface_metrics.go
@@ -230,9 +230,6 @@ func (im *InterfaceMetrics) convertToCHF(deltas map[string]map[string]uint64) []
 		dst.DeviceName = im.conf.DeviceName
 		dst.SrcAddr = im.conf.DeviceIP
 		dst.Timestamp = time.Now().Unix()
-		for k, v := range im.conf.UserTags {
-			dst.CustomStr[k] = v
-		}
 		if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
 			dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
 		}

--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -16,6 +16,7 @@ import (
 type MibDB struct {
 	db       *leveldb.DB
 	profiles map[string]*Profile
+	traps    map[string]*kt.Mib
 	log      logger.ContextL
 }
 
@@ -42,6 +43,7 @@ func NewMibDB(mibpath string, profileDir string, log logger.ContextL) (*MibDB, e
 	mdb := &MibDB{
 		log:      log,
 		profiles: map[string]*Profile{},
+		traps:    map[string]*kt.Mib{},
 	}
 
 	if mibpath != "" {
@@ -71,6 +73,10 @@ func (db *MibDB) Close() {
 }
 
 func (db *MibDB) GetForKey(oid string) (*kt.Mib, error) {
+	if res, ok := db.traps[oid]; ok {
+		return res, nil
+	}
+
 	if db.db == nil { // We might not have set up a db here.
 		return nil, nil
 	}

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -160,6 +160,14 @@ func (mdb *MibDB) loadProfileDir(profileDir string, extends map[string]*Profile)
 			}
 		}
 
+		if file.Name() == "traps.yaml" || file.Name() == "traps.yml" { // Traps are pulled out into seperate files.
+			err := mdb.parseTrapsFromYml(fname, file, extends)
+			if err != nil {
+				mdb.log.Errorf("There was an error when parsing the %s trap file: %v.", fname, err)
+			}
+			continue
+		}
+
 		pts := strings.Split(fname, ".")
 		switch pts[len(pts)-1] {
 		case "xml":

--- a/pkg/inputs/snmp/mibs/trap.go
+++ b/pkg/inputs/snmp/mibs/trap.go
@@ -1,0 +1,68 @@
+package mibs
+
+import (
+	"os"
+	"strings"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Trap struct {
+	Oid    string `yaml:"trap_oid"`
+	Name   string `yaml:"trap_name"`
+	Events []OID  `yaml:"events"`
+}
+
+type TrapBase struct {
+	logger.ContextL `yaml:"-"`
+	Traps           []Trap `yaml:"traps"`
+	From            string `yaml:"from,omitempty"`
+}
+
+func (mdb *MibDB) parseTrapsFromYml(fname string, file os.DirEntry, extends map[string]*Profile) error {
+	t := TrapBase{ContextL: mdb.log, From: file.Name()}
+	data, err := os.ReadFile(fname)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(data, &t)
+	if err != nil {
+		return err
+	}
+
+	added := 0
+	for _, trap := range t.Traps {
+		for _, event := range trap.Events {
+			mib := &kt.Mib{
+				Oid:        event.Oid,
+				Name:       event.Name,
+				Enum:       event.Enum,
+				Tag:        event.Tag,
+				Conversion: event.Conversion,
+				Extra:      trap.Name,
+				Mib:        trap.Oid,
+			}
+			if len(mib.Enum) > 0 {
+				mib.EnumRev = make(map[int64]string)
+			}
+			for k, v := range mib.Enum {
+				mib.Enum[strings.ToLower(k)] = v
+				mib.EnumRev[v] = k
+			}
+			added++
+			oid := mib.Oid // Normalize to having a . prefix.
+			if !strings.HasPrefix(oid, ".") {
+				oid = "." + oid
+			}
+			mdb.traps[oid] = mib
+		}
+	}
+
+	mdb.log.Infof("Loading %d snmp trap data points from %s.", added, fname)
+
+	return nil
+}

--- a/pkg/inputs/syslog/syslog.go
+++ b/pkg/inputs/syslog/syslog.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kentik/ktranslate/pkg/api"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	snmp_util "github.com/kentik/ktranslate/pkg/inputs/snmp/util"
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
@@ -181,7 +182,11 @@ func (ks *KentikSyslog) formatMessage(msg sfmt.LogParts) ([]byte, error) {
 		if dev, ok := ks.devices[pts[0]]; ok {
 			msg["device_name"] = dev.Name // Copy in any of these info we get
 			for k, v := range dev.UserTags {
-				msg[k] = v
+				key := k
+				if !strings.HasPrefix(key, snmp_util.NRUserTagPrefix) {
+					key = snmp_util.NRUserTagPrefix + k
+				}
+				msg[key] = v
 			}
 		}
 	}


### PR DESCRIPTION
Lets a file called `traps.yml` or `traps.yaml` exist in the snmp-profiles section to define trap based data. Example would be:

```
## Testing.

collect:
- device: NR-SNMP-MIB
  traps:
  - name: newrelicAlertNotification
    type: trap
    event_type: SNMPTrapSample
    trap_oid: .1.3.6.1.4.1.52032.2.1.1.0.101
    metrics:
    - name: severity
      OID: .1.3.6.1.4.1.52032.2.1.1.1.1
    - metric: currentstate
      OID: .1.3.6.1.4.1.52032.2.1.1.1.2
    - name: policyname
      OID: .1.3.6.1.4.1.52032.2.1.1.1.3
    - name: incidenturl
      OID: .1.3.6.1.4.1.52032.2.1.1.1.4
    - name: incidentackurl
      OID: .1.3.6.1.4.1.52032.2.1.1.1.5
    - name: conditionid
      OID: .1.3.6.1.4.1.52032.2.1.1.1.6
    - name: accountid
      OID: .1.3.6.1.4.1.52032.2.1.1.1.7
    - name: eventtype
      OID: .1.3.6.1.4.1.52032.2.1.1.1.8
    - name: incidentid
      OID: .1.3.6.1.4.1.52032.2.1.1.1.9
    - name: details
      OID: .1.3.6.1.4.1.52032.2.1.1.1.10
    - name: conditionname
      OID: .1.3.6.1.4.1.52032.2.1.1.1.11
    - name: targetname
      OID: .1.3.6.1.4.1.52032.2.1.1.1.12
    - name: targetlink
      OID: .1.3.6.1.4.1.52032.2.1.1.1.13
    - name: targetproduct
      OID: .1.3.6.1.4.1.52032.2.1.1.1.14
    - name: targetid
      OID: .1.3.6.1.6.3.1.1.4.1.0
    - name: targettype
      OID: 1.3.6.1.6.1.4.1.2.3.1.1.1.1.1
```