### PR TITLE
Allow matches to drop if no match

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -32,6 +32,10 @@ var (
 	}
 )
 
+const (
+	FORCE_MATCH_TOKEN = "!"
+)
+
 func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.MetricInfo, lastMetadata *kt.LastMetadata) {
 	mapr := in.Flatten()
 	for k, v := range mapr {
@@ -121,6 +125,12 @@ func DropOnFilter(attr map[string]interface{}, lastMetadata *kt.LastMetadata, is
 		keepForOtherMatch := false // We use inverse of this, so default is to drop flow. BUT, need to have a match set else all flow passes.
 		seenNonAdmin := 0
 		for k, re := range lastMetadata.MatchAttr {
+			forceMatch := false
+			if strings.HasPrefix(k, FORCE_MATCH_TOKEN) {
+				k = k[1:]
+				forceMatch = true
+			}
+
 			// If this is not an interface attribute, skip interface matches.
 			if !isIfMetric && (k == kt.AdminStatus || strings.HasPrefix(k, "if_") || strings.HasPrefix(k, "input_if_") || strings.HasPrefix(k, "output_if_")) {
 				continue
@@ -138,6 +148,11 @@ func DropOnFilter(attr map[string]interface{}, lastMetadata *kt.LastMetadata, is
 							keepForOtherMatch = re.MatchString(strv)
 						}
 					}
+				}
+			} else { // If the key doesn't exist but the match tells us to force this, drop here.
+				if forceMatch {
+					seenNonAdmin++
+					keepForOtherMatch = false
 				}
 			}
 		}

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -197,6 +197,37 @@ func TestDropOnFilter(t *testing.T) {
 			},
 			false, // keep because mib-name matches and no admin status.
 		},
+		{
+			map[string]interface{}{
+				kt.AdminStatus: "up",
+				"if_Alias":     "foo",
+			},
+			kt.NewJCHF(),
+			map[string]kt.MetricInfo{},
+			kt.LastMetadata{
+				MatchAttr: map[string]*regexp.Regexp{
+					"!if_Description": regexp.MustCompile("igb3"),
+					kt.AdminStatus:    regexp.MustCompile("up"),
+				},
+			},
+			true, // drop because missing desciption.
+		},
+		{
+			map[string]interface{}{
+				kt.AdminStatus:   "up",
+				"if_Alias":       "foo",
+				"if_Description": "igb3",
+			},
+			kt.NewJCHF(),
+			map[string]kt.MetricInfo{},
+			kt.LastMetadata{
+				MatchAttr: map[string]*regexp.Regexp{
+					"!if_Description": regexp.MustCompile("igb3"),
+					kt.AdminStatus:    regexp.MustCompile("up"),
+				},
+			},
+			false, // keep because matching desciption.
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -148,10 +148,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		}
 	} else {
 		dst.DeviceName = addr.IP.String()
-		dst.Provider = kt.ProviderDefault
-	}
-	if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
-		dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
+		dst.Provider = kt.ProviderTrapUnknown
 	}
 
 	// What trap is this from?

--- a/pkg/inputs/snmp/util/adaptor.go
+++ b/pkg/inputs/snmp/util/adaptor.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -67,6 +68,14 @@ func ParseV3Config(v3config *kt.V3SNMPConfig) (*gosnmp.UsmSecurityParameters, go
 		params.AuthenticationProtocol = gosnmp.SHA512
 	default:
 		return nil, gosnmp.AuthNoPriv, "", "", fmt.Errorf("invalid v3 authentication_protocol: %s. valid options: NoAuth|MD5|SHA|SHA224|SHA256|SHA384|SHA512", v3config.AuthenticationProtocol)
+	}
+
+	// If there is an invalid AWS defined string, error here.
+	if strings.HasPrefix(params.AuthenticationPassphrase, kt.AWSErrPrefix) {
+		return nil, gosnmp.AuthNoPriv, "", "", fmt.Errorf("Invalid AuthenticationPassphrase: %s", params.AuthenticationPassphrase)
+	}
+	if strings.HasPrefix(params.PrivacyPassphrase, kt.AWSErrPrefix) {
+		return nil, gosnmp.AuthNoPriv, "", "", fmt.Errorf("Invalid PrivacyPassphrase: %s", params.PrivacyPassphrase)
 	}
 
 	return &params, flags, v3config.ContextEngineID, v3config.ContextName, nil

--- a/pkg/kt/aws.go
+++ b/pkg/kt/aws.go
@@ -1,0 +1,55 @@
+package kt
+
+/**
+Helper functions to make working with AWS easier.
+*/
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+var (
+	secSev *secretsmanager.SecretsManager
+)
+
+const (
+	AwsSmPrefix  = "aws.sm."
+	AWSErrPrefix = "AwsError: "
+)
+
+func loadViaAWSSecrets(key string) string {
+	if secSev == nil {
+		sess := session.Must(session.NewSession())
+		secSev = secretsmanager.New(sess)
+	}
+
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(key),
+	}
+	result, err := secSev.GetSecretValue(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case secretsmanager.ErrCodeResourceNotFoundException:
+				return AWSErrPrefix + secretsmanager.ErrCodeResourceNotFoundException
+			case secretsmanager.ErrCodeInvalidParameterException:
+				return AWSErrPrefix + secretsmanager.ErrCodeInvalidParameterException
+			case secretsmanager.ErrCodeInvalidRequestException:
+				return AWSErrPrefix + secretsmanager.ErrCodeInvalidRequestException
+			case secretsmanager.ErrCodeDecryptionFailure:
+				return AWSErrPrefix + secretsmanager.ErrCodeDecryptionFailure
+			case secretsmanager.ErrCodeInternalServiceError:
+				return AWSErrPrefix + secretsmanager.ErrCodeInternalServiceError
+			default:
+				return AWSErrPrefix + aerr.Error()
+			}
+		}
+	}
+	if result.SecretString != nil {
+		return *result.SecretString
+	}
+	return ""
+}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -417,6 +417,8 @@ func (a *V3SNMPConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					if sval, ok := f.Interface().(string); ok {
 						if strings.HasPrefix(sval, "${") { // Expecting values of the form ${V3_AUTH_PROTOCOL}
 							f.SetString(os.Getenv(sval[2 : len(sval)-1]))
+						} else if strings.HasPrefix(sval, AwsSmPrefix) { // See if we can pull these out of AWS Secret Manager directly
+							f.SetString(loadViaAWSSecrets(sval[len(AwsSmPrefix):]))
 						}
 					}
 				}

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -65,6 +65,7 @@ const (
 	ProviderSan                Provider = "kentik-san"
 	ProviderAgent              Provider = "kentik-agent"
 	ProviderFibreChannel       Provider = "kentik-fibre-channel"
+	ProviderTrapUnknown        Provider = "kentik-trap-device"
 )
 
 const (


### PR DESCRIPTION
By default, `match_attributes` are skipped if the key doesn't exist in a result. This allows prefixing the key with a `!` to drop this result if the key is null. For example, 

```
match_attributes:		
  !if_Alias: ^igb3 
```

Will drop all interfaces without an alias defined, in addition to those which don't match the regex.

Additionally, this allows users in AWS to store snmp secrets in the aws secret store. Prefix strings in the snmp-v3 config section of `snmp.yaml` and the value will be read from the secret store. For example:

```
    authentication_passphrase: aws.sm.Test
```

To work, this assumes that appropriate `AWS_` env vars are set to allow ktranslate to talk to the secret store. 

