### PR TITLE
#213, look at or vs and for matches

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -153,6 +153,7 @@ func DropOnFilter(attr map[string]interface{}, lastMetadata *kt.LastMetadata, is
 				if forceMatch {
 					seenNonAdmin++
 					keepForOtherMatch = false
+					break
 				}
 			}
 		}

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -146,6 +146,9 @@ func DropOnFilter(attr map[string]interface{}, lastMetadata *kt.LastMetadata, is
 						seenNonAdmin++
 						if !keepForOtherMatch {
 							keepForOtherMatch = re.MatchString(strv)
+							if !keepForOtherMatch && forceMatch { // In this case, we failed the force match so break right now.
+								break
+							}
 						}
 					}
 				}

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -228,6 +228,22 @@ func TestDropOnFilter(t *testing.T) {
 			},
 			false, // keep because matching desciption.
 		},
+		{
+			map[string]interface{}{
+				kt.AdminStatus:   "up",
+				"if_Description": "igb4",
+			},
+			kt.NewJCHF(),
+			map[string]kt.MetricInfo{},
+			kt.LastMetadata{
+				MatchAttr: map[string]*regexp.Regexp{
+					"!if_Alias":      regexp.MustCompile("igb3"),
+					"if_Description": regexp.MustCompile("igb4"),
+					kt.AdminStatus:   regexp.MustCompile("up"),
+				},
+			},
+			true, // drop because alias is missing.
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/inputs/snmp/metadata/interface_metadata.go
+++ b/pkg/inputs/snmp/metadata/interface_metadata.go
@@ -81,7 +81,6 @@ func NewInterfaceMetadata(interfaceMetadataMibs map[string]*kt.Mib, log logger.C
 			if !ok {
 				log.Infof("Adding custom interface metadata oid: %s -> %s", oid, name)
 				m.Set(oid, name)
-
 			}
 		}
 	}


### PR DESCRIPTION
This addresses #213 where match attributes were getting OR'd vs AND'd. 

Now if a match attribute is forced (with a `!` prefix), it MUST be set to pass the record. 