### PR TITLE
Capping dns cache size and time spent looking

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -181,6 +181,9 @@ func setMode(bs *baseserver.BaseServer, mode string, sample int, syslog string) 
 	case "nr1.flow":
 		flag.Set("flow_only", "true")
 		setNr()
+	case "nr1.discovery":
+		flag.Set("snmp_discovery", "true")
+		setNr()
 	case "nr1.syslog": // Tune for syslog.
 		flag.Set("compression", "gzip")
 		flag.Set("sinks", "new_relic")

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -118,6 +118,8 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) error {
 		}
 	}
 
+	time.Sleep(1 * time.Second) // Give logs time to get sent back.
+
 	return nil
 }
 


### PR DESCRIPTION
I realized that the dns resolution feature could use some more polish. 

This caps the max number of IPs resolved at 10,000. This number can be changed by setting the `KentikMaxDnsCacheSize=10` env var. 

Also caps the time spent trying to resolve an IP. This is hard coded to 80 ms. 