### PR TITLE
Plugin health and MemoryCache based MemoryUtilization

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -118,7 +118,7 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) error {
 		}
 	}
 
-	time.Sleep(1 * time.Second) // Give logs time to get sent back.
+	time.Sleep(2 * time.Second) // Give logs time to get sent back.
 
 	return nil
 }

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -224,6 +224,8 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 			memoryUsed, oku := dst.CustomBigInt["MemoryUsed"]
 			memoryFree, okf := dst.CustomBigInt["MemoryFree"]
 			memoryTotal, okt := dst.CustomBigInt["MemoryTotal"]
+			memoryBuffer, okb := dst.CustomBigInt["MemoryBuffer"]
+			memoryCache, okc := dst.CustomBigInt["MemoryCache"]
 			if oku && okf {
 				memoryTotal := memoryFree + memoryUsed
 				if memoryTotal > 0 {
@@ -239,6 +241,11 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 			} else if okt && oku {
 				if memoryTotal > 0 {
 					dst.CustomBigInt["MemoryUtilization"] = int64(float32(memoryUsed) / float32(memoryTotal) * 100)
+					dst.CustomMetrics["MemoryUtilization"] = dst.CustomMetrics["MemoryTotal"]
+				}
+			} else if okt && okb && okc {
+				if memoryTotal > 0 {
+					dst.CustomBigInt["MemoryUtilization"] = int64(float32(memoryTotal-(memoryBuffer+memoryCache)) / float32(memoryTotal) * 100)
 					dst.CustomMetrics["MemoryUtilization"] = dst.CustomMetrics["MemoryTotal"]
 				}
 			}

--- a/pkg/sinks/nr/nr.go
+++ b/pkg/sinks/nr/nr.go
@@ -363,6 +363,7 @@ func (s *NRSink) sendLogBatch(ctx context.Context, logs []string) {
 	}
 	if !hasSyslog {
 		ls.Common.Attributes["plugin.type"] = kt.PluginHealth
+		ls.Common.Attributes["logtype"] = "ktranslate-health"
 	}
 
 	target, err := json.Marshal([]logSet{ls}) // Has to be an array here, no idea why.


### PR DESCRIPTION
#209 to make logging better.

Also,Supports 

```
1.3.6.1.2.1.25.2.3.1.6.1 - Physical
1.3.6.1.2.1.25.2.3.1.6.6 - Buffers
1.3.6.1.2.1.25.2.3.1.6.7 - Cache
```

Style MemoryUtilization metrics. 

```
      {
        "name": "kentik.snmp.MemoryCache",
        "type": "gauge",
        "value": 3746164,
        "attributes": {
          "objectIdentifier": "1.3.6.1.2.1.25.2.3.1.6.7",
          "mib-name": "SYNOLOGY-SYSTEM-MIB",
          "instrumentation.name": "disk_station",
          "mib-table": "system",
          "tags.test": "one",
          "provider": "kentik-net-snmp",
          "device_name": "mabel",
          "eventType": "KSnmpDeviceMetric"
        }
      },
      {
        "name": "kentik.snmp.MemoryTotal",
        "type": "gauge",
        "value": 4910492,
        "attributes": {
          "objectIdentifier": "1.3.6.1.2.1.25.2.3.1.6.1",
          "mib-name": "SYNOLOGY-SYSTEM-MIB",
          "instrumentation.name": "disk_station",
          "eventType": "KSnmpDeviceMetric",
          "provider": "kentik-net-snmp",
          "device_name": "mabel",
          "mib-table": "system",
          "tags.test": "one"
        }
      },
      {
        "name": "kentik.snmp.MemoryBuffer",
        "type": "gauge",
        "value": 21320,
        "attributes": {
          "mib-table": "system",
          "tags.test": "one",
          "objectIdentifier": "1.3.6.1.2.1.25.2.3.1.6.6",
          "mib-name": "SYNOLOGY-SYSTEM-MIB",
          "instrumentation.name": "disk_station",
          "provider": "kentik-net-snmp",
          "device_name": "mabel",
          "eventType": "KSnmpDeviceMetric"
        }
      },
      {
        "name": "kentik.snmp.MemoryUtilization",
        "type": "gauge",
        "value": 23,
        "attributes": {
          "objectIdentifier": "1.3.6.1.2.1.25.2.3.1.6.1",
          "mib-name": "SYNOLOGY-SYSTEM-MIB",
          "instrumentation.name": "disk_station",
          "mib-table": "system",
          "tags.test": "one",
          "provider": "kentik-net-snmp",
          "device_name": "mabel",
          "eventType": "KSnmpDeviceMetric"
        }
      },
```
