### PR TITLE
Fix device metrics

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -262,6 +262,7 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 			added++
 		} else if conf.Devices[key] != nil {
 			if conf.Disco.ReplaceDevices { // But keep backwards compatible with existing devices and don't change their entries.
+				d.UpdateFrom(conf.Devices[key])
 				conf.Devices[key] = d
 				replaced++
 			} else {
@@ -269,6 +270,7 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 			}
 		} else {
 			if conf.Disco.ReplaceDevices { // Else, new style keys all use keyAlt.
+				d.UpdateFrom(conf.Devices[keyAlt])
 				conf.Devices[keyAlt] = d
 				replaced++
 			} else {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -430,3 +430,14 @@ func (a *V3SNMPConfig) InheritGlobal() bool {
 	}
 	return a.useGlobal
 }
+
+// Save any hard coded parts of this profile which might get overriten by an automatic process.
+func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig) {
+	if old == nil {
+		return
+	}
+
+	if strings.HasPrefix(old.MibProfile, "!") {
+		d.MibProfile = old.MibProfile
+	}
+}


### PR DESCRIPTION
Fix for #222 

Basically a better way of mapping mibs back to the oid which polled them.

In bgp4.yml, there are 2 oids defined:

```
      - OID: 1.3.6.1.2.1.15.3.1.2
        name: bgpPeerState
```

And

```
      - OID: 1.3.6.1.2.1.15.3.1.20
        name: bgpPeerHoldTimeConfigured
```

In the old way, code looked for the prefix of a oid to map back to a name. But, since `2` is contained by `20` the wrong enum was used. New way all the info is passed along in 1 section, so no hacky prefix lookup needed. 

Also a fix for when `mib_profile` is hand edited with a `!` to force a profile. Now this forcing is remembered across discovery runs. 
