### PR TITLE
Nye update

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -335,11 +335,11 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.Timestamp = time.Now().Unix()
 	dst.CustomMetrics = map[string]kt.MetricInfo{}
 	dst.CustomBigInt["MinRttMs"] = stats.MinRtt.Microseconds()
-	dst.CustomMetrics["MinRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: dm.profileName, Type: "ping"}
+	dst.CustomMetrics["MinRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["MaxRttMs"] = stats.MaxRtt.Microseconds()
-	dst.CustomMetrics["MaxRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: dm.profileName, Type: "ping"}
+	dst.CustomMetrics["MaxRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["AvgRttMs"] = stats.AvgRtt.Microseconds()
-	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: dm.profileName, Type: "ping"}
+	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 
 	return []*kt.JCHF{dst}, nil
 }

--- a/pkg/inputs/snmp/pollOnce.go
+++ b/pkg/inputs/snmp/pollOnce.go
@@ -31,7 +31,7 @@ func pollOnce(ctx context.Context, tdevice string, conf *kt.SnmpConfig, connectT
 
 	profile := mibdb.FindProfile(device.OID, device.Description, device.MibProfile)
 	if profile == nil {
-		return fmt.Errorf("No profile found for %s", device)
+		return fmt.Errorf("No profile found for %s", tdevice)
 	}
 
 	// We need two of these, to avoid concurrent access by the two pollers.

--- a/pkg/inputs/snmp/pollOnce.go
+++ b/pkg/inputs/snmp/pollOnce.go
@@ -1,0 +1,73 @@
+package snmp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	go_metrics "github.com/kentik/go-metrics"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/inputs/snmp/metadata"
+	snmp_metrics "github.com/kentik/ktranslate/pkg/inputs/snmp/metrics"
+	snmp_util "github.com/kentik/ktranslate/pkg/inputs/snmp/util"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func pollOnce(ctx context.Context, tdevice string, conf *kt.SnmpConfig, connectTimeout time.Duration, retries int, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, log logger.ContextL) error {
+	device := conf.Devices[tdevice]
+	if device == nil {
+		for _, dev := range conf.Devices {
+			if dev.DeviceName == tdevice {
+				device = dev
+				break
+			}
+		}
+	}
+
+	if device == nil {
+		return fmt.Errorf("The %s device was not found in the SNMP configuration file.", tdevice)
+	}
+
+	profile := mibdb.FindProfile(device.OID, device.Description, device.MibProfile)
+	if profile == nil {
+		return fmt.Errorf("No profile found for %s", device)
+	}
+
+	// We need two of these, to avoid concurrent access by the two pollers.
+	// gosnmp isn't real clear on its approach to concurrency, but it seems
+	// like maintaining separate GoSNMP structs for the two goroutines is safe.
+	metadataServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
+	if err != nil {
+		log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
+		return err
+	}
+	metricsServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
+	if err != nil {
+		log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
+		return err
+	}
+
+	nm := kt.NewSnmpDeviceMetric(registry, device.DeviceName)
+	metadataPoller := metadata.NewPoller(metadataServer, conf.Global, device, jchfChan, nm, profile, log)
+	metricPoller := snmp_metrics.NewPoller(metricsServer, conf.Global, device, jchfChan, nm, profile, log)
+
+	metadataPoller.StartLoop(ctx)
+	// Give a little time to get this done.
+	time.Sleep(1 * time.Second)
+
+	flows, err := metricPoller.Poll(ctx)
+	if err != nil {
+		return err
+	}
+
+	jchfChan <- flows
+
+	// Give some time and then halt the process.
+	go func() {
+		time.Sleep(3 * time.Second)
+		os.Exit(0)
+	}()
+
+	return nil
+}

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -32,6 +32,7 @@ var (
 	snmpWalkOid    = flag.String("snmp_walk_oid", ".1.3.6.1.2.1", "Walk this oid if -snmp_do_walk is set.")
 	snmpWalkFormat = flag.String("snmp_walk_format", "", "use this format for walked values if -snmp_do_walk is set.")
 	snmpOutFile    = flag.String("snmp_out_file", "", "If set, write updated snmp file here.")
+	snmpPollNow    = flag.String("snmp_poll_now", "", "If set, run one snmp poll for the specified device and then exit.")
 )
 
 func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL) error {
@@ -58,6 +59,11 @@ func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 		mibdb = mdb
 	} else {
 		log.Infof("Skipping configurable mibs")
+	}
+
+	// If we just want to poll one device and exit, do this here.
+	if *snmpPollNow != "" {
+		return pollOnce(ctx, *snmpPollNow, conf, connectTimeout, retries, jchfChan, metrics, registry, log)
 	}
 
 	// Now, launch a metadata and metrics server for each configured or discovered device.

--- a/pkg/sinks/nr/nr.go
+++ b/pkg/sinks/nr/nr.go
@@ -246,7 +246,7 @@ func (s *NRSink) test(ctx context.Context) error {
 		s.sendNR(ctx, payload, url)
 		err := <-errChan
 		if err != nil {
-			return err
+			return fmt.Errorf("Error testing %s: %v", url, err)
 		}
 	}
 


### PR DESCRIPTION
Covers a few FRs:

#225 -- `"instrumentation.name": "ping"`
#218 

Will error like: 
```
service Run() error: Error testing https://insights-collector.eu01.nr-data.net/v1/accounts/2822422/events: There was an error when communicating to New Relic One: 403.
```

when one of the NR urls is wrong.

#216 

Adds a flag ` -snmp_poll_now=mabel` which forces 1 snmp poll and then exits. Example use might be:

```
docker run -ti --name ktranslate-poll-now --rm --net=host \
--user `id -u`:`id -g` \
-v `pwd`/snmp-base.yaml:/snmp-base.yaml \
kentik/ktranslate:v2 \
    -snmp /snmp-base.yaml \
    -snmp_poll_now="router123.domain" \
    -format=new_relic_metric
```



