### PR TITLE
Multiple Table Support

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -682,8 +682,8 @@ func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 				attrNew["mib-table"] = name.Table
 
 				// See if the metadata knows about this attribute.
-				if tableName, ok := lm.GetTableName(newKey); ok {
-					if tableName != name.Table && tableName != kt.DeviceTagTable {
+				if tableName, allNames, ok := lm.GetTableName(newKey); ok {
+					if !allNames[name.Table] && tableName != kt.DeviceTagTable {
 						continue
 					}
 				} else {
@@ -697,7 +697,7 @@ func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 
 		// Case where metric has no table.
 		if name.Table == "" {
-			if tableName, ok := lm.GetTableName(newKey); ok {
+			if tableName, _, ok := lm.GetTableName(newKey); ok {
 				if tableName != "" && tableName != kt.DeviceTagTable {
 					continue
 				}

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -216,7 +216,7 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 
 			for _, table := range dst.CustomTables {
 				for k, v := range table.Customs {
-					dst.CustomMetrics[k] = kt.MetricInfo{Table: v.TableName}
+					dst.CustomMetrics[k] = kt.MetricInfo{Table: v.TableName, Tables: v.TableNames}
 				}
 			}
 		}

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -543,9 +543,17 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 					}
 				}
 				if strings.HasPrefix(t.Column.Name, "if") {
-					interfaceMetadata[t.Column.Oid] = mib
+					if em, ok := interfaceMetadata[t.Column.Oid]; ok {
+						em.Extend(mib)
+					} else {
+						interfaceMetadata[t.Column.Oid] = mib
+					}
 				} else {
-					deviceMetadata[t.Column.Oid] = mib
+					if em, ok := deviceMetadata[t.Column.Oid]; ok {
+						em.Extend(mib)
+					} else {
+						deviceMetadata[t.Column.Oid] = mib
+					}
 				}
 			}
 		}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -122,6 +122,7 @@ type V3SNMPConfig struct {
 	ContextEngineID          string `yaml:"context_engine_id"`
 	ContextName              string `yaml:"context_name"`
 	useGlobal                bool
+	origStr                  string
 }
 
 type SnmpDeviceConfig struct {
@@ -391,6 +392,14 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 type V3SNMP V3SNMPConfig // Need a 2nd type alias to avoid stack overflow on parsing.
 
+// Make sure that things serialize back to how they were.
+func (a *V3SNMPConfig) MarshalYAML() (interface{}, error) {
+	if a.origStr != "" {
+		return a.origStr, nil
+	}
+	return a, nil
+}
+
 // This lets the config get overriden by a global_v3 string.
 func (a *V3SNMPConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var conf = V3SNMP{}
@@ -414,6 +423,7 @@ func (a *V3SNMPConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				return err
 			}
 		}
+		conf.origStr = single // Let us know where this came from.
 		*a = V3SNMPConfig(conf)
 	} else {
 		// Now, see if we need to map in any ENV vars.

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -184,14 +184,15 @@ type JCHF struct {
 }
 
 type MetricInfo struct {
-	Oid     string        `json:"-"`
-	Mib     string        `json:"-"`
-	Name    string        `json:"-"`
-	Profile string        `json:"-"`
-	Table   string        `json:"-"`
-	Format  string        `json:"-"`
-	Type    string        `json:"-"`
-	PollDur time.Duration `json:"-"`
+	Oid     string          `json:"-"`
+	Mib     string          `json:"-"`
+	Name    string          `json:"-"`
+	Profile string          `json:"-"`
+	Table   string          `json:"-"`
+	Format  string          `json:"-"`
+	Type    string          `json:"-"`
+	PollDur time.Duration   `json:"-"`
+	Tables  map[string]bool `json:"-"`
 }
 
 func (m *MetricInfo) GetType() string {


### PR DESCRIPTION
Fixes #230 where if a metadata oid is used in multiple tables, only 1 table will get this oid. 

Also addresses #227 part 2 where after discovery the `aws.ss.XXX` part of config is replaced with the pulled value. 