### PR TITLE
Ensure that if_interface_name Works for CISCO_IF_EXTENSION

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -650,6 +650,7 @@ var keepAcrossTables = map[string]bool{
 	"provider":       true,
 	"sysoid_profile": true,
 	kt.IndexVar:      true,
+	"if_Index":       true,
 }
 
 func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata) map[string]interface{} {
@@ -682,7 +683,7 @@ func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 				attrNew["mib-table"] = name.Table
 
 				// See if the metadata knows about this attribute.
-				if tableName, allNames, ok := lm.GetTableName(newKey); ok {
+				if tableName, allNames, ok := lm.GetTableName(newKey); ok && len(allNames) > 0 {
 					if !allNames[name.Table] && tableName != kt.DeviceTagTable {
 						continue
 					}

--- a/pkg/inputs/snmp/metadata/interface_metadata.go
+++ b/pkg/inputs/snmp/metadata/interface_metadata.go
@@ -79,7 +79,7 @@ func NewInterfaceMetadata(interfaceMetadataMibs map[string]*kt.Mib, log logger.C
 			mibs[name] = mib
 			_, ok := m.Get(oid)
 			if !ok {
-				log.Infof("Adding custom interface metadata oid: %s -> %s", oid, name)
+				log.Infof("Adding custom interface metadata oid: %s -> %s %v", oid, name, mib.OtherTables)
 				m.Set(oid, name)
 			}
 		}

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -236,12 +236,12 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 	// Now, pass along lookup info if we find any.
 	for k, _ := range dst.CustomStr {
 		if mib, ok := p.lookupMib(k, false); ok {
-			dst.CustomMetrics[k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table}
+			dst.CustomMetrics[k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table, Tables: mib.OtherTables}
 		}
 	}
 	for k, _ := range dst.CustomInt {
 		if mib, ok := p.lookupMib(k, false); ok {
-			dst.CustomMetrics[k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table}
+			dst.CustomMetrics[k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table, Tables: mib.OtherTables}
 		}
 	}
 
@@ -266,7 +266,7 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 		for k, v := range id.ExtraInfo {
 			dst.CustomStr["if."+intr+"."+k] = v
 			if mib, ok := p.lookupMib(k, true); ok {
-				dst.CustomMetrics["if_"+k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table}
+				dst.CustomMetrics["if_"+k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table, Tables: mib.OtherTables}
 			}
 		}
 	}
@@ -290,10 +290,10 @@ func (p *Poller) lookupMib(key string, isInterface bool) (*kt.Mib, bool) {
 		}
 	} else {
 		for _, mib := range p.interfaceMetadataMibs {
-			if mib.Name == key {
+			if mib.Name == key || mib.Name == "if_"+key {
 				return mib, true
 			}
-			if mib.Tag == key {
+			if mib.Tag == key || mib.Tag == "if_"+key {
 				return mib, true
 			}
 		}

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -39,6 +39,7 @@ type MIB struct {
 	MetricTags   []Tag  `yaml:"metric_tags,omitempty"`
 	ForcedType   string `yaml:"forced_type,omitempty"`
 	Symbol       OID    `yaml:"symbol,omitempty"`
+	IsInterface  bool   `yaml:"is_interface,omitempty"`
 	sortKey      string
 	fromExtended bool
 }
@@ -394,7 +395,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				p.Warnf("Skipping mib with no name: %v", mib)
 				continue
 			}
-			if strings.HasPrefix(metric.Symbol.Name, "if") {
+			if metric.IsInterface || strings.HasPrefix(metric.Symbol.Name, "if") {
 				interfaceMetrics[metric.Symbol.Oid] = mib
 			} else {
 				deviceMetrics[metric.Symbol.Oid] = mib
@@ -434,7 +435,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				p.Warnf("Skipping mib with no name: %v", mib)
 				continue
 			}
-			if strings.HasPrefix(s.Name, "if") {
+			if metric.IsInterface || strings.HasPrefix(s.Name, "if") {
 				interfaceMetrics[s.Oid] = mib
 			} else {
 				deviceMetrics[s.Oid] = mib
@@ -542,7 +543,7 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 						}
 					}
 				}
-				if strings.HasPrefix(t.Column.Name, "if") {
+				if metric.IsInterface || strings.HasPrefix(t.Column.Name, "if") {
 					if em, ok := interfaceMetadata[t.Column.Oid]; ok {
 						em.Extend(mib)
 					} else {

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -23,6 +23,7 @@ type OID struct {
 	Conversion string           `yaml:"conversion,omitempty"`
 	PollTime   int              `yaml:"poll_time_sec,omitempty"`
 	MatchAttr  []string         `yaml:"match_attributes,omitempty"`
+	Format     string           `yaml:"format,omitempty"`
 }
 
 type Tag struct {
@@ -373,6 +374,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				Mib:          metric.Mib,
 				Table:        metric.Table.GetTableName(),
 				FromExtended: metric.fromExtended,
+				Format:       metric.Symbol.Format,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -413,6 +415,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				Mib:          metric.Mib,
 				Table:        metric.Table.GetTableName(),
 				FromExtended: metric.fromExtended,
+				Format:       s.Format,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -286,6 +286,7 @@ type Mib struct {
 	lastPoll     time.Time
 	FromExtended bool
 	OtherTables  map[string]bool
+	Format       string
 }
 
 func (mb *Mib) String() string {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -313,11 +313,9 @@ func (mb *Mib) IsPollReady() bool { // If there's a poll duration, return false 
 
 func (mb *Mib) Extend(nm *Mib) {
 	if mb.OtherTables == nil {
-		mb.OtherTables = map[string]bool{}
+		mb.OtherTables = map[string]bool{mb.Table: true}
 	}
-	if mb.Table != nm.Table {
-		mb.OtherTables[nm.Table] = true
-	}
+	mb.OtherTables[nm.Table] = true
 }
 
 type LastMetadata struct {


### PR DESCRIPTION
Right now the attribute `if_interface_name` doesn't show up for some cisco specific extensions.

This PR updates how interface and device attributes are set so that the its seen as belonging to this table in addition to iftable. 