### PR TITLE
Src_addr, panic at the disco

### DIFF
--- a/.github/workflows/clean-stale-issues.yml
+++ b/.github/workflows/clean-stale-issues.yml
@@ -14,6 +14,7 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          exempt-issue-labels: enhancement
           days-before-issue-stale: 30
           days-before-pr-stale: 45
           days-before-issue-close: 5

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -653,6 +653,13 @@ var keepAcrossTables = map[string]bool{
 	"if_Index":       true,
 }
 
+var allowSysAttr = map[string]bool{
+	"Uptime":   true,
+	"MinRttMs": true,
+	"MaxRttMs": true,
+	"AvgRttMs": true,
+}
+
 func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata) map[string]interface{} {
 	attrNew := map[string]interface{}{
 		"objectIdentifier":     name.Oid,
@@ -667,7 +674,7 @@ func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 	}
 
 	for k, v := range attr {
-		if metricName != "Uptime" { // Only allow Sys* attributes on uptime.
+		if !allowSysAttr[metricName] { // Only allow Sys* attributes on specific metrics.
 			if strings.HasPrefix(k, "Sys") || k == "src_addr" {
 				continue
 			}

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -103,6 +103,9 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 			continue
 		}
 
+		if len(oidResults) == 0 {
+			dm.log.Warnf("OID failed to return results, Metric Name: %s, Profile: %s", mib.Name, dm.profileName)
+		}
 		for _, result := range oidResults {
 			results = append(results, wrapper{variable: result, mib: mib, oid: oid})
 		}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -488,6 +488,9 @@ func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig) {
 func (d *SnmpDeviceConfig) InitUserTags(serviceName string) {
 	d.allUserTags = map[string]string{}
 	if serviceName != "ktranslate" {
+		if d.UserTags == nil { // Prevent nil map assignment.
+			d.UserTags = map[string]string{}
+		}
 		d.UserTags["container_service"] = serviceName
 	}
 


### PR DESCRIPTION
#244 , warns if device metrics in a profile do not return anything.
#245 , ensures src_addr is present for synthetic metrics.
Adds a guard on service_name for snmp disco to prevent a panic.
Tweak the state bot system to not fire if the right label is set.
