### PR TITLE
Ensuring user tags go into the right tables again

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -697,7 +697,9 @@ func copyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 				} else {
 					// If this metric comes from a specific table, only show attributes for this table.
 					if !strings.HasPrefix(newKey, name.Table) {
-						continue
+						if !allNames[name.Table] && tableName != kt.DeviceTagTable {
+							continue
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The last take on attributes was stripping out user tags. This commit ensures that tags are placed on all metrics again. 