### PR TITLE
add timestamp field for formatters

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -11,7 +11,6 @@ import (
 var (
 	DroppedAttrs = map[string]bool{
 		"result_type":             true,
-		"timestamp":               true,
 		"sampled_packet_size":     true,
 		"lat/long_dest":           true,
 		"member_id":               true,


### PR DESCRIPTION
This adds the timestamp field for formatters that use the `util.DroppedAttrs` helper.