### PR TITLE
Reduce logging for missing metrics

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -349,6 +349,7 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomMetrics["MaxRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["AvgRttMs"] = stats.AvgRtt.Microseconds()
 	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dm.conf.SetUserTags(dst.CustomStr)
 
 	return []*kt.JCHF{dst}, nil
 }

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -227,6 +227,7 @@ type SnmpDeviceMetric struct {
 	Metadata         go_metrics.Meter
 	Errors           go_metrics.Meter
 	Fail             go_metrics.Gauge
+	Missing          go_metrics.Gauge
 }
 
 const (
@@ -248,6 +249,7 @@ func NewSnmpDeviceMetric(registry go_metrics.Registry, deviceName string) *SnmpD
 		Metadata:         go_metrics.GetOrRegisterMeter("metadata^device_name="+deviceName, registry),
 		Errors:           go_metrics.GetOrRegisterMeter("snmp_errors^device_name="+deviceName, registry),
 		Fail:             go_metrics.GetOrRegisterGauge("snmp_fail^device_name="+deviceName, registry),
+		Missing:          go_metrics.GetOrRegisterGauge("snmp_missing^force=true^device_name="+deviceName, registry),
 	}
 	sm.Fail.Update(SNMP_GOOD) // 1 means that this device is not failing.
 	return &sm


### PR DESCRIPTION
This one will only log once a missing metric at warn level, the rest of the time at debug. 

Also creates a new internal gauge metric to track these, `snmp_missing`.

Tackles #257, missing user tags as well.  