### PR TITLE
Refactor to make synth data for es more usable. (#261)

### DIFF
--- a/pkg/formats/elasticsearch/elasticsearch.go
+++ b/pkg/formats/elasticsearch/elasticsearch.go
@@ -17,10 +17,7 @@ import (
 )
 
 const (
-	InstNameNetflowEvent = "netflow-events"
-	InstNameVPCEvent     = "vpc-flow-events"
-	InstNameAWSVPCEvent  = "aws-vpc-flow-events"
-	actionEntry          = `{"index":{}}`
+	actionEntry = `{"index":{}}`
 )
 
 var json = jsoniter.ConfigFastest
@@ -52,12 +49,14 @@ func NewFormat(log logger.Underlying, compression kt.Compression) (*Elasticsearc
 func (f *ElasticsearchFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 	msgsNew := make([]map[string]interface{}, 0, len(msgs))
 	for _, msg := range msgs {
-		if msg.EventType == kt.KENTIK_EVENT_SNMP {
-			continue
+		switch msg.EventType {
+		case kt.KENTIK_EVENT_SYNTH, kt.KENTIK_EVENT_TRACE:
+			msgsNew = append(msgsNew, f.handleSynth(msg))
+		default:
+			mm := msg.Flatten()
+			strip(mm)
+			msgsNew = append(msgsNew, mm)
 		}
-		mm := msg.Flatten()
-		strip(mm)
-		msgsNew = append(msgsNew, mm)
 	}
 
 	esBulkData := []string{}
@@ -140,6 +139,30 @@ func (f *ElasticsearchFormat) Rollup(rolls []rollup.Rollup) (*kt.Output, error) 
 	return kt.NewOutputWithProvider([]byte(strings.Join(esBulkData, "")), rolls[0].Provider, kt.RollupOutput), nil
 }
 
+func (f *ElasticsearchFormat) handleSynth(in *kt.JCHF) map[string]interface{} {
+	metrics := util.GetSynMetricNameSet(in.CustomInt["result_type"])
+	attr := in.Flatten()
+	strip(attr)
+
+	for m, name := range metrics {
+		if _, ok := attr[m]; ok {
+			attr[name.Name] = attr[m]
+			delete(attr, m)
+		}
+	}
+
+	// If there's a traceroute, try to unserialize this one.
+	if raw, ok := attr["error_cause/trace_route"]; ok {
+		trace := []interface{}{}
+		if err := json.Unmarshal([]byte(raw.(string)), &trace); err == nil {
+			attr["trace_route"] = trace
+			delete(attr, "error_cause/trace_route")
+		}
+	}
+
+	return attr
+}
+
 func serialize(o interface{}) (string, error) {
 	s := actionEntry + "\n"
 	data, err := json.Marshal(o)
@@ -150,8 +173,27 @@ func serialize(o interface{}) (string, error) {
 	return s, nil
 }
 
+var (
+	DroppedAttrs = map[string]bool{
+		"sampled_packet_size": true,
+		"lat/long_dest":       true,
+		"member_id":           true,
+		"dst_eth_mac":         true,
+		"src_eth_mac":         true,
+		"ult_exit_port":       true,
+		"app_protocol":        true,
+		"dst_route_prefix":    true,
+		"src_route_prefix":    true,
+		"trf_termination":     true,
+		"simple_trf_prof":     true,
+	}
+)
+
 func strip(in map[string]interface{}) {
 	for k, v := range in {
+		if DroppedAttrs[k] {
+			delete(in, k) // Skip.
+		}
 		switch tv := v.(type) {
 		case string:
 			if tv == "" || tv == "-" || tv == "--" {
@@ -166,21 +208,7 @@ func strip(in map[string]interface{}) {
 				delete(in, k)
 			}
 		}
-		if _, ok := util.DroppedAttrs[k]; ok {
-			delete(in, k)
-		}
 	}
 	in["instrumentation.provider"] = kt.InstProvider // Let them know who sent this.
-	switch in["provider"] {
-	case kt.ProviderVPC:
-		switch in["kt.from"] {
-		case kt.FromLambda:
-			in["instrumentation.name"] = InstNameAWSVPCEvent
-		default:
-			in["instrumentation.name"] = InstNameVPCEvent
-		}
-	default:
-		in["instrumentation.name"] = InstNameNetflowEvent
-	}
 	in["collector.name"] = kt.CollectorName
 }

--- a/pkg/formats/elasticsearch/elasticsearch_test.go
+++ b/pkg/formats/elasticsearch/elasticsearch_test.go
@@ -23,7 +23,6 @@ func TestSerializeElasticsearch(t *testing.T) {
 	assert.Equal(len(kt.InputTesting), len(out))
 	for i, _ := range out {
 		assert.Equal(kt.InputTesting[i].SrcAddr, out[i]["src_addr"])
-		assert.Equal(int(0), int(out[i]["timestamp"].(int64)))
 	}
 }
 
@@ -40,6 +39,5 @@ func TestSerializeElasticsearchGzip(t *testing.T) {
 	assert.Equal(len(kt.InputTesting), len(out))
 	for i, _ := range out {
 		assert.Equal(kt.InputTesting[i].SrcAddr, out[i]["src_addr"])
-		assert.Equal(int(0), int(out[i]["timestamp"].(int64)))
 	}
 }


### PR DESCRIPTION
What do you think of this vs #253? 

Idea is to give more context to synthetic data, also parse out the traceroute results. Example data: 

```
{
  "index": {}
}
{
  "dst_addr": "163.116.183.35",
  "src_as": 45102,
  "trf_origination": "outside",
  "result_type": 2,
  "dst_endpoint": "163.116.183.35:0",
  "protocol": "HOPOPT",
  "instrumentation.provider": "kentik",
  "ult_exit_device_id": 32199,
  "sent": 5,
  "src_geo": "AE",
  "test_id": 18135,
  "dst_geo": "SA",
  "collector.name": "ktranslate",
  "max_rtt": 31667,
  "avg_rtt": 31567,
  "agent_id": 730,
  "application": "HOPOPT",
  "timestamp": 1644619276,
  "src_addr": "47.91.105.167",
  "std_rtt": 52,
  "ult_exit_network_bndry": "none",
  "application_type": "synthetic_agent",
  "task_id": 2519892,
  "src_endpoint": "47.91.105.167:0",
  "test_url": "https://portal.kentik.com/v4/synthetics/tests/18135/results",
  "company_id": 53141,
  "min_rtt": 31524,
  "result_type_str": "ping",
  "provider": "kentik-network-synthetic",
  "dst_as": 55256,
  "jit_rtt": 82,
  "device_id": 104891,
  "eventType": "KSynth",
  "Type": "kflow"
}
{
  "index": {}
}
{
  "application_type": "synthetic_agent",
  "ult_exit_network_bndry": "none",
  "trf_origination": "outside",
  "dst_geo": "SA",
  "Type": "kflow",
  "application": "HOPOPT",
  "device_id": 104891,
  "src_geo": "AE",
  "trace_route": [
    {
      "hop": 1,
      "nodes": {}
    },
    {
      "hop": 2,
      "nodes": {}
    },
    {
      "hop": 3,
      "nodes": {
        "11.209.232.197": [
          5766,
          2618,
          1840,
          2221
        ]
      }
    },
    {
      "hop": 4,
      "nodes": {
        "11.209.233.66": [
          1272,
          1074,
          1090,
          1055
        ]
      }
    },
    {
      "hop": 5,
      "nodes": {
        "116.251.72.18": [
          4498,
          2433,
          2193,
          2126
        ]
      }
    },
    {
      "hop": 6,
      "nodes": {
        "94.205.49.145": [
          2089,
          2075,
          2094,
          2099
        ]
      }
    },
    {
      "hop": 7,
      "nodes": {}
    },
    {
      "nodes": {},
      "hop": 8
    },
    {
      "hop": 9,
      "nodes": {
        "185.1.8.27": [
          16640,
          16712,
          16671,
          18173
        ]
      }
    },
    {
      "hop": 10,
      "nodes": {}
    },
    {
      "hop": 11,
      "nodes": {
        "87.109.46.153": [
          31842,
          31860,
          31850,
          31819
        ]
      }
    },
    {
      "hop": 12,
      "nodes": {
        "163.116.183.35": [
          31868,
          31842,
          31783,
          31919
        ]
      }
    }
  ],
  "ult_exit_device_id": 32199,
  "test_id": 18135,
  "ping_min_rtt_(weighted)": 12,
  "test_url": "https://portal.kentik.com/v4/synthetics/tests/18135/results",
  "task_id": 2519893,
  "dst_endpoint": "163.116.183.35:0",
  "time": 4355960,
  "provider": "kentik-network-synthetic",
  "timestamp": 1644619304,
  "src_addr": "47.91.105.167",
  "instrumentation.provider": "kentik",
  "agent_id": 730,
  "dst_as": 55256,
  "src_as": 45102,
  "eventType": "KTrace",
  "company_id": 53141,
  "collector.name": "ktranslate",
  "result_type": 4,
  "protocol": "HOPOPT",
  "src_endpoint": "47.91.105.167:0",
  "result_type_str": "trace",
  "dst_addr": "163.116.183.35"
}
{
  "index": {}
}
{
  "Type": "kflow",
  "jit_rtt": 128,
  "device_id": 104891,
  "result_type_str": "knock",
  "collector.name": "ktranslate",
  "company_id": 53141,
  "src_endpoint": "35.247.178.52:0",
  "ult_exit_network_bndry": "none",
  "timestamp": 1644619315,
  "dst_as": 55256,
  "application_type": "synthetic_agent",
  "src_cdn_int": "Google Youtube",
  "ult_exit_device_id": 32199,
  "test_url": "https://portal.kentik.com/v4/synthetics/tests/5905/results",
  "src_cloud_service": "general",
  "dst_addr": "163.116.193.35",
  "protocol": "HOPOPT",
  "trf_origination": "outside",
  "instrumentation.provider": "kentik",
  "eventType": "KSynth",
  "std_rtt": 67,
  "application": "HOPOPT",
  "provider": "kentik-network-synthetic",
  "sent": 5,
  "task_id": 1721836,
  "test_id": 5905,
  "result_type": 5,
  "dst_endpoint": "163.116.193.35:0",
  "dst_geo": "SG",
  "avg_rtt": 1284,
  "src_as": 396982,
  "agent_id": 628,
  "src_geo": "SG",
  "max_rtt": 1345,
  "min_rtt": 1180,
  "src_cloud": "gcp",
  "src_addr": "35.247.178.52"
}
{
  "index": {}
}
{
  "device_id": 104891,
  "ping_min_rtt_(weighted)": 4,
  "result_type_str": "trace",
  "instrumentation.provider": "kentik",
  "application_type": "synthetic_agent",
  "src_addr": "35.247.178.52",
  "src_as": 396982,
  "trace_route": [
    {
      "hop": 1,
      "nodes": {
        "216.239.48.197": [
          1797,
          1085,
          1110
        ]
      }
    },
    {
      "hop": 2,
      "nodes": {
        "103.16.102.159": [
          1855,
          1560,
          1569
        ]
      }
    },
    {
      "hop": 3,
      "nodes": {
        "163.116.193.35": [
          1579,
          1271
        ]
      }
    },
    {
      "hop": 4,
      "nodes": {
        "163.116.193.35": [
          2099,
          1486,
          1483
        ]
      }
    }
  ],
  "company_id": 53141,
  "test_id": 5905,
  "src_cloud_service": "general",
  "src_endpoint": "35.247.178.52:0",
  "timestamp": 1644619315,
  "src_geo": "SG",
  "application": "HOPOPT",
  "trf_origination": "outside",
  "src_cloud": "gcp",
  "src_cdn_int": "Google Youtube",
  "dst_addr": "163.116.193.35",
  "collector.name": "ktranslate",
  "agent_id": 628,
  "dst_endpoint": "163.116.193.35:0",
  "ult_exit_device_id": 32199,
  "Type": "kflow",
  "dst_geo": "SG",
  "result_type": 4,
  "protocol": "HOPOPT",
  "eventType": "KTrace",
  "provider": "kentik-network-synthetic",
  "dst_as": 55256,
  "time": 284945,
  "task_id": 1721837,
  "ult_exit_network_bndry": "none",
  "test_url": "https://portal.kentik.com/v4/synthetics/tests/5905/results"
}
```