### PR TITLE
Publish to quay.io as well.

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Login to Quay.IO
         uses: docker/login-action@v1
         with:
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_LOGIN_TOKEN }}
 

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_LOGIN_TOKEN_TOKEN }}
+          password: ${{ secrets.QUAY_LOGIN_TOKEN }}
 
       - name: Install dependencies
         run: sudo apt-get install make libpcap-dev golint

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - add-quay-reg
 
 jobs:
   deploy:
@@ -38,6 +39,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay.IO
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_LOGIN_TOKEN_TOKEN }}
+
       - name: Install dependencies
         run: sudo apt-get install make libpcap-dev golint
 
@@ -61,21 +68,7 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: kentik/ktranslate:${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:latest, kentik/ktranslate:v2
-          build-args: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
-          secrets: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-
-      - name: Build and Publish Docker (AWS Lambda)
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          platforms: linux/arm64
-          push: true
-          tags: kentik/ktranslate:v2arm64
+          tags: quay.io/kentik/ktranslate:v2, quay.io/kentik/ktranslate:latest
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - add-quay-reg
 
 jobs:
   deploy:
@@ -69,7 +68,21 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: quay.io/kentik/ktranslate:v2, quay.io/kentik/ktranslate:latest
+          tags: kentik/ktranslate:${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:latest, kentik/ktranslate:v2 quay.io/kentik/ktranslate:v2, quay.io/kentik/ktranslate:latest
+          build-args: |
+            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
+            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
+          secrets: |
+            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
+
+      - name: Build and Publish Docker (AWS Lambda)
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: kentik/ktranslate:v2arm64
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}


### PR DESCRIPTION
Adding a quay.io target along with docker hub. This is because docker hub no longer allows a pull from none signed in accounts. 