### PR TITLE
Allow multiple snmpv3 configs for discovery

### DIFF
--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -172,18 +172,19 @@ type SnmpTrapConfig struct {
 }
 
 type SnmpDiscoConfig struct {
-	Cidrs              StringArray   `yaml:"cidrs"`
-	Debug              bool          `yaml:"debug"`
-	Ports              []int         `yaml:"ports"`
-	DefaultCommunities []string      `yaml:"default_communities"`
-	UseV1              bool          `yaml:"use_snmp_v1"`
-	DefaultV3          *V3SNMPConfig `yaml:"default_v3"`
-	AddDevices         bool          `yaml:"add_devices"`
-	AddAllMibs         bool          `yaml:"add_mibs"`
-	Threads            int           `yaml:"threads"`
-	ReplaceDevices     bool          `yaml:"replace_devices"`
-	NoDedup            bool          `yaml:"no_dedup_engine_id,omitempty"`
-	CidrOrig           string        `yaml:"-"`
+	Cidrs              StringArray     `yaml:"cidrs"`
+	Debug              bool            `yaml:"debug"`
+	Ports              []int           `yaml:"ports"`
+	DefaultCommunities []string        `yaml:"default_communities"`
+	UseV1              bool            `yaml:"use_snmp_v1"`
+	DefaultV3          *V3SNMPConfig   `yaml:"default_v3"`
+	OtherV3s           []*V3SNMPConfig `yaml:"other_v3s,omitempty"`
+	AddDevices         bool            `yaml:"add_devices"`
+	AddAllMibs         bool            `yaml:"add_mibs"`
+	Threads            int             `yaml:"threads"`
+	ReplaceDevices     bool            `yaml:"replace_devices"`
+	NoDedup            bool            `yaml:"no_dedup_engine_id,omitempty"`
+	CidrOrig           string          `yaml:"-"`
 }
 
 type SnmpGlobalConfig struct {


### PR DESCRIPTION
This is for #255 -- allows multiple snmp v3 configs to be passed in for discovery. It does this by adding the `other_v3s` list to the discovery yaml config. This list is added to anything in the `default_v3` field, to keep things backwards compatible. Supports env vars and AWS secrets like other v3 settings. 

Example format is:

```
discovery:
  cidrs: "@cidrs.yaml"
  debug: false
  ports:
  - 161
  default_communities:
  default_v3: null
  other_v3s:
  - user_name: test
    authentication_protocol: SHA
    authentication_passphrase: Pa33Word
    privacy_protocol: AES
    privacy_passphrase: hunter2
    context_engine_id: ""
    context_name: "" 
  - ${OTHER_V3_CONFIG}
  add_devices: true
  threads: 4
  use_snmp_v1: false
  replace_devices: true
```

