### PR TITLE
Adding profile comments as a user tag

### DIFF
--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -66,8 +66,8 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		// See if there's a device comment for this profile.
 		dev := profile.GetDeviceSysComment(conf.OID)
 		if dev != "" {
-			log.Infof("Adding model tag %s", dev)
-			conf.AddUserTag("kt.model", dev)
+			log.Debugf("Adding model tag %s", dev)
+			conf.AddUserTag("kentik.model", dev)
 		}
 	}
 

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -62,6 +62,13 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 				}
 			}
 		}
+
+		// See if there's a device comment for this profile.
+		dev := profile.GetDeviceSysComment(conf.OID)
+		if dev != "" {
+			log.Infof("Adding model tag %s", dev)
+			conf.AddUserTag("kt.model", dev)
+		}
 	}
 
 	// Load any attribute level whiltelist info here.

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -487,6 +487,17 @@ func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig) {
 	}
 }
 
+func (d *SnmpDeviceConfig) AddUserTag(k string, v string) {
+	if d.allUserTags == nil {
+		d.allUserTags = map[string]string{}
+	}
+	key := k
+	if !strings.HasPrefix(key, UserTagPrefix) {
+		key = UserTagPrefix + k
+	}
+	d.allUserTags[key] = v
+}
+
 func (d *SnmpDeviceConfig) InitUserTags(serviceName string) {
 	d.allUserTags = map[string]string{}
 	if serviceName != "ktranslate" {


### PR DESCRIPTION
Like we talked about, comments in the profile yaml files about what exact device is matching each sysoid are useful. These look like

```
sysobjectid:
  - 1.3.6.1.4.1.9.1.669     #  Cisco ASA 5510
  - 1.3.6.1.4.1.9.1.670     #  Cisco ASA 5520
  - 1.3.6.1.4.1.9.1.671     #  Cisco ASA 5520sc
```

This code grabs these out with a regex and ads it as a tag for each device. For example:

```
  "tags.kt.model": "Catalyst 9400 Series 10 Slot",
```

Questions:
* Do we want these tags on all metrics?
* Does the tag `kt.model` look good? 
