### PR TITLE
k8s example

### DIFF
--- a/deployment/kubernetes/ktranslate-pv.yaml
+++ b/deployment/kubernetes/ktranslate-pv.yaml
@@ -1,0 +1,194 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktranslate-discovery
+spec:
+  selector:
+    matchLabels:
+      app: ktranslate-discovery
+  template:
+    metadata:
+      labels:
+        app: ktranslate-discovery
+    spec:
+      containers:
+      - name: discovery
+        image: docker.io/kentik/ktranslate:v2
+        imagePullPolicy: Always
+        args:
+          - -snmp
+          - /data/snmp.yaml
+          - -log_level=info
+          - -snmp_discovery=true
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        volumeMounts:
+          - name: ktranslate-discovery-claim
+            mountPath: /data
+      volumes:
+        - name: ktranslate-discovery-claim
+          hostPath:
+            path: /mnt/data/
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktranslate
+spec:
+  selector:
+    matchLabels:
+      app: ktranslate
+  template:
+    metadata:
+      labels:
+        app: ktranslate
+    spec:
+      containers:
+      - name: ktranslate
+        image: docker.io/kentik/ktranslate:v2
+        imagePullPolicy: Always
+        args:
+          - --listen=0.0.0.0:8082
+          - --metalisten=0.0.0.0:8083
+          - --snmp=/data/snmp.yaml
+          - --log_level=info
+          - --nf.source=sflow
+          - --nf.addr=0.0.0.0
+          - --nf.port=6343
+          - --sinks=prometheus
+          - --format=prometheus
+          - --prom_listen=:8084
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - name: firehose
+          containerPort: 8082
+        - name: metadata
+          containerPort: 8083
+        - name: prometheus
+          containerPort: 8084
+        - name: sflow
+          containerPort: 6343
+          protocol: UDP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metadata
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metadata
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: ktranslate-discovery-claim
+            mountPath: /data
+      volumes:
+        - name: ktranslate-discovery-claim
+          hostPath:
+            path: /mnt/data/
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-firehose
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8082
+    name: firehose
+    targetPort: 8082
+    protocol: TCP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-metadata
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8083
+    name: metadata
+    targetPort: 8083
+    protocol: TCP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-prom
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8084
+    name: prom
+    targetPort: 8084
+    protocol: TCP
+  selector:
+    app: ktranslate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-sflow
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 6343
+    name: sflow
+    targetPort: 6343
+    protocol: UDP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ktranslate-discovery-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ktranslate-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/deployment/kubernetes/ktranslate.yaml
+++ b/deployment/kubernetes/ktranslate.yaml
@@ -1,0 +1,151 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ktranslate
+spec:
+  selector:
+    matchLabels:
+      app: ktranslate
+  template:
+    metadata:
+      labels:
+        app: ktranslate
+    spec:
+      containers:
+      - name: ktranslate
+        image: docker.io/kentik/ktranslate:v2
+        imagePullPolicy: Always
+        args:
+          - --listen=0.0.0.0:8082
+          - --metalisten=0.0.0.0:8083
+          - --snmp=/etc/ktranslate/snmp.yml
+          - --log_level=info
+          - --nf.source=sflow
+          - --nf.addr=0.0.0.0
+          - --nf.port=6343
+          - --sinks=prometheus
+          - --format=prometheus
+          - --prom_listen=:8084
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - name: firehose
+          containerPort: 8082
+        - name: metadata
+          containerPort: 8083
+        - name: prometheus
+          containerPort: 8084
+        - name: sflow
+          containerPort: 6343
+          protocol: UDP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metadata
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metadata
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: ktranslate-config
+            mountPath: /etc/ktranslate/snmp.yml
+            subPath: snmp.yml
+      volumes:
+        - name: ktranslate-config
+          configMap:
+            name: ktranslate-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-firehose
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8082
+    name: firehose
+    targetPort: 8082
+    protocol: TCP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-metadata
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8083
+    name: metadata
+    targetPort: 8083
+    protocol: TCP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-prom
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 8084
+    name: prom
+    targetPort: 8084
+    protocol: TCP
+  selector:
+    app: ktranslate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ktranslate-sflow
+  labels:
+    app: ktranslate
+spec:
+  ports:
+  - port: 6343
+    name: sflow
+    targetPort: 6343
+    protocol: UDP
+  selector:
+    app: ktranslate
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ktranslate-config
+data:
+  snmp.yml: |
+    devices:
+      switch:
+        device_name: switch
+        device_ip: 10.10.0.10
+        flow_only: true
+        user_tags: {}
+    global:
+      poll_time_sec: 30
+      drop_if_outside_poll: false
+      mib_profile_dir: /etc/ktranslate/profiles
+      mibs_db: /etc/ktranslate/mibs.db
+      mibs_enabled:
+      - IF-MIB
+      timeout_ms: 3000
+      retries: 0


### PR DESCRIPTION
An example deployment config to help get started deploying ktranslate in a kubernetes environment.  With the above, this is an example of the prometheus endpoint:

```# TYPE flow_process_sf_samples_sum counter
flow_process_sf_samples_sum{agent="192.168.39.196",router="10.244.0.1",type="CounterSample",version="5"} 1
# HELP flow_summary_decoding_time_us Decoding time summary.
# TYPE flow_summary_decoding_time_us summary
flow_summary_decoding_time_us{name="sFlow",quantile="0.5"} 127.541
flow_summary_decoding_time_us{name="sFlow",quantile="0.9"} 127.541
flow_summary_decoding_time_us{name="sFlow",quantile="0.99"} 127.541
flow_summary_decoding_time_us_sum{name="sFlow"} 127.541
flow_summary_decoding_time_us_count{name="sFlow"} 1
# HELP flow_summary_processing_time_us Processing time summary.
# TYPE flow_summary_processing_time_us summary
flow_summary_processing_time_us{name="sFlow",quantile="0.5"} 259.782
flow_summary_processing_time_us{name="sFlow",quantile="0.9"} 259.782
flow_summary_processing_time_us{name="sFlow",quantile="0.99"} 259.782
flow_summary_processing_time_us_sum{name="sFlow"} 259.782
flow_summary_processing_time_us_count{name="sFlow"} 1
# HELP flow_traffic_bytes Bytes received by the application.
# TYPE flow_traffic_bytes counter
flow_traffic_bytes{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow"} 768
# HELP flow_traffic_packets Packets received by the application.
# TYPE flow_traffic_packets counter
flow_traffic_packets{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow"} 1
# HELP flow_traffic_summary_size_bytes Summary of packet size.
# TYPE flow_traffic_summary_size_bytes summary
flow_traffic_summary_size_bytes{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow",quantile="0.5"} 768
flow_traffic_summary_size_bytes{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow",quantile="0.9"} 768
flow_traffic_summary_size_bytes{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow",quantile="0.99"} 768
flow_traffic_summary_size_bytes_sum{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow"} 768
flow_traffic_summary_size_bytes_count{local_ip="0.0.0.0",local_port="6343",remote_ip="10.244.0.1",type="sFlow"} 1
```