### PR TITLE
Basic conversion to handle string valued metrics: #252

### DIFF
--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -26,6 +26,7 @@ const (
 	CONV_HEXTOIP   = "hextoip"
 	CONV_ENGINE_ID = "engine_id"
 	CONV_REGEXP    = "regexp"
+	CONV_ONE       = "to_one"
 )
 
 var (
@@ -250,6 +251,8 @@ func GetFromConv(pdu gosnmp.SnmpPDU, conv string, log logger.ContextL) (int64, s
 		return hexToIP(bv)
 	case CONV_ENGINE_ID:
 		return engineID(bv)
+	case CONV_ONE:
+		return toOne(bv)
 	default:
 		// Otherwise, try out some custom conversions.
 		split := strings.Split(conv, ":")
@@ -359,4 +362,9 @@ func fromRegexp(bv []byte, reg string) (int64, string) {
 		return 0, string(res[1])
 	}
 	return int64(ival), string(res[1]) // Parsed as int but return both just in case.
+}
+
+// This one is used for certain string valued oids which we want to poll as metrics. Just converts to 1.
+func toOne(bv []byte) (int64, string) {
+	return 1, string(bv)
 }

--- a/pkg/inputs/snmp/util/util_test.go
+++ b/pkg/inputs/snmp/util/util_test.go
@@ -191,3 +191,19 @@ func TestRegex(t *testing.T) {
 		assert.Equal(expt, ival, "%s", in)
 	}
 }
+
+func TestToOne(t *testing.T) {
+	assert := assert.New(t)
+	l := lt.NewTestContextL(logger.NilContext, t)
+
+	tests := map[string]int64{
+		"lalalalaal": 1,
+		"foofoffofo": 1,
+	}
+
+	for in, expt := range tests {
+		pdu := gosnmp.SnmpPDU{Value: []byte(in)}
+		ival, _ := GetFromConv(pdu, CONV_ONE, l)
+		assert.Equal(expt, ival, "%s", in)
+	}
+}


### PR DESCRIPTION
Is this too basic to handle this case? What I've done is added a conversion called `to_one`. For any metric, this will convert the metric to a gaudge with a value of 1. The string value will also be captured as an attribute. It will get polled every $TICK instead of every 3 hours. For example, consider a metric with 

```
      - symbols:
          OID: 1.0.8802.1.1.2.1.4.1.1.7
          name: lldpRemPortId
          conversion: to_one 
```

This will turn into a metric `snmp.lldpRemPortId` which will always equal one. It will also have an attribute called `lldpRemPortId` with the last polled value. 

Thoughts? 
