### PR TITLE
Do not perminantly cache device metadata

### DIFF
--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -34,7 +34,7 @@ var (
 	}()
 )
 
-// Poll device-level metadata, which we only need once(?).  Works for (at least) Juniper, Cisco, and Arista.
+// Poll device-level metadata.
 func GetDeviceMetadata(log logger.ContextL, server *gosnmp.GoSNMP, deviceMetadataMibs map[string]*kt.Mib) (*kt.DeviceMetricsMetadata, error) {
 	md := kt.DeviceMetricsMetadata{
 		Customs:    map[string]string{},


### PR DESCRIPTION
This addresses #272. Currently, device level metadata is polled once at start and then never again. 
This is a legacy behavior from when we only looked at SysOID and things like this, but doesn't seem optimal now. Patch just removes the cache part so that device metadata is polled every time interface metadata is polled. 

Separately, it looks like we're using https://github.com/kentik/ktranslate/blob/main/pkg/inputs/snmp/metadata/poll.go#L35, which is

```
	DEFAULT_INTERVAL = 30 * 60 * time.Second // Run every 30 min.
```

I really thought this was polled every 3 hours but looks like its actually every 30. What do you think? Keep at 30 or move around? Also we can change so that device metadata is polled every 3hrs, but interface 30. Thoughts? 

