### PR TITLE
Guard for when uptime is not available, fall back to tick duration.

### DIFF
--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -65,7 +65,7 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		log:              log,
 		metrics:          metrics,
 		server:           server,
-		interfaceMetrics: NewInterfaceMetrics(gconf, conf, metrics, interfaceMetricMibs, profile, log),
+		interfaceMetrics: NewInterfaceMetrics(gconf, conf, metrics, interfaceMetricMibs, profile, counterTimeSec, log),
 		deviceMetrics:    NewDeviceMetrics(gconf, conf, metrics, deviceMetricMibs, profile, log),
 		counterTimeSec:   counterTimeSec,
 		dropIfOutside:    dropIfOutside,


### PR DESCRIPTION
To get the interval for counts, we rely on the uptime value:

```					
Interval:   in.CustomBigInt["Uptime"] * 10, // Values are in 100's of a second, so multiply by 10 to get milliseconds.
``` 

But if for whatever reason this is 0, then this will not be set and so break metrics which depend on knowing the interval. This code uses the tick value as a best guess for interval when Uptime is not present. 