### PR TITLE
Fixing inputq_len metric; also default local dns resolver on

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -172,10 +172,12 @@ func setMode(bs *baseserver.BaseServer, mode string, sample int, syslog string) 
 		setNr() // Here, we only send the flow in as events to NR.
 		flag.Set("vpc", "aws")
 		flag.Set("aws_lambda", "true")
+		flag.Set("dns", "local")
 	case "vpc":
 		flag.Set("rollups", "s_sum,vpc.xmt.bytes,out_bytes,custom_str.source_vpc,custom_str.application_type,custom_str.source_account,custom_str.source_region,src_addr,custom_str.src_as_name,src_geo,l4_src_port,protocol")
 		flag.Set("rollups", "s_sum,vpc.rcv.bytes,in_bytes,custom_str.dest_vpc,custom_str.application_type,custom_str.dest_account,custom_str.dest_region,dst_addr,custom_str.dst_as_name,dst_geo,l4_dst_port,protocol")
 	case "nr1.vpc":
+		flag.Set("dns", "local")
 		setNr()
 	case "flow":
 		flag.Set("rollups", "s_sum,bytes.xmt,in_bytes+out_bytes,device_name,src_addr,custom_str.src_as_name,src_geo,l4_src_port,protocol")

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -63,7 +63,7 @@ func NewKTranslate(config *Config, log logger.ContextL, registry go_metrics.Regi
 			AlphaQDrop:   go_metrics.GetOrRegisterMeter("alphaq_drop", registry),
 			JCHFQ:        go_metrics.GetOrRegisterGauge("jchfq", registry),
 			InputQ:       go_metrics.GetOrRegisterMeter("inputq", registry),
-			InputQLen:    go_metrics.GetOrRegisterMeter("inputq_len", registry),
+			InputQLen:    go_metrics.GetOrRegisterGauge("inputq_len^force=true", registry),
 		},
 		alphaChans: make([]chan *Flow, config.Threads),
 		jchfChans:  make([]chan *kt.JCHF, config.Threads),
@@ -252,7 +252,7 @@ func (kc *KTranslate) HttpInfo(w http.ResponseWriter, r *http.Request) {
 		JCHFQ:          kc.metrics.JCHFQ.Value(),
 		AlphaQDrop:     kc.metrics.AlphaQDrop.Rate1(),
 		InputQ:         kc.metrics.InputQ.Rate1(),
-		InputQLen:      kc.metrics.InputQLen.Rate1(),
+		InputQLen:      kc.metrics.InputQLen.Value(),
 		Sinks:          map[ss.Sink]map[string]float64{},
 		SnmpDeviceData: map[string]map[string]float64{},
 		Inputs:         map[string]map[string]float64{},
@@ -450,7 +450,7 @@ func (kc *KTranslate) watchInput(ctx context.Context, seri func([]*kt.JCHF, []by
 					kc.config.ThreadsInput++
 				}
 			}
-			kc.metrics.InputQLen.Mark(int64(len(kc.inputChan)))
+			kc.metrics.InputQLen.Update(int64(len(kc.inputChan)))
 		case <-ctx.Done():
 			kc.log.Infof("watchInput Done")
 			return

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -135,7 +135,7 @@ type hc struct {
 	JCHFQ          int64
 	AlphaQDrop     float64
 	InputQ         float64
-	InputQLen      float64
+	InputQLen      int64
 	Sinks          map[sinks.Sink]map[string]float64
 	SnmpDeviceData map[string]map[string]float64
 	Inputs         map[string]map[string]float64
@@ -155,6 +155,6 @@ type KKCMetric struct {
 	JCHFQ          go_metrics.Gauge
 	AlphaQDrop     go_metrics.Meter
 	InputQ         go_metrics.Meter
-	InputQLen      go_metrics.Meter
+	InputQLen      go_metrics.Gauge
 	SnmpDeviceData *kt.SnmpMetricSet
 }


### PR DESCRIPTION
Fixes the metric `kentik.ktranslate.chf.kkc.inputq_len` to make it a gauge. This metric tracks backlog of inputs into the format layer of ktranslate. Should be always 0 for normal operations. 

Also, adds in #277, defaults to on the dns resolver for VPC flows. New option for this one is `--dns=local` which will use the local resolver instead of having to specify a specific IP. Should work well in a cloud environment. 