### PR TITLE
Alert if non utf8 chars are found in the output of the new relic format

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -579,7 +579,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 func (f *NRMFormat) handleInvalid(in []*kt.JCHF, output []byte) (*kt.Output, error) {
 	msg := "Invalid utf8 char found in new relic output."
 	if len(in) > 0 {
-		msg = in[0].DeviceName + ": " + msg
+		msg = fmt.Sprintf("device=%s provider=%s: %s", in[0].DeviceName, in[0].Provider, msg)
 	}
 
 	if !f.seenInvalid {

--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"net"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/elliotchance/orderedmap"
 
@@ -201,7 +202,9 @@ func getTable(log logger.ContextL, g *gosnmp.GoSNMP, oid string, mib *kt.Mib, md
 			if mib.Conversion != "" { // Adjust for any hard coded values here.
 				_, value = snmp_util.GetFromConv(variable, mib.Conversion, log)
 			}
-			md.Tables[idx].Customs[oidName] = kt.NewMetaValue(mib, value, 0)
+			if utf8.ValidString(value) {
+				md.Tables[idx].Customs[oidName] = kt.NewMetaValue(mib, value, 0)
+			}
 		case gosnmp.IPAddress: // Does this work?
 			switch val := variable.Value.(type) {
 			case string:
@@ -216,7 +219,9 @@ func getTable(log logger.ContextL, g *gosnmp.GoSNMP, oid string, mib *kt.Mib, md
 			if mib.Conversion != "" { // Adjust for any hard coded values here.
 				_, value = snmp_util.GetFromConv(variable, mib.Conversion, log)
 			}
-			md.Tables[idx].Customs[oidName] = kt.NewMetaValue(mib, value, 0)
+			if utf8.ValidString(value) {
+				md.Tables[idx].Customs[oidName] = kt.NewMetaValue(mib, value, 0)
+			}
 		default:
 			// Try to just use as a number
 			md.Tables[idx].Customs[oidName] = kt.NewMetaValue(mib, "", gosnmp.ToBigInt(variable.Value).Int64())

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -202,7 +203,9 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 			dst.DeviceName = dd.DeviceMetricsMetadata.SysName
 		}
 		for k, v := range dd.DeviceMetricsMetadata.Customs {
-			dst.CustomStr[k] = v
+			if utf8.ValidString(v) {
+				dst.CustomStr[k] = v
+			}
 		}
 		for k, v := range dd.DeviceMetricsMetadata.CustomInts {
 			dst.CustomInt[k] = int32(v)
@@ -260,9 +263,11 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 
 		// And in anything extra which came out here.
 		for k, v := range id.ExtraInfo {
-			dst.CustomStr["if."+intr+"."+k] = v
-			if mib, ok := p.lookupMib(k, true); ok {
-				dst.CustomMetrics["if_"+k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table, Tables: mib.OtherTables}
+			if utf8.ValidString(v) {
+				dst.CustomStr["if."+intr+"."+k] = v
+				if mib, ok := p.lookupMib(k, true); ok {
+					dst.CustomMetrics["if_"+k] = kt.MetricInfo{Oid: mib.Oid, Mib: mib.Mib, Table: mib.Table, Tables: mib.OtherTables}
+				}
 			}
 		}
 	}

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -179,6 +179,12 @@ func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 					device.NoUseBulkWalkAll = true
 					cl.Infof("Turning off BulkWalkAll for device via profile.")
 				}
+
+				// Use the profile's provider if it is set.
+				if profile.Provider != "" {
+					device.Provider = profile.Provider
+					cl.Infof("Setting profile of %s for device %s.", device.Provider, device.DeviceName)
+				}
 			}
 		}
 


### PR DESCRIPTION
We're seeing reports where non utf8 chars can come in via snmp which when passed on to NR will trigger an `invalid json` error at the parse phase of NR (but after the web server returns 200 annoyingly enough).

This adds a basic check and will error out any payloads which contain non-uft8 chars before they get sent on. On the first error, the full payload will be sent to logging, but subsequently just the device name and provider.

For example:

```
[Error] KTranslate There was an error when converting to native: device=bart provider=kentik-net-snmp: Invalid utf8 char found in new relic output. ([{"metrics":[{"name":"kentik.snmp.ifHCOutUcastPkts","type":"count","value":0,"interval.ms":14420,"attributes":{"provider":"kentik-net-snmp","if_interface_name":"igb3","if_Netmask":"255.255.255.255","if_PhysAddress":"\u0000g#\u0019","if_Index":"4","instrumentation.name":"net-snmp" ...
``` 

And then:

```
2022-02-24T16:07:10.771 ktranslate(88802) [Error] KTranslate There was an error when converting to native: device=mabel provider=kentik-net-snmp: Invalid utf8 char found in new relic output..
```

Hopefully this should make troubleshooting these easier. Thoughts? 
