### PR TITLE
S3, Http config; looping polling for SNMP

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -625,7 +625,8 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If SNMP is configured, start this system too. Poll for metrics and metadata, also handle traps.
 	if kc.config.SNMPFile != "" {
 		if kc.config.SNMPDisco { // Here, we're just returning the list of devices on the network which might speak snmp.
-			return snmp.Discover(ctx, kc.config.SNMPFile, kc.log)
+			err, _, _, _ := snmp.Discover(ctx, kc.config.SNMPFile, kc.log)
+			return err
 		}
 		assureInput()
 		kc.metrics.SnmpDeviceData = kt.NewSnmpMetricSet(kc.registry)

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -625,7 +625,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If SNMP is configured, start this system too. Poll for metrics and metadata, also handle traps.
 	if kc.config.SNMPFile != "" {
 		if kc.config.SNMPDisco { // Here, we're just returning the list of devices on the network which might speak snmp.
-			err, _, _, _ := snmp.Discover(ctx, kc.config.SNMPFile, kc.log)
+			_, err := snmp.Discover(ctx, kc.config.SNMPFile, kc.log)
 			return err
 		}
 		assureInput()

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -275,7 +275,7 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 			added++
 		} else if conf.Devices[key] != nil {
 			if conf.Disco.ReplaceDevices { // But keep backwards compatible with existing devices and don't change their entries.
-				d.UpdateFrom(conf.Devices[key])
+				d.UpdateFrom(conf.Devices[key], conf)
 				conf.Devices[key] = d
 				replaced++
 			} else {
@@ -283,7 +283,7 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 			}
 		} else {
 			if conf.Disco.ReplaceDevices { // Else, new style keys all use keyAlt.
-				d.UpdateFrom(conf.Devices[keyAlt])
+				d.UpdateFrom(conf.Devices[keyAlt], conf)
 				conf.Devices[keyAlt] = d
 				replaced++
 			} else {

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -125,8 +125,8 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (error,
 	return nil, added, replaced, deviceDelta
 }
 
-func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, snmpFile string, log logger.ContextL, pollTimeSec int) {
-	pt := time.Duration(pollTimeSec) * time.Second
+func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, snmpFile string, log logger.ContextL, pollTimeMin int) {
+	pt := time.Duration(pollTimeMin) * time.Minute
 	log.Infof("Running SNMP Discovery Loop every %v", pt)
 	discoCheck := time.NewTicker(pt)
 	defer discoCheck.Stop()

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -33,7 +33,7 @@ var (
 	snmpWalkFormat = flag.String("snmp_walk_format", "", "use this format for walked values if -snmp_do_walk is set.")
 	snmpOutFile    = flag.String("snmp_out_file", "", "If set, write updated snmp file here.")
 	snmpPollNow    = flag.String("snmp_poll_now", "", "If set, run one snmp poll for the specified device and then exit.")
-	snmpDiscoDur   = flag.Int("snmp_discovery_sec", 0, "If set, run snmp discovery on this interval (in seconds).")
+	snmpDiscoDur   = flag.Int("snmp_discovery_min", 0, "If set, run snmp discovery on this interval (in minutes).")
 	ServiceName    = ""
 )
 

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -90,7 +90,7 @@ func Close() {
 func initSnmp(ctx context.Context, snmpFile string, log logger.ContextL) (*kt.SnmpConfig, time.Duration, int, error) {
 	// First, parse the config file and see what we're doing.
 	log.Infof("Client SNMP: Running SNMP interface polling, loading config from %s", snmpFile)
-	conf, err := parseConfig(snmpFile, log)
+	conf, err := parseConfig(ctx, snmpFile, log)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -266,9 +266,9 @@ func launchSnmp(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpD
 	return nil
 }
 
-func parseConfig(file string, log logger.ContextL) (*kt.SnmpConfig, error) {
+func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.SnmpConfig, error) {
 	ms := kt.SnmpConfig{}
-	by, err := ioutil.ReadFile(file)
+	by, err := snmp_util.LoadFile(ctx, file)
 	if err != nil {
 		return nil, err
 	}
@@ -379,5 +379,5 @@ func launchPingOnly(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.S
 
 // Public wrapper for calling this other places.
 func ParseConfig(file string, log logger.ContextL) (*kt.SnmpConfig, error) {
-	return parseConfig(file, log)
+	return parseConfig(context.Background(), file, log)
 }

--- a/pkg/inputs/snmp/util/file.go
+++ b/pkg/inputs/snmp/util/file.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// Utility to load a config file from various places
+func LoadFile(ctx context.Context, file string) ([]byte, error) {
+	u, err := url.Parse(file)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "http", "https":
+		return loadFromHttp(ctx, file)
+	case "s3":
+		return loadFromS3(ctx, u)
+	default:
+		return ioutil.ReadFile(file)
+	}
+}
+
+// Utility to write a config file to various places
+func WriteFile(ctx context.Context, file string, payload []byte, perms fs.FileMode) error {
+	u, err := url.Parse(file)
+	if err != nil {
+		return err
+	}
+
+	switch u.Scheme {
+	case "http", "https":
+		return fmt.Errorf("Not supported scheme: %s", u.Scheme)
+	case "s3":
+		return writeToS3(ctx, u, payload)
+	default:
+		return ioutil.WriteFile(file, payload, perms)
+	}
+}
+
+func loadFromHttp(ctx context.Context, file string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, file, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func loadFromS3(ctx context.Context, url *url.URL) ([]byte, error) {
+	sess := session.Must(session.NewSession())
+	client := s3manager.NewDownloader(sess)
+	buf := aws.NewWriteAtBuffer([]byte{})
+	size, err := client.DownloadWithContext(ctx, buf, &s3.GetObjectInput{
+		Bucket: aws.String(url.Host),
+		Key:    aws.String(url.Path),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	bufr := buf.Bytes()
+	return bufr[0:size], nil
+}
+
+func writeToS3(ctx context.Context, url *url.URL, payload []byte) error {
+	sess := session.Must(session.NewSession())
+	client := s3manager.NewUploader(sess)
+	_, err := client.UploadWithContext(ctx, &s3manager.UploadInput{
+		Bucket: aws.String(url.Host),
+		Body:   bytes.NewBuffer(payload),
+		Key:    aws.String(url.Path),
+	})
+	return err
+}

--- a/pkg/inputs/snmp/util/file_test.go
+++ b/pkg/inputs/snmp/util/file_test.go
@@ -26,6 +26,7 @@ func TestLoadFile(t *testing.T) {
 		":foo":               nil,
 		svr.URL:              content,
 		"s3://foo/bar/a/one": nil,
+		"S3://foo/bar/a/two": nil,
 	}
 
 	// Save test data to local.
@@ -47,6 +48,35 @@ func TestLoadFile(t *testing.T) {
 		} else {
 			assert.NoError(err)
 			assert.Equal(string(expt), string(res), "failed %s", in)
+		}
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	assert := assert.New(t)
+	content := []byte("aaaa") // Set some test content.
+
+	// Save test data to local.
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.FailNow()
+	}
+
+	defer os.Remove(file.Name())
+	tests := map[string]bool{
+		":foo":      false,
+		file.Name(): true,
+	}
+
+	ctx := context.Background()
+	for target, good := range tests {
+		err := WriteFile(ctx, target, content, 0644)
+		if !good {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+			c, _ := ioutil.ReadFile(target) // This one assumes that we're writting locally.
+			assert.Equal(string(content), string(c), "failed %s", target)
 		}
 	}
 }

--- a/pkg/inputs/snmp/util/file_test.go
+++ b/pkg/inputs/snmp/util/file_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadFile(t *testing.T) {
+	assert := assert.New(t)
+	content := []byte("aaaa") // Set some test content.
+
+	// Some test server
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, string(content))
+	}))
+	defer svr.Close()
+
+	tests := map[string][]byte{
+		":foo":               nil,
+		svr.URL:              content,
+		"s3://foo/bar/a/one": nil,
+	}
+
+	// Save test data to local.
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.FailNow()
+	}
+	if _, err := file.Write(content); err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+	tests[file.Name()] = content
+
+	ctx := context.Background()
+	for in, expt := range tests {
+		res, err := LoadFile(ctx, in)
+		if expt == nil {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+			assert.Equal(string(expt), string(res), "failed %s", in)
+		}
+	}
+}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -478,13 +478,60 @@ func (a *V3SNMPConfig) InheritGlobal() bool {
 }
 
 // Save any hard coded parts of this profile which might get overriten by an automatic process.
-func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig) {
+func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig, conf *SnmpConfig) {
 	if old == nil {
 		return
 	}
 
 	if strings.HasPrefix(old.MibProfile, "!") {
 		d.MibProfile = old.MibProfile
+	}
+	if old.SampleRate > 0 {
+		d.SampleRate = old.SampleRate
+	}
+	if old.FlowOnly {
+		d.FlowOnly = old.FlowOnly
+	}
+	if old.PingOnly {
+		d.PingOnly = old.PingOnly
+	}
+	if old.PollTimeSec > 0 {
+		d.PollTimeSec = old.PollTimeSec
+	}
+	if old.TimeoutMS > 0 {
+		d.TimeoutMS = old.TimeoutMS
+	}
+	if old.Retries > 0 {
+		d.Retries = old.Retries
+	}
+	if old.MonitorAdminShut {
+		d.MonitorAdminShut = old.MonitorAdminShut
+	}
+	if old.NoUseBulkWalkAll {
+		d.NoUseBulkWalkAll = old.NoUseBulkWalkAll
+	}
+	if old.RunPing {
+		d.RunPing = old.RunPing
+	}
+	if d.UserTags == nil && old.UserTags != nil {
+		d.UserTags = map[string]string{}
+	}
+	for k, v := range old.UserTags {
+		if _, ok := d.UserTags[k]; !ok {
+			if _, ok := conf.Global.UserTags[k]; !ok {
+				d.UserTags[k] = v
+			}
+		}
+	}
+	if d.MatchAttr == nil && old.MatchAttr != nil {
+		d.MatchAttr = map[string]string{}
+	}
+	for k, v := range old.MatchAttr {
+		if _, ok := d.MatchAttr[k]; !ok {
+			if _, ok := conf.Global.MatchAttr[k]; !ok {
+				d.MatchAttr[k] = v
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Allow snmp config files to be prefixed s3:// or http(s):// in addition to a local path. If a remote path, fetch the resource from the remote place. 

Also, adds a flag `--snmp_discovery_min` which will run discovery every X minutes and restart the snmp polling system if a new device is found. 