### PR TITLE
Trying extra hard to have device_name always set for syslog

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/sinks/kentik"
 	"github.com/kentik/ktranslate/pkg/util/enrich"
 	"github.com/kentik/ktranslate/pkg/util/gopatricia/patricia"
+	"github.com/kentik/ktranslate/pkg/util/resolv"
 	"github.com/kentik/ktranslate/pkg/util/rule"
 
 	"github.com/judwhite/go-svc"
@@ -557,7 +558,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 
 	// DNS mapper if set.
 	if kc.config.DnsResolver != "" {
-		res, err := NewResolver(ctx, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.DnsResolver)
+		res, err := resolv.NewResolver(ctx, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.DnsResolver)
 		if err != nil {
 			return err
 		}
@@ -664,7 +665,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If we're looking for syslog flows coming in
 	if kc.config.SyslogSource != "" {
 		assureInput()
-		ss, err := syslog.NewSyslogSource(ctx, kc.config.SyslogSource, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.LogTee, kc.registry, kc.apic)
+		ss, err := syslog.NewSyslogSource(ctx, kc.config.SyslogSource, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.LogTee, kc.registry, kc.apic, kc.resolver)
 		if err != nil {
 			return err
 		}

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/sinks/kentik"
 	"github.com/kentik/ktranslate/pkg/util/enrich"
 	"github.com/kentik/ktranslate/pkg/util/gopatricia/patricia"
+	"github.com/kentik/ktranslate/pkg/util/resolv"
 	"github.com/kentik/ktranslate/pkg/util/rule"
 
 	model "github.com/kentik/ktranslate/pkg/util/kflow2"
@@ -98,7 +99,7 @@ type KTranslate struct {
 	filters      []filter.Filter
 	geo          *patricia.MMMap
 	asn          *patricia.MMMap
-	resolver     *Resolver
+	resolver     *resolv.Resolver
 	auth         *auth.Server
 	apic         *api.KentikApi
 	tooBig       chan int

--- a/pkg/util/resolv/resolver.go
+++ b/pkg/util/resolv/resolver.go
@@ -1,4 +1,4 @@
-package cat
+package resolv
 
 import (
 	"context"


### PR DESCRIPTION
I think this should address #284 

Works extra hard to make sure that `device_name` is filled in and set. Note -- works best if the `-dns=local` flag is set. Worth it to always set this for syslog listeners? 