### PR TITLE
Not sending in Ping PacketLoss if the value is NaN: #288

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -393,11 +393,11 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 	if conf.Disco.IgnoreOrig != "" {
 		t, err := yaml.Marshal(conf.Disco.IgnoreList)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = ioutil.WriteFile(conf.Disco.IgnoreOrig, t, permissions)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !isTest {
 			conf.Disco.IgnoreList = nil

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -355,8 +355,10 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["StdDevRtt"] = stats.StdDevRtt.Microseconds()
 	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
-	dst.CustomBigInt["PacketLossPct"] = int64(stats.PacketLoss * 1000.)
-	dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	if stats.PacketLoss >= 0.0 {
+		dst.CustomBigInt["PacketLossPct"] = int64(stats.PacketLoss * 1000.)
+		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	}
 	dm.conf.SetUserTags(dst.CustomStr)
 
 	return []*kt.JCHF{dst}, nil

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -26,6 +26,7 @@ type OID struct {
 	PollTime   int              `yaml:"poll_time_sec,omitempty"`
 	MatchAttr  []string         `yaml:"match_attributes,omitempty"`
 	Format     string           `yaml:"format,omitempty"`
+	AllowDup   bool             `yaml:"allow_duplicate,omitempty"`
 }
 
 type Tag struct {
@@ -385,6 +386,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				Table:        metric.Table.GetTableName(),
 				FromExtended: metric.fromExtended,
 				Format:       metric.Symbol.Format,
+				AllowDup:     metric.Symbol.AllowDup,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -426,6 +428,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				Table:        metric.Table.GetTableName(),
 				FromExtended: metric.fromExtended,
 				Format:       s.Format,
+				AllowDup:     s.AllowDup,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -492,6 +495,7 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 				Tag:        tag.Tag,
 				Conversion: tag.Column.Conversion,
 				Enum:       tag.Column.Enum,
+				AllowDup:   tag.Column.AllowDup,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -537,6 +541,7 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 					Mib:        metric.Mib,
 					Table:      metric.Table.GetTableName(),
 					Enum:       t.Column.Enum,
+					AllowDup:   t.Column.AllowDup,
 				}
 				if len(mib.Enum) > 0 {
 					mib.EnumRev = make(map[int64]string)
@@ -777,7 +782,7 @@ func prune(mibs map[string]*kt.Mib, counterTimeSec int, minCounterTime int) {
 
 	// Lastly, delete if we're not keeping.
 	for oid, mib := range mibs {
-		if !keepNames[oid] {
+		if !keepNames[oid] && !mib.AllowDup {
 			delete(mibs, oid)
 		}
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -294,6 +294,7 @@ type Mib struct {
 	FromExtended bool
 	OtherTables  map[string]bool
 	Format       string
+	AllowDup     bool
 }
 
 func (mb *Mib) String() string {


### PR DESCRIPTION
Fixing #288 

UDP ping can fail. In this case, you get NaN for PacketLoss. This PR will not set a value if ping is not working. 

Q-- should there be a metric or other way to indicate that ping is broken in this case? 
