### PR TITLE
Allow an ignore list for certain IPs to not be discovered on #287

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -359,7 +359,9 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 		if err != nil {
 			return err
 		}
-		conf.Disco.IgnoreList = nil
+		if !isTest {
+			conf.Disco.IgnoreList = nil
+		}
 	}
 
 	if conf.DeviceOrig != "" {
@@ -383,6 +385,9 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 	// Swap for our external sections.
 	if conf.Disco.CidrOrig != "" {
 		t = bytes.Replace(t, []byte("cidrs: []"), []byte(`cidrs: "@`+conf.Disco.CidrOrig+`"`), 1)
+	}
+	if conf.Disco.IgnoreOrig != "" {
+		t = bytes.Replace(t, []byte("ignore_list: []"), []byte(`ignore_list: "@`+conf.Disco.IgnoreOrig+`"`), 1)
 	}
 	if conf.DeviceOrig != "" {
 		t = bytes.Replace(t, []byte("devices: {}"), []byte(`devices: "@`+conf.DeviceOrig+`"`), 1)

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -69,6 +69,11 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) error {
 	}
 	defer mdb.Close()
 
+	ignoreMap := map[string]bool{}
+	for _, ip := range conf.Disco.IgnoreList {
+		ignoreMap[ip] = true
+	}
+
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
 	for _, ipr := range conf.Disco.Cidrs {
 		_, _, err := net.ParseCIDR(ipr)
@@ -102,6 +107,9 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) error {
 		log.Infof("Starting to check %d ips in %s", len(results), ipr)
 		for i, result := range results {
 			if strings.HasSuffix(ipr, "/32") || result.IsHostUp() {
+				if ignoreMap[result.Host.String()] { // If we have marked this ip as to be ignored, don't do anything more with it.
+					continue
+				}
 				wg.Add(1)
 				posit := fmt.Sprintf("%d/%d)", i+1, len(results))
 				go doubleCheckHost(result, timeout, ctl, &mux, &wg, foundDevices, mdb, conf, posit, log)

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -350,6 +350,18 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 		conf.Disco.Cidrs = nil
 	}
 
+	if conf.Disco.IgnoreOrig != "" {
+		t, err := yaml.Marshal(conf.Disco.IgnoreList)
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(conf.Disco.IgnoreOrig, t, permissions)
+		if err != nil {
+			return err
+		}
+		conf.Disco.IgnoreList = nil
+	}
+
 	if conf.DeviceOrig != "" {
 		t, err := yaml.Marshal(conf.Devices)
 		if err != nil {

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -292,6 +292,20 @@ func parseConfig(file string, log logger.ContextL) (*kt.SnmpConfig, error) {
 		ms.Disco.Cidrs = cidrList
 	}
 
+	if ms.Disco != nil && len(ms.Disco.IgnoreList) > 0 && strings.HasPrefix(ms.Disco.IgnoreList[0], "@") {
+		ignoreList := []string{}
+		byc, err := ioutil.ReadFile(ms.Disco.IgnoreList[0][1:])
+		if err != nil {
+			return nil, err
+		}
+		err = yaml.Unmarshal(byc, &ignoreList)
+		if err != nil {
+			return nil, err
+		}
+		ms.Disco.IgnoreOrig = ms.Disco.IgnoreList[0][1:]
+		ms.Disco.IgnoreList = ignoreList
+	}
+
 	fullDevices := map[string]*kt.SnmpDeviceConfig{}
 	for name, devFile := range ms.Devices {
 		if strings.HasPrefix(name, "file_") && strings.HasPrefix(devFile.DeviceName, "@") {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -173,6 +173,7 @@ type SnmpTrapConfig struct {
 
 type SnmpDiscoConfig struct {
 	Cidrs              StringArray     `yaml:"cidrs"`
+	IgnoreList         []string        `yaml:"ignore_list,omitempty"`
 	Debug              bool            `yaml:"debug"`
 	Ports              []int           `yaml:"ports"`
 	DefaultCommunities []string        `yaml:"default_communities"`

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -173,7 +173,7 @@ type SnmpTrapConfig struct {
 
 type SnmpDiscoConfig struct {
 	Cidrs              StringArray     `yaml:"cidrs"`
-	IgnoreList         StringArray     `yaml:"ignore_list,omitempty"`
+	IgnoreList         StringArray     `yaml:"ignore_list"`
 	Debug              bool            `yaml:"debug"`
 	Ports              []int           `yaml:"ports"`
 	DefaultCommunities []string        `yaml:"default_communities"`

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -173,7 +173,7 @@ type SnmpTrapConfig struct {
 
 type SnmpDiscoConfig struct {
 	Cidrs              StringArray     `yaml:"cidrs"`
-	IgnoreList         []string        `yaml:"ignore_list,omitempty"`
+	IgnoreList         StringArray     `yaml:"ignore_list,omitempty"`
 	Debug              bool            `yaml:"debug"`
 	Ports              []int           `yaml:"ports"`
 	DefaultCommunities []string        `yaml:"default_communities"`
@@ -186,6 +186,7 @@ type SnmpDiscoConfig struct {
 	ReplaceDevices     bool            `yaml:"replace_devices"`
 	NoDedup            bool            `yaml:"no_dedup_engine_id,omitempty"`
 	CidrOrig           string          `yaml:"-"`
+	IgnoreOrig         string          `yaml:"-"`
 }
 
 type SnmpGlobalConfig struct {


### PR DESCRIPTION
Works for #287  -- Allows a setup like 

```
discovery:
  cidrs:
  - 172.16.1.0/24
  ignore_list:
  - 172.16.1.5
  - 172.16.1.6
  - 172.16.1.7
  - 172.16.1.8
  - 172.16.1.9
  - 172.16.1.10
```

To discover IPs on `172.16.1.0/24` except for those in the `ignore_list`. Note: `ignore_list` does not take cidrs -- only 1 IP per line. 
