### PR TITLE
Fixing bug where external cidrs and devices got broken

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -339,7 +339,9 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 		if err != nil {
 			return err
 		}
-		conf.Disco.Cidrs = nil
+		if !isTest {
+			conf.Disco.Cidrs = nil
+		}
 	}
 
 	if conf.DeviceOrig != "" {
@@ -351,7 +353,9 @@ func addDevices(foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, c
 		if err != nil {
 			return err
 		}
-		conf.Devices = nil
+		if !isTest {
+			conf.Devices = nil
+		}
 	}
 
 	// Save out the config file.


### PR DESCRIPTION
As reported by a customer. When we added the check to see if a snmp file is writeable in disco, we broke the ability to use external cidrs and device lists in disco. 

This fix leverages the isTest bool to not nil out the external values when we're not writing this out for real. 