### PR TITLE
Fixing a crash caused by a missing mib in metadata

### DIFF
--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -309,7 +309,7 @@ func (mb *Mib) GetName() string { // Tag takes precedince over name if it is pre
 }
 
 func (mb *Mib) IsPollReady() bool { // If there's a poll duration, return false if not enough time has elapsed before this next poll.
-	if mb.PollDur == 0 { // If not set, just always return true
+	if mb == nil || mb.PollDur == 0 { // If not set, just always return true
 		return true
 	}
 	now := time.Now()


### PR DESCRIPTION
Most recent release has a bug where if a metadata oid is polled and is missing a mib for it the container will crash:

```
goroutine 75 [running]:
github.com/kentik/ktranslate/pkg/kt.(*Mib).IsPollReady(0xc002271b38)
        /src/pkg/kt/snmp.go:312 +0x18
github.com/kentik/ktranslate/pkg/inputs/snmp/metadata.(*DeviceMetadata).poll(0xc001f664c0, {0x181c300, 0xc00116a000}, 0x0)
```

This ads a nil check on the offending line, causing the system to work as normal.