### PR TITLE
Tweak poll so that timers do not leak on restart.

### DIFF
--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -133,6 +133,7 @@ func (p *Poller) StartLoop(ctx context.Context) {
 
 			case <-ctx.Done():
 				p.log.Infof("Metadata Poll Done")
+				interfaceCheck.Stop()
 				return
 			}
 		}

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -150,6 +150,8 @@ func (p *Poller) StartLoop(ctx context.Context) {
 
 			case <-ctx.Done():
 				p.log.Infof("Metrics Poll Done")
+				statusCheck.Stop()
+				counterCheck.Stop()
 				return
 			}
 		}

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -214,6 +214,7 @@ func (p *Poller) StartPingOnlyLoop(ctx context.Context) {
 
 			case <-ctx.Done():
 				p.log.Infof("Metrics PingOnly Done")
+				counterCheck.Stop()
 				return
 			}
 		}


### PR DESCRIPTION
This may not be needed but cleans up some potentially leaky timers. Usually it doesn't matter if these do not get stopped because the program will exit. But with the ability to re-run snmp discovery they can now get re-created all the time.  