### PR TITLE
Adding a --snmp_validate flag for snmp profiles

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -70,7 +70,7 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (*SnmpD
 	}
 
 	// Use this for auto-discovering metrics to pull.
-	mdb, err := mibs.NewMibDB(conf.Global.MibDB, conf.Global.MibProfileDir, log)
+	mdb, err := mibs.NewMibDB(conf.Global.MibDB, conf.Global.MibProfileDir, false, log)
 	if err != nil {
 		return nil, fmt.Errorf("There was an error when setting up the %s mibDB database and the %s profiles: %v.", conf.Global.MibDB, conf.Global.MibProfileDir, err)
 	}

--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -19,6 +19,7 @@ type MibDB struct {
 	trapMibs map[string]*kt.Mib
 	traps    map[string]Trap
 	log      logger.ContextL
+	validate bool // Error out if a profile is not correct.
 }
 
 var (
@@ -40,12 +41,13 @@ var (
 	}
 )
 
-func NewMibDB(mibpath string, profileDir string, log logger.ContextL) (*MibDB, error) {
+func NewMibDB(mibpath string, profileDir string, validate bool, log logger.ContextL) (*MibDB, error) {
 	mdb := &MibDB{
 		log:      log,
 		profiles: map[string]*Profile{},
 		traps:    map[string]Trap{},
 		trapMibs: map[string]*kt.Mib{},
+		validate: validate,
 	}
 
 	if mibpath != "" {

--- a/pkg/inputs/snmp/mibs/load_test.go
+++ b/pkg/inputs/snmp/mibs/load_test.go
@@ -33,7 +33,7 @@ func TestCheckForProvider(t *testing.T) {
 
 func TestFullProvider(t *testing.T) {
 	l := lt.NewTestContextL(logger.NilContext, t)
-	mdb, err := NewMibDB("", "", l)
+	mdb, err := NewMibDB("", "", false, l)
 	assert.NoError(t, err)
 	defer mdb.Close()
 

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -34,6 +34,7 @@ var (
 	snmpOutFile    = flag.String("snmp_out_file", "", "If set, write updated snmp file here.")
 	snmpPollNow    = flag.String("snmp_poll_now", "", "If set, run one snmp poll for the specified device and then exit.")
 	snmpDiscoDur   = flag.Int("snmp_discovery_min", 0, "If set, run snmp discovery on this interval (in minutes).")
+	validateMib    = flag.Bool("snmp_validate", false, "If true, validate mib profiles and exit.")
 	ServiceName    = ""
 )
 
@@ -54,11 +55,15 @@ func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 
 	// Load a mibdb if we have one.
 	if conf.Global != nil {
-		mdb, err := mibs.NewMibDB(conf.Global.MibDB, conf.Global.MibProfileDir, log)
+		mdb, err := mibs.NewMibDB(conf.Global.MibDB, conf.Global.MibProfileDir, *validateMib, log)
 		if err != nil {
 			return fmt.Errorf("There was an error when setting up the %s mibDB database and the %s profiles: %v.", conf.Global.MibDB, conf.Global.MibProfileDir, err)
 		}
 		mibdb = mdb
+		if *validateMib {
+			// We just want to validate that this was ok so time to exit now.
+			os.Exit(0)
+		}
 	} else {
 		log.Infof("Skipping configurable mibs")
 	}


### PR DESCRIPTION
#292 -- Adds the flag `--snmp_validate` to validate that the snmp profiles are correct. 

With an error:
```
2022-03-25T15:53:22.924 ktranslate(43542) [Info] KTranslate Ignoring file ./config/profiles/kentik_snmp/generic
2022-03-25T15:53:22.924 ktranslate(43542) [Info] KTranslate Recursing into ./config/profiles/kentik_snmp/hp
service Run() error: There was an error when setting up the ./config/mibs.db mibDB database and the ./config/profiles profiles: There was an error when parsing the ./config/profiles/kentik_snmp/hp/hp-ilo.yml YAML mib: yaml: unmarshal errors:
  line 527: cannot unmarshal !!str `9)` into int64..
(ktenv) pye@ribeye:~/src/ktranslate(main) $ echo $?
246
```

Without:

```
2022-03-25T15:59:54.820 ktranslate(44662) [Info] KTranslate Ignoring file ./config/profiles/kentik_snmp/vmware
2022-03-25T15:59:54.820 ktranslate(44662) [Info] KTranslate Ignoring file ./config/profiles/kentik_snmp
2022-03-25T15:59:54.820 ktranslate(44662) [Info] KTranslate Now trying to extend profiles
(ktenv) pye@ribeye:~/src/ktranslate(add-snmp-validation) $ echo $?
0
```

Once this is merged in I'll add to the CI for https://github.com/kentik/snmp-profiles -- already found a few in here. 