### PR TITLE
Changing ping logic to always run, even when device is offline

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -271,26 +271,6 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 		dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
 	}
 
-	// If we are running an active check, add it in here now.
-	if pinger != nil {
-		pings, err := dm.GetPingStats(ctx, pinger)
-		if err != nil {
-			return nil, err
-		}
-		if len(pings) > 0 {
-			dst.CustomBigInt["MinRttMs"] = pings[0].CustomBigInt["MinRttMs"]
-			dst.CustomMetrics["MinRttMs"] = pings[0].CustomMetrics["MinRttMs"]
-			dst.CustomBigInt["MaxRttMs"] = pings[0].CustomBigInt["MaxRttMs"]
-			dst.CustomMetrics["MaxRttMs"] = pings[0].CustomMetrics["MaxRttMs"]
-			dst.CustomBigInt["AvgRttMs"] = pings[0].CustomBigInt["AvgRttMs"]
-			dst.CustomMetrics["AvgRttMs"] = pings[0].CustomMetrics["AvgRttMs"]
-			dst.CustomBigInt["StdDevRtt"] = pings[0].CustomBigInt["StdDevRtt"]
-			dst.CustomMetrics["StdDevRtt"] = pings[0].CustomMetrics["StdDevRtt"]
-			dst.CustomBigInt["PacketLossPct"] = pings[0].CustomBigInt["PacketLossPct"]
-			dst.CustomMetrics["PacketLossPct"] = pings[0].CustomMetrics["PacketLossPct"]
-		}
-	}
-
 	flows = append(flows, dst)
 
 	dm.metrics.DeviceMetrics.Mark(int64(len(flows)))


### PR DESCRIPTION
There's two ways that ping can get turned on:

1) set `ping_only: true` in the device config.
2) set `response_time: true` in the global section.

If the device is down, currently ping gets turned off along with the rest of the snmp checks unless its set up in mode 1. 
This PR changes mode 2 so that it works like mode 1 and always pings the target device, even if the device is down. 