### PR TITLE
Update health with status of why bad

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -327,7 +327,14 @@ func (dm *DeviceMetrics) GetStatusFlows() []*kt.JCHF {
 		dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
 	}
 	dst.CustomBigInt["PollingHealth"] = dm.metrics.Fail.Value()
-	dst.CustomStr[kt.StringPrefix+"PollingHealth"] = kt.SNMP_STATUS_MAP[dst.CustomBigInt["PollingHealth"]]
+	reasonVal := kt.SNMP_STATUS_MAP[dst.CustomBigInt["PollingHealth"]]
+	pts := strings.Split(reasonVal, ": ")
+	if len(pts) == 2 {
+		dst.CustomStr[kt.StringPrefix+"PollingHealth"] = pts[0]
+		dst.CustomStr[kt.StringPrefix+"PollingHealthReason"] = pts[1]
+	} else {
+		dst.CustomStr[kt.StringPrefix+"PollingHealth"] = reasonVal
+	}
 	return []*kt.JCHF{dst}
 }
 

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -113,7 +113,7 @@ func (p *Poller) StartLoop(ctx context.Context) {
 					p.log.Warnf("Skipping a counter datapoint for the period %v -- poll scheduled for %v, but only dequeued at %v",
 						scheduledTime.Truncate(counterAlignment), scheduledTime, startTime)
 					p.interfaceMetrics.DiscardDeltaState()
-					p.metrics.Fail.Update(kt.SNMP_BAD)
+					p.metrics.Fail.Update(kt.SNMP_BAD_POLL_TIMEOUT)
 					continue
 				}
 
@@ -164,12 +164,12 @@ func (p *Poller) Poll(ctx context.Context) ([]*kt.JCHF, error) {
 	deviceFlows, err := p.deviceMetrics.Poll(ctx, p.server, p.pinger)
 	if err != nil {
 		p.log.Warnf("Cannot poll device metrics: %v", err)
-		p.metrics.Fail.Update(kt.SNMP_BAD)
+		p.metrics.Fail.Update(kt.SNMP_BAD_DEVICE_ERR)
 	}
 
 	flows, err := p.interfaceMetrics.Poll(ctx, p.server, deviceFlows)
 	if err != nil {
-		p.metrics.Fail.Update(kt.SNMP_BAD)
+		p.metrics.Fail.Update(kt.SNMP_BAD_INTERFACE_ERR)
 		return nil, err
 	}
 
@@ -180,7 +180,7 @@ func (p *Poller) Poll(ctx context.Context) ([]*kt.JCHF, error) {
 	if len(flows) > 0 {
 		p.metrics.Fail.Update(kt.SNMP_GOOD)
 	} else {
-		p.metrics.Fail.Update(kt.SNMP_BAD) // Otherwise, set to bad because there's no data coming out of this device.
+		p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
 	}
 
 	return flows, nil

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -183,6 +183,8 @@ func (p *Poller) Poll(ctx context.Context) ([]*kt.JCHF, error) {
 		p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
 	}
 
+	p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
+
 	return flows, nil
 }
 

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -183,8 +183,6 @@ func (p *Poller) Poll(ctx context.Context) ([]*kt.JCHF, error) {
 		p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
 	}
 
-	p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
-
 	return flows, nil
 }
 

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -180,7 +180,7 @@ func (p *Poller) Poll(ctx context.Context) ([]*kt.JCHF, error) {
 	if len(flows) > 0 {
 		p.metrics.Fail.Update(kt.SNMP_GOOD)
 	} else {
-		p.metrics.Fail.Update(kt.SNMP_BAD_NO_FLOWS) // Otherwise, set to bad because there's no data coming out of this device.
+		p.metrics.Fail.Update(kt.SNMP_BAD_NO_DATA) // Otherwise, set to bad because there's no data coming out of this device.
 	}
 
 	return flows, nil

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -243,13 +243,13 @@ func launchSnmp(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpD
 	metadataServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
 	if err != nil {
 		log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
-		metrics.Fail.Update(kt.SNMP_BAD)
+		metrics.Fail.Update(kt.SNMP_BAD_INIT_METADATA)
 		return err
 	}
 	metricsServer, err := snmp_util.InitSNMP(device, connectTimeout, retries, "", log)
 	if err != nil {
 		log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
-		metrics.Fail.Update(kt.SNMP_BAD)
+		metrics.Fail.Update(kt.SNMP_BAD_INIT_METRICS)
 		return err
 	}
 
@@ -267,7 +267,7 @@ func launchSnmp(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpD
 		// delta values yet.
 		_, err := metricPoller.Poll(ctx)
 		if err != nil {
-			metrics.Fail.Update(kt.SNMP_BAD)
+			metrics.Fail.Update(kt.SNMP_BAD_FIRST_METRICS_POLL)
 			log.Warnf("There was an error when polling the SNMP counters: %v.", err)
 		}
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -238,7 +238,6 @@ type SnmpDeviceMetric struct {
 
 const (
 	SNMP_GOOD                   = 1
-	SNMP_BAD                    = 2
 	SNMP_BAD_NO_FLOWS           = 3
 	SNMP_BAD_DEVICE_ERR         = 4
 	SNMP_BAD_INTERFACE_ERR      = 5

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -237,14 +237,28 @@ type SnmpDeviceMetric struct {
 }
 
 const (
-	SNMP_GOOD = 1
-	SNMP_BAD  = 2
+	SNMP_GOOD                   = 1
+	SNMP_BAD                    = 2
+	SNMP_BAD_NO_FLOWS           = 3
+	SNMP_BAD_DEVICE_ERR         = 4
+	SNMP_BAD_INTERFACE_ERR      = 5
+	SNMP_BAD_POLL_TIMEOUT       = 6
+	SNMP_BAD_INIT_METADATA      = 7
+	SNMP_BAD_INIT_METRICS       = 8
+	SNMP_BAD_FIRST_METRICS_POLL = 9
 )
 
 var (
 	SNMP_STATUS_MAP = map[int64]string{
-		1: "GOOD",
-		2: "BAD",
+		SNMP_GOOD:                   "GOOD",
+		SNMP_BAD:                    "BAD",
+		SNMP_BAD_NO_FLOWS:           "BAD: No flows",
+		SNMP_BAD_DEVICE_ERR:         "BAD: Device Error",
+		SNMP_BAD_INTERFACE_ERR:      "BAD: Interface Error",
+		SNMP_BAD_POLL_TIMEOUT:       "BAD: Poll Timeout",
+		SNMP_BAD_INIT_METADATA:      "BAD: Init Metadata",
+		SNMP_BAD_INIT_METRICS:       "BAD: Init Metrics",
+		SNMP_BAD_FIRST_METRICS_POLL: "BAD: Metrics Poll",
 	}
 )
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -251,7 +251,6 @@ const (
 var (
 	SNMP_STATUS_MAP = map[int64]string{
 		SNMP_GOOD:                   "GOOD",
-		SNMP_BAD:                    "BAD",
 		SNMP_BAD_NO_FLOWS:           "BAD: No flows",
 		SNMP_BAD_DEVICE_ERR:         "BAD: Device Error",
 		SNMP_BAD_INTERFACE_ERR:      "BAD: Interface Error",

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -238,7 +238,7 @@ type SnmpDeviceMetric struct {
 
 const (
 	SNMP_GOOD                   = 1
-	SNMP_BAD_NO_FLOWS           = 3
+	SNMP_BAD_NO_DATA            = 3
 	SNMP_BAD_DEVICE_ERR         = 4
 	SNMP_BAD_INTERFACE_ERR      = 5
 	SNMP_BAD_POLL_TIMEOUT       = 6
@@ -250,7 +250,7 @@ const (
 var (
 	SNMP_STATUS_MAP = map[int64]string{
 		SNMP_GOOD:                   "GOOD",
-		SNMP_BAD_NO_FLOWS:           "BAD: No flows",
+		SNMP_BAD_NO_DATA:            "BAD: No data",
 		SNMP_BAD_DEVICE_ERR:         "BAD: Device Error",
 		SNMP_BAD_INTERFACE_ERR:      "BAD: Interface Error",
 		SNMP_BAD_POLL_TIMEOUT:       "BAD: Poll Timeout",


### PR DESCRIPTION
#300 

This adds a reason to the polling health metric.

Right now, there are these reasons:

```
		SNMP_GOOD:                   "GOOD",
		SNMP_BAD_NO_FLOWS:           "BAD: No flows",
		SNMP_BAD_DEVICE_ERR:         "BAD: Device Error",
		SNMP_BAD_INTERFACE_ERR:      "BAD: Interface Error",
		SNMP_BAD_POLL_TIMEOUT:       "BAD: Poll Timeout",
		SNMP_BAD_INIT_METADATA:      "BAD: Init Metadata",
		SNMP_BAD_INIT_METRICS:       "BAD: Init Metrics",
		SNMP_BAD_FIRST_METRICS_POLL: "BAD: Metrics Poll",
```

If bad, these are separated into 2 attributes:

```
"PollingHealth": "BAD",
```
And
```
"PollingHealthReason": "No flows"
```

If good, `PollingHealthReason` is not set. 

Other trick is that the value can go from 

```
	SNMP_GOOD                   = 1
	SNMP_BAD_NO_FLOWS           = 3
	SNMP_BAD_DEVICE_ERR         = 4
	SNMP_BAD_INTERFACE_ERR      = 5
	SNMP_BAD_POLL_TIMEOUT       = 6
	SNMP_BAD_INIT_METADATA      = 7
	SNMP_BAD_INIT_METRICS       = 8
	SNMP_BAD_FIRST_METRICS_POLL = 9
```

Where anything > 1 is bad. Should it be collapsed down into the 1 or 2 range again? 
