### PR TITLE
Fix stats per run

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -342,11 +342,20 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["StdDevRtt"] = stats.StdDevRtt.Microseconds()
 	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomBigInt["PacketsSent"] = int64(stats.PacketsSent)
+	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomBigInt["PacketsRecv"] = int64(stats.PacketsRecv)
+	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomBigInt["PacketsRecvDuplicates"] = int64(stats.PacketsRecvDuplicates)
+	dst.CustomMetrics["PacketsRecvDuplicates"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	if stats.PacketLoss >= 0.0 {
 		dst.CustomBigInt["PacketLossPct"] = int64(stats.PacketLoss * 1000.)
 		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	}
 	dm.conf.SetUserTags(dst.CustomStr)
 
-	return []*kt.JCHF{dst}, nil
+	// Reset the stats system.
+	err := pinger.Reset()
+
+	return []*kt.JCHF{dst}, err
 }

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -343,11 +343,11 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomBigInt["StdDevRtt"] = stats.StdDevRtt.Microseconds()
 	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["PacketsSent"] = int64(stats.PacketsSent)
-	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["PacketsRecv"] = int64(stats.PacketsRecv)
-	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["PacketsRecvDuplicates"] = int64(stats.PacketsRecvDuplicates)
-	dst.CustomMetrics["PacketsRecvDuplicates"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["PacketsRecvDuplicates"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
 	if stats.PacketLoss >= 0.0 {
 		dst.CustomBigInt["PacketLossPct"] = int64(stats.PacketLoss * 1000.)
 		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}

--- a/pkg/inputs/snmp/ping/ping.go
+++ b/pkg/inputs/snmp/ping/ping.go
@@ -31,6 +31,8 @@ func NewPinger(log logger.ContextL, target string, inter time.Duration) (*Pinger
 	if os.Getenv(KENTIK_PING_PRIV) == "true" {
 		log.Infof("Running ping service in privileged mode.")
 		p.priv = true
+	} else {
+		log.Infof("Running ping service in non privileged mode.")
 	}
 
 	err := p.Reset()

--- a/pkg/inputs/snmp/ping/ping.go
+++ b/pkg/inputs/snmp/ping/ping.go
@@ -17,29 +17,47 @@ type Pinger struct {
 	log    logger.ContextL
 	target string
 	pinger *ping.Pinger
+	count  int
+	priv   bool
 }
 
 func NewPinger(log logger.ContextL, target string, inter time.Duration) (*Pinger, error) {
 	p := &Pinger{
 		log:    log,
 		target: target,
-	}
-	pinger, err := ping.NewPinger(target)
-	if err != nil {
-		return nil, err
+		count:  int(inter.Seconds()), // Run 1 ping per sec, for this many seconds.
 	}
 
-	pinger.Interval = inter
 	if os.Getenv(KENTIK_PING_PRIV) == "true" {
 		log.Infof("Running ping service in privileged mode.")
-		pinger.SetPrivileged(true)
+		p.priv = true
 	}
-	go pinger.Run()
-	p.pinger = pinger
 
-	return p, nil
+	err := p.Reset()
+	return p, err
 }
 
 func (p *Pinger) Statistics() *ping.Statistics {
 	return p.pinger.Statistics()
+}
+
+func (p *Pinger) Reset() error {
+	pinger, err := ping.NewPinger(p.target)
+	if err != nil {
+		return err
+	}
+
+	// pinger.Interval = inter // Run at 1 per second.
+	pinger.Count = p.count
+	pinger.SetPrivileged(p.priv)
+	p.pinger = pinger
+
+	go func() {
+		err := p.pinger.Run()
+		if err != nil {
+			p.log.Errorf("Cannot ping: %v", err)
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
Fixes a few things for the ping system. 

1) Now it actually runs 1 ping per second.
2) Resets the stats after each reporting period so that packet loss change is reported right away. 
3) Adds in PacketsSent, PacketsRecv, PacketsRecvDuplicates metrics also. 