### PR TITLE
Fixing nulls for rfc5424 style messages

### DIFF
--- a/pkg/inputs/syslog/syslog.go
+++ b/pkg/inputs/syslog/syslog.go
@@ -214,8 +214,14 @@ func (ks *KentikSyslog) formatMessage(ctx context.Context, msg sfmt.LogParts) ([
 		msg["device_name"] = msg["client_name"]
 	}
 
-	msg["message"] = msg["content"] // Swap these around for NR.
-	delete(msg, "content")
+	// Swap these around for NR.
+	if _, ok := msg["message"]; !ok {
+		if _, ok := msg["content"]; ok {
+			msg["message"] = msg["content"]
+			delete(msg, "content")
+		}
+	}
+
 	msg["plugin.type"] = kt.PluginSyslog         // NR Processing.
 	msg["instrumentation.name"] = InstNameSyslog // NR Processing.
 


### PR DESCRIPTION
This fixes a case where `NULLs` would come in for some syslog messages `message` field. 

Bug is that `content` was swapped for `message` field because `message` is what NR looks for. But in RFC5424, its already the message field and there is no content field. Fix is to be smarter about this and only swap if there both is NO message and there is a content.  