### PR TITLE
Fixing enums for table based device metadata

### DIFF
--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -249,17 +249,8 @@ func (dm *DeviceMetadata) handleTable(idx string, value wrapper, oidName string,
 			md.Tables[idx].Customs[oidName] = kt.NewMetaValue(value.mib, val, 0)
 		}
 	default:
-		// Try to just use as a number, either via an enum or directly.
-		val := gosnmp.ToBigInt(value.variable.Value).Int64()
-		if value.mib != nil && value.mib.EnumRev != nil {
-			if ev, ok := value.mib.EnumRev[val]; ok {
-				md.Tables[idx].Customs[oidName] = kt.NewMetaValue(value.mib, ev, 0)
-			} else {
-				md.Tables[idx].Customs[oidName] = kt.NewMetaValue(value.mib, "", val)
-			}
-		} else {
-			md.Tables[idx].Customs[oidName] = kt.NewMetaValue(value.mib, "", val)
-		}
+		// Try to just use as a number, either via an enum or directly. Enum handled in the NewMetaValue func.
+		md.Tables[idx].Customs[oidName] = kt.NewMetaValue(value.mib, "", gosnmp.ToBigInt(value.variable.Value).Int64())
 	}
 }
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -52,7 +52,7 @@ func NewDeviceTableMetadata() DeviceTableMetadata {
 }
 
 func NewMetaValue(mib *Mib, sv string, iv int64) MetaValue {
-	if mib.EnumRev != nil {
+	if mib != nil && mib.EnumRev != nil {
 		if nv, ok := mib.EnumRev[iv]; ok {
 			sv = nv
 		} else {


### PR DESCRIPTION
This fixes a bug introduced with https://github.com/kentik/ktranslate/pull/304

Turns out table based device metadata handled enums just fine. Its only non table values which didn't get enumerated. This reverts back to the original handling of table enums. 

