### PR TITLE
Fixing CPU use on ping. Also allow check_all_ip disco

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -113,7 +113,7 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (*SnmpD
 		st := time.Now()
 		log.Infof("Starting to check %d ips in %s", len(results), ipr)
 		for i, result := range results {
-			if strings.HasSuffix(ipr, "/32") || result.IsHostUp() {
+			if strings.HasSuffix(ipr, "/32") || result.IsHostUp() || conf.Disco.CheckAll {
 				if ignoreMap[result.Host.String()] { // If we have marked this ip as to be ignored, don't do anything more with it.
 					continue
 				}

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -19,7 +19,7 @@ import (
 
 type pingStatus struct {
 	sent     uint64
-	recieved uint64
+	received uint64
 }
 
 type DeviceMetrics struct {
@@ -355,11 +355,11 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 
 	// Calc these directly
 	sent := uint64(stats.PacketsSent)
-	recieved := uint64(stats.PacketsRecv)
+	received := uint64(stats.PacketsRecv)
 	diffSent := sent - dm.ping.sent
-	diffRecv := recieved - dm.ping.recieved
+	diffRecv := received - dm.ping.received
 	dm.ping.sent = sent
-	dm.ping.recieved = recieved
+	dm.ping.received = received
 	percnt := 0.0
 	if diffSent > 0 {
 		percnt = float64(diffSent-diffRecv) / float64(diffSent) * 100.

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -17,6 +17,11 @@ import (
 	snmp_util "github.com/kentik/ktranslate/pkg/inputs/snmp/util"
 )
 
+type pingStatus struct {
+	sent     int64
+	recieved int64
+}
+
 type DeviceMetrics struct {
 	log         logger.ContextL
 	conf        *kt.SnmpDeviceConfig
@@ -25,6 +30,7 @@ type DeviceMetrics struct {
 	profileName string
 	oids        map[string]*kt.Mib
 	missing     map[string]bool
+	ping        pingStatus
 }
 
 func NewDeviceMetrics(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, profileMetrics map[string]*kt.Mib, profile *mibs.Profile, log logger.ContextL) *DeviceMetrics {
@@ -318,6 +324,10 @@ func (dm *DeviceMetrics) GetStatusFlows() []*kt.JCHF {
 	return []*kt.JCHF{dst}
 }
 
+func (dm *DeviceMetrics) ResetPingStats() {
+	dm.ping = pingStatus{}
+}
+
 func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) ([]*kt.JCHF, error) {
 	if pinger == nil {
 		return nil, nil
@@ -342,20 +352,28 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["StdDevRtt"] = stats.StdDevRtt.Microseconds()
 	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
-	dst.CustomBigInt["PacketsSent"] = int64(stats.PacketsSent)
+
+	// Calc these directly
+	sent := int64(stats.PacketsSent)
+	recieved := int64(stats.PacketsRecv)
+	diffSent := sent - dm.ping.sent
+	diffRecv := recieved - dm.ping.recieved
+	dm.ping.sent = sent
+	dm.ping.recieved = recieved
+	percnt := 0.0
+	if diffSent > 0 {
+		percnt = float64(diffSent-diffRecv) / float64(diffSent) * 100.
+	}
+
+	dst.CustomBigInt["PacketsSent"] = diffSent
 	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
-	dst.CustomBigInt["PacketsRecv"] = int64(stats.PacketsRecv)
+	dst.CustomBigInt["PacketsRecv"] = diffRecv
 	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
-	dst.CustomBigInt["PacketsRecvDuplicates"] = int64(stats.PacketsRecvDuplicates)
-	dst.CustomMetrics["PacketsRecvDuplicates"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
-	if stats.PacketLoss >= 0.0 {
-		dst.CustomBigInt["PacketLossPct"] = int64(stats.PacketLoss * 1000.)
+	if percnt >= 0.0 {
+		dst.CustomBigInt["PacketLossPct"] = int64(percnt * 1000.)
 		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	}
 	dm.conf.SetUserTags(dst.CustomStr)
 
-	// Reset the stats system.
-	err := pinger.Reset()
-
-	return []*kt.JCHF{dst}, err
+	return []*kt.JCHF{dst}, nil
 }

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -18,8 +18,8 @@ import (
 )
 
 type pingStatus struct {
-	sent     int64
-	recieved int64
+	sent     uint64
+	recieved uint64
 }
 
 type DeviceMetrics struct {
@@ -354,8 +354,8 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 
 	// Calc these directly
-	sent := int64(stats.PacketsSent)
-	recieved := int64(stats.PacketsRecv)
+	sent := uint64(stats.PacketsSent)
+	recieved := uint64(stats.PacketsRecv)
 	diffSent := sent - dm.ping.sent
 	diffRecv := recieved - dm.ping.recieved
 	dm.ping.sent = sent
@@ -365,9 +365,9 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 		percnt = float64(diffSent-diffRecv) / float64(diffSent) * 100.
 	}
 
-	dst.CustomBigInt["PacketsSent"] = diffSent
+	dst.CustomBigInt["PacketsSent"] = int64(diffSent)
 	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
-	dst.CustomBigInt["PacketsRecv"] = diffRecv
+	dst.CustomBigInt["PacketsRecv"] = int64(diffRecv)
 	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
 	if percnt >= 0.0 {
 		dst.CustomBigInt["PacketLossPct"] = int64(percnt * 1000.)

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -96,7 +96,7 @@ func NewPollerForPing(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jch
 		deviceMetrics:  NewDeviceMetrics(gconf, conf, metrics, nil, profile, log),
 	}
 
-	p, err := ping.NewPinger(log, conf.DeviceIP, time.Duration(counterTimeSec)*time.Second)
+	p, err := ping.NewPinger(log, conf.DeviceIP, time.Duration(counterTimeSec)*time.Second, conf.PingSec)
 	if err != nil {
 		log.Errorf("Cannot setup ping service for %s -> %s: %v", err, conf.DeviceIP, conf.DeviceName)
 	} else {
@@ -224,6 +224,7 @@ func (p *Poller) StartPingOnlyLoop(ctx context.Context) {
 	jitterWindow := 15 * time.Second
 	firstCollection := time.Now().Truncate(counterAlignment).Add(counterAlignment).Add(time.Duration(rand.Int63n(int64(jitterWindow))))
 	counterCheck := tick.NewFixedTimer(firstCollection, counterAlignment)
+	p.deviceMetrics.ResetPingStats() // Initialize to 0 sent and recieved.
 
 	p.log.Infof("snmpPingOnly: First run will be at %v. Running every %v", firstCollection, counterAlignment)
 

--- a/pkg/inputs/snmp/ping/ping.go
+++ b/pkg/inputs/snmp/ping/ping.go
@@ -17,7 +17,6 @@ type Pinger struct {
 	log      logger.ContextL
 	target   string
 	pinger   *ping.Pinger
-	count    int
 	priv     bool
 	num      int
 	interval time.Duration
@@ -31,7 +30,6 @@ func NewPinger(log logger.ContextL, target string, inter time.Duration, pingSec 
 	p := &Pinger{
 		log:      log,
 		target:   target,
-		count:    int(inter.Seconds()),                 // Run pingSec ping interval, for this many seconds.
 		interval: time.Second * time.Duration(pingSec), // Send 1 ping every this many seconds.
 	}
 
@@ -57,7 +55,6 @@ func (p *Pinger) Reset() error {
 	}
 
 	pinger.Interval = p.interval // Sent 1 packet every X seconds. Default to 1.
-	//pinger.Count = p.count // Do not set a count here, just go forever.
 	pinger.SetPrivileged(p.priv)
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		p.log.Infof("Ping run %d finished.", p.num)

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -57,6 +57,7 @@ func StartSNMPPolls(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 	if conf.Global != nil {
 		mdb, err := mibs.NewMibDB(conf.Global.MibDB, conf.Global.MibProfileDir, *validateMib, log)
 		if err != nil {
+			time.Sleep(2 * time.Second) // Give logs time to get sent back.
 			return fmt.Errorf("There was an error when setting up the %s mibDB database and the %s profiles: %v.", conf.Global.MibDB, conf.Global.MibProfileDir, err)
 		}
 		mibdb = mdb

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -161,6 +161,7 @@ type SnmpDeviceConfig struct {
 	NoUseBulkWalkAll    bool              `yaml:"no_use_bulkwalkall"`
 	InstrumentationName string            `yaml:"instrumentationName,omitempty"`
 	RunPing             bool              `yaml:"response_time,omitempty"`
+	PingSec             int               `yaml:"ping_interval_sec,omitempty"`
 	allUserTags         map[string]string
 	walker              SNMPTestWalker
 }
@@ -187,6 +188,7 @@ type SnmpDiscoConfig struct {
 	Threads            int             `yaml:"threads"`
 	ReplaceDevices     bool            `yaml:"replace_devices"`
 	NoDedup            bool            `yaml:"no_dedup_engine_id,omitempty"`
+	CheckAll           bool            `yaml:"check_all_ips,omitempty"`
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`
 }


### PR DESCRIPTION
#311 -- allow `check_all_ips` option to make discovery check all ips in a cidr even if they don't appear to be up. 

Also fixes a case where CPU use can rise over time when ping checks are enabled. 