### PR TITLE
chore: update add_mibs to default true

### DIFF
--- a/config/snmp-base.yaml
+++ b/config/snmp-base.yaml
@@ -14,7 +14,7 @@ discovery:
   - public
   default_v3: null
   add_devices: true
-  add_mibs: false
+  add_mibs: true
   threads: 4
   replace_devices: true
 global:

--- a/config/snmp-win.yaml
+++ b/config/snmp-win.yaml
@@ -14,7 +14,7 @@ discovery:
   - public
   default_v3: null
   add_devices: true
-  add_mibs: false
+  add_mibs: true
   threads: 4
   replace_devices: true
 global:

--- a/config/snmp.yaml.sample
+++ b/config/snmp.yaml.sample
@@ -14,6 +14,7 @@ discovery:
   - public
   default_v3: null
   add_devices: true
+  add_mibs: true
   threads: 4
   replace_devices: true
   use_snmp_v1: false


### PR DESCRIPTION
requesting update to default YAML files to change `add_mibs: true` for discovery settings. we've had a few instances of users pulling their YAML directly off the container and not updating this setting before running discovery and then having confusion about missing metrics later.