### PR TITLE
Resolve flow sending devices by dns

### DIFF
--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -248,7 +248,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]strin
 
 	// Resolve any hostnames if a resolver is set up.
 	if kc.resolver != nil {
-		dst.CustomStr["dst_host"] = kc.resolver.Resolve(ctx, dst.DstAddr)
+		dst.CustomStr["dst_host"] = kc.resolver.Resolve(ctx, dst.DstAddr, false)
 	}
 
 	if src.CHF.Ipv4SrcAddr() > 0 {
@@ -266,7 +266,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]strin
 	dst.DstRoutePrefix = addr.String()
 
 	if kc.resolver != nil {
-		dst.CustomStr["src_host"] = kc.resolver.Resolve(ctx, dst.SrcAddr)
+		dst.CustomStr["src_host"] = kc.resolver.Resolve(ctx, dst.SrcAddr, false)
 	}
 
 	// next hops
@@ -557,8 +557,8 @@ func (kc *KTranslate) doEnrichments(ctx context.Context, citycache map[uint32]st
 
 		// If there's a resolver, try to resolve to hostnames.
 		if kc.resolver != nil {
-			msg.CustomStr["src_host"] = kc.resolver.Resolve(ctx, msg.SrcAddr)
-			msg.CustomStr["dst_host"] = kc.resolver.Resolve(ctx, msg.DstAddr)
+			msg.CustomStr["src_host"] = kc.resolver.Resolve(ctx, msg.SrcAddr, false)
+			msg.CustomStr["dst_host"] = kc.resolver.Resolve(ctx, msg.DstAddr, false)
 		}
 	}
 

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -656,7 +656,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If we're looking for netflow direct flows coming in
 	if kc.config.FlowSource != "" {
 		assureInput()
-		nfs, err := flow.NewFlowSource(ctx, kc.config.FlowSource, kc.config.MaxFlowPerMessage, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, kc.inputChan, kc.apic)
+		nfs, err := flow.NewFlowSource(ctx, kc.config.FlowSource, kc.config.MaxFlowPerMessage, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, kc.inputChan, kc.apic, kc.resolver)
 		if err != nil {
 			return err
 		}

--- a/pkg/inputs/flow/flow.go
+++ b/pkg/inputs/flow/flow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/api"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
 	"github.com/kentik/ktranslate/pkg/kt"
+	"github.com/kentik/ktranslate/pkg/util/resolv"
 
 	"github.com/netsampler/goflow2/utils"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -40,8 +41,8 @@ var (
 	MappingFile   = flag.String("nf.mapping", "", "Configuration file for custom netflow mappings")
 )
 
-func NewFlowSource(ctx context.Context, proto FlowSource, maxBatchSize int, log logger.Underlying, registry go_metrics.Registry, jchfChan chan []*kt.JCHF, apic *api.KentikApi) (*KentikDriver, error) {
-	kt := NewKentikDriver(ctx, proto, maxBatchSize, log, registry, jchfChan, apic, *MessageFields)
+func NewFlowSource(ctx context.Context, proto FlowSource, maxBatchSize int, log logger.Underlying, registry go_metrics.Registry, jchfChan chan []*kt.JCHF, apic *api.KentikApi, resolv *resolv.Resolver) (*KentikDriver, error) {
+	kt := NewKentikDriver(ctx, proto, maxBatchSize, log, registry, jchfChan, apic, *MessageFields, resolv)
 	kt.Infof("Netflow listener running on %s:%d for format %s and a batch size of %d", *Addr, *Port, proto, maxBatchSize)
 	kt.Infof("Netflow listener sending fields %s", *MessageFields)
 

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -112,7 +112,7 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 	} else {
 		in.DeviceName = net.IP(fmsg.SamplerAddress).String()
 		if t.resolv != nil {
-			dm := t.resolv.Resolve(t.ctx, in.DeviceName)
+			dm := t.resolv.Resolve(t.ctx, in.DeviceName, true)
 			if dm != "" {
 				in.DeviceName = dm
 			}

--- a/pkg/inputs/syslog/syslog.go
+++ b/pkg/inputs/syslog/syslog.go
@@ -188,7 +188,7 @@ func (ks *KentikSyslog) formatMessage(ctx context.Context, msg sfmt.LogParts) ([
 			dev.SetMsgUserTags(msg)
 		}
 		if ks.resolver != nil {
-			msg["client_name"] = ks.resolver.Resolve(ctx, pts[0])
+			msg["client_name"] = ks.resolver.Resolve(ctx, pts[0], true)
 		}
 	}
 
@@ -198,7 +198,7 @@ func (ks *KentikSyslog) formatMessage(ctx context.Context, msg sfmt.LogParts) ([
 			if hs, ok := hostname.(string); ok {
 				if ipr := net.ParseIP(hs); ipr != nil {
 					if ks.resolver != nil {
-						msg["device_name"] = ks.resolver.Resolve(ctx, hs)
+						msg["device_name"] = ks.resolver.Resolve(ctx, hs, true)
 					} else {
 						msg["device_name"] = hs
 					}

--- a/pkg/util/resolv/resolver.go
+++ b/pkg/util/resolv/resolver.go
@@ -66,7 +66,7 @@ func NewResolver(ctx context.Context, log logger.Underlying, dnsHost string) (*R
 	return res, nil
 }
 
-func (r *Resolver) Resolve(ctx context.Context, ip string) string {
+func (r *Resolver) Resolve(ctx context.Context, ip string, log bool) string {
 	r.mux.RLock()
 	final, ok := r.cache[ip]
 	if ok {
@@ -94,6 +94,9 @@ func (r *Resolver) Resolve(ctx context.Context, ip string) string {
 	} // ignore errors here
 	r.mux.Lock()
 	r.cache[ip] = final // cache.
+	if log {
+		r.Infof("%s resolved to %s", ip, final)
+	}
 	r.mux.Unlock()
 
 	return final

--- a/pkg/util/resolv/resolver.go
+++ b/pkg/util/resolv/resolver.go
@@ -94,10 +94,10 @@ func (r *Resolver) Resolve(ctx context.Context, ip string, log bool) string {
 	} // ignore errors here
 	r.mux.Lock()
 	r.cache[ip] = final // cache.
+	r.mux.Unlock()
 	if log {
 		r.Infof("%s resolved to %s", ip, final)
 	}
-	r.mux.Unlock()
 
 	return final
 }


### PR DESCRIPTION
If a device's IP is not in `snmp.yaml`, netflow collector doesn't know what to call it. This will use dns if possible to resolve it to a device name.

Also adds locking to the resolver class which probably should have been there the whole time. 

#315