### PR TITLE
Add more examples

### DIFF
--- a/hack/elasticsearch/README.md
+++ b/hack/elasticsearch/README.md
@@ -1,0 +1,11 @@
+# Elasticsearch with ktranslate
+This is a Docker compose setup that will create an Elasticsearch with Kibana stack and setup
+ktranslate to listen to a NetFlow generator.
+
+# Run
+
+`docker compose up`
+
+This should launch all services. To view Kibana, visit http://localhost:5601. You will need to go to
+http://localhost:5601/app/management/kibana/indexPatterns/create and create an index pattern of
+`kentik*`. You can then visit http://localhost:5601/app/discover and you should see data.

--- a/hack/elasticsearch/docker-compose.yml
+++ b/hack/elasticsearch/docker-compose.yml
@@ -1,0 +1,80 @@
+version: "3.9"
+services:
+  elasticsearch:
+    image: elasticsearch:7.14.2
+    restart: always
+    environment:
+      - "discovery.type=single-node"
+    healthcheck:
+      test: ["CMD", "curl", "localhost:9090"]
+      interval: 10s
+      timeout: 1s
+      retries: 30
+      start_period: 10s
+    ports:
+      - 9200:9200
+
+  elasticsearch-init:
+    image: ehazlett/curl:latest
+    restart: on-failure
+    entrypoint: ["/bin/sh"]
+    command:
+      - "-c"
+      - "wait-for-it.sh -h elasticsearch -p 9200 -- curl -XPUT http://elasticsearch:9200/kentik"
+    depends_on:
+      - elasticsearch
+
+  kibana:
+    image: kibana:7.14.2
+    restart: always
+    environment:
+      - ELASTICSEARCH_HOSTS=["http://elasticsearch:9200"]
+    healthcheck:
+      test: ["CMD", "curl", "localhost:5601"]
+      interval: 10s
+      timeout: 1s
+      retries: 30
+      start_period: 10s
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
+
+  ktranslate:
+    image: kentik/ktranslate:v2
+    command:
+      - --sinks=http
+      - --format=elasticsearch
+      - --http_header
+      - "Content-type:application/json"
+      - --http_url
+      - "http://elasticsearch:9200/kentik/_bulk"
+      - -geo
+      - /etc/ktranslate/GeoLite2-Country.mmdb
+      - -udrs
+      - /etc/ktranslate/udr.csv
+      - -api_devices
+      - /etc/ktranslate/devices.json
+      - -asn
+      - /etc/ktranslate/GeoLite2-ASN.mmdb
+      - --nf.source=netflow5
+      - --nf.addr=0.0.0.0
+      - --nf.port=9995
+    restart: always
+    ports:
+      - 9090:9090
+      - 9995:9995/udp
+    depends_on:
+      - elasticsearch
+      - elasticsearch-init
+
+  nflow:
+    image: ehazlett/nflow-generator:latest
+    restart: always
+    command:
+      - -t
+      - ktranslate
+      - -p
+      - "9995"
+    depends_on:
+      - ktranslate

--- a/hack/influxdb/README.md
+++ b/hack/influxdb/README.md
@@ -1,0 +1,12 @@
+# InfluxDB with ktranslate
+This is a Docker compose setup that will create an InfluxDB stack and setup
+ktranslate to listen to a NetFlow generator.
+
+# Run
+
+`docker compose up`
+
+This should launch all services. To view InfluxDB, visit http://localhost:8086.
+
+User: `admin`
+Password: `influxdb`

--- a/hack/influxdb/docker-compose.yml
+++ b/hack/influxdb/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.9"
+services:
+  influxdb:
+    image: influxdb:2.2.0-alpine
+    restart: always
+    environment:
+      - "DOCKER_INFLUXDB_INIT_MODE=setup"
+      - "DOCKER_INFLUXDB_INIT_USERNAME=admin"
+      - "DOCKER_INFLUXDB_INIT_PASSWORD=influxdb"
+      - "DOCKER_INFLUXDB_INIT_ORG=system"
+      - "DOCKER_INFLUXDB_INIT_BUCKET=default"
+      - "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=secret-token"
+    healthcheck:
+      test: ["CMD", "curl", "localhost:8086"]
+      interval: 10s
+      timeout: 1s
+      retries: 30
+      start_period: 10s
+    ports:
+      - 8086:8086
+
+  ktranslate:
+    image: kentik/ktranslate:v2
+    command:
+      - --sinks=http
+      - --format=influx
+      - --http_url
+      - "http://influxdb:8086/api/v2/write?org=system&bucket=default"
+      - --http_header
+      - "Authorization: Token secret-token"
+      - --http_header
+      - "Content-type: application/json"
+      - --nf.source=netflow5
+      - --nf.addr=0.0.0.0
+      - --nf.port=9995
+    restart: always
+    ports:
+      - 9995:9995/udp
+    depends_on:
+      - influxdb
+
+  nflow:
+    image: ehazlett/nflow-generator:latest
+    restart: always
+    command:
+      - -t
+      - ktranslate
+      - -p
+      - "9995"
+    depends_on:
+      - ktranslate

--- a/hack/prometheus/README.md
+++ b/hack/prometheus/README.md
@@ -1,0 +1,9 @@
+# Prometheus with ktranslate
+This is a Docker compose setup that will create a Prometheus stack and setup
+ktranslate to listen to a NetFlow generator.
+
+# Run
+
+`docker compose up`
+
+This should launch all services. To view Prometheus, visit http://localhost:9090.

--- a/hack/prometheus/docker-compose.yml
+++ b/hack/prometheus/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    volumes:
+      - type: bind
+        source: ./prometheus.yml
+        target: /etc/prometheus/prometheus.yml
+    healthcheck:
+      test: ["CMD", "curl", "localhost:9090"]
+      interval: 10s
+      timeout: 1s
+      retries: 30
+      start_period: 10s
+    ports:
+      - 9090:9090
+
+  ktranslate:
+    image: kentik/ktranslate:v2
+    command:
+      - --sinks=prometheus
+      - --format=prometheus
+      - --prom_listen=:9000
+      - --http_header
+      - "Content-type:application/json"
+      - --nf.source=netflow5
+      - --nf.addr=0.0.0.0
+      - --nf.port=9995
+    restart: always
+    ports:
+      - 9000:9000
+      - 9995:9995/udp
+    depends_on:
+      - prometheus
+
+  nflow:
+    image: ehazlett/nflow-generator:latest
+    restart: always
+    command:
+      - -t
+      - ktranslate
+      - -p
+      - "9995"
+    depends_on:
+      - ktranslate

--- a/hack/prometheus/prometheus.yml
+++ b/hack/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval:     5s
+scrape_configs:
+  - job_name: 'ktranslate'
+    static_configs:
+      - targets: ['ktranslate:9000']

--- a/hack/snmp/README.md
+++ b/hack/snmp/README.md
@@ -1,0 +1,10 @@
+# SNMP Example
+The example requires the Lima VM. To setup Lima see [here](https://github.com/lima-vm/lima#getting-started).
+
+This is a Docker compose setup that will create a ktranslate instance to poll the SNMP configuration
+for the Lima VM.
+
+# Run
+
+`docker compose up`
+

--- a/hack/snmp/docker-compose.yml
+++ b/hack/snmp/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  ktranslate:
+    image: kentik/ktranslate:v2
+    network_mode: host
+    command:
+      - --format=json
+      - --snmp=/snmp.yml
+    restart: always
+    ports:
+      - 9995:9995/udp
+    volumes:
+      - type: bind
+        source: ./snmp.yml
+        target: /snmp.yml

--- a/hack/snmp/snmp.yml
+++ b/hack/snmp/snmp.yml
@@ -1,0 +1,53 @@
+devices:
+  lima-ktranslate__127.0.0.1:
+    device_name: ktranslate
+    device_ip: 127.0.0.1
+    snmp_comm: public
+    use_snmp_v1: false
+    debug: false
+    port: 161
+    oid: .1.3.6.1.4.1.8072.3.2.10
+    description: 'Linux lima-ktranslate 5.15.0-25-generic #25-Ubuntu SMP Wed Mar 30
+      15:57:31 UTC 2022 aarch64'
+    last_checked: 2022-05-23T16:52:35.51822962Z
+    mib_profile: net-snmp.yml
+    provider: kentik-net-snmp
+    user_tags: {}
+    discovered_mibs:
+    - HOST-RESOURCES-MIB
+    - IF-MIB
+    - MIB-DELL-10892
+    - UCD-DISKIO-MIB
+    - UCD-SNMP-MIB
+    match_attributes: {}
+    monitor_admin_shut: false
+    no_use_bulkwalkall: false
+trap: null
+discovery:
+  cidrs:
+  - 127.0.0.1/32
+  ignore_list: []
+  debug: false
+  ports:
+  - 161
+  default_communities:
+  - public
+  use_snmp_v1: false
+  default_v3: null
+  add_devices: true
+  add_mibs: false
+  threads: 16
+  replace_devices: true
+global:
+  poll_time_sec: 30
+  drop_if_outside_poll: false
+  mib_profile_dir: /etc/ktranslate/profiles
+  mibs_db: /etc/ktranslate/mibs.db
+  mibs_enabled:
+  - IF-MIB
+  timeout_ms: 3000
+  retries: 0
+  global_v3: null
+  response_time: false
+  user_tags: {}
+  match_attributes: {}


### PR DESCRIPTION
This adds more examples including an example Lima VM and Elasticsearch, Prometheus, InfluxDB, and an SNMP example using the Lima VM.