### PR TITLE
Destination Agent Info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-ping/ping v0.0.0-20211014180314-6e2b003bffdd
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/gosnmp/gosnmp v1.34.0
+	github.com/gosnmp/gosnmp v1.35.0
 	github.com/honeycombio/libhoney-go v1.15.6
 	github.com/json-iterator/go v1.1.12
 	github.com/judwhite/go-svc v1.2.1
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sasha-s/go-hll v0.0.0-20180522065212-c6eb27aee351
 	github.com/segmentio/kafka-go v0.4.23
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/syndtr/goleveldb v1.0.0
 	google.golang.org/grpc v1.42.0
 	gopkg.in/mcuadros/go-syslog.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/googleapis/gax-go/v2 v2.1.1 h1:dp3bWCh+PPO1zjRRiCSczJav13sBvG4UhNyVTa
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gosnmp/gosnmp v1.34.0 h1:p96iiNTTdL4ZYspPC3leSKXiHfE1NiIYffMu9100p5E=
-github.com/gosnmp/gosnmp v1.34.0/go.mod h1:QWTRprXN9haHFof3P96XTDYc46boCGAh5IXp0DniEx4=
+github.com/gosnmp/gosnmp v1.35.0 h1:EuWWNPxTCdAUx2/NbQcSa3WdNxjzpy4Phv57b4MWpJM=
+github.com/gosnmp/gosnmp v1.35.0/go.mod h1:2AvKZ3n9aEl5TJEo/fFmf/FGO4Nj4cVeEc5yuk88CYc=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0 h1:rgxjzoDmDXw5q8HONgyHhBas4to0/XWRo/gPpJhsUNQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0/go.mod h1:qrJPVzv9YlhsrxJc3P/Q85nr0w1lIRikTl4JlhdDH5w=
@@ -266,8 +266,6 @@ github.com/judwhite/go-svc v1.2.1 h1:a7fsJzYUa33sfDJRF2N/WXhA+LonCEEY8BJb1tuS5tA
 github.com/judwhite/go-svc v1.2.1/go.mod h1:mo/P2JNX8C07ywpP9YtO2gnBgnUiFTHqtsZekJrUuTk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kentik/api-schema-public v0.0.0-20211011204132-acc22cb40b78 h1:7OfbiKWgQA7Z7MLTcRL/LOrr9MjTcDDZSTRst2+mhjo=
-github.com/kentik/api-schema-public v0.0.0-20211011204132-acc22cb40b78/go.mod h1:3eRiIiOwdOkInkMptcgaG5q4AvDjQd7zvQYGM7KeSzc=
 github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945 h1:PCi9E7y4j28fqFMjjAVn97jZ90FpbavvbhKa/FGiDZA=
 github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945/go.mod h1:3eRiIiOwdOkInkMptcgaG5q4AvDjQd7zvQYGM7KeSzc=
 github.com/kentik/go-metrics v0.0.0-20200109025407-4bfd4a9b42c5 h1:1rZ84eG01A0q93bOxVEY38qvJlfbcFlgKboFERP9TRQ=
@@ -396,8 +394,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -357,7 +357,7 @@ func (api *KentikApi) getSynthInfo(ctx context.Context) error {
 	}
 
 	api.synAgents = synAgents
-	api.synAgentsByIP = api.synAgentsByIP
+	api.synAgentsByIP = synAgentsByIP
 	api.synTests = synTests
 	api.Infof("Loaded %d Kentik Tests and %d Agents via API", len(api.synTests), len(api.synAgents))
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -109,6 +109,13 @@ func (api *KentikApi) GetAgent(aid kt.AgentId) *synthetics.Agent {
 	return api.synAgents[aid]
 }
 
+func (api *KentikApi) GetAgentByIP(ip string) *synthetics.Agent {
+	if api == nil {
+		return nil
+	}
+	return api.synAgentsByIP[ip]
+}
+
 func (api *KentikApi) GetDevicesAsMap(cid kt.Cid) map[string]*kt.Device {
 	if api == nil {
 		return nil
@@ -177,15 +184,16 @@ func (api *KentikApi) getDevices(ctx context.Context) error {
 
 type KentikApi struct {
 	logger.ContextL
-	tr         *http.Transport
-	client     *http.Client
-	devices    map[kt.Cid]kt.Devices
-	synAgents  map[kt.AgentId]*synthetics.Agent
-	synTests   map[kt.TestId]*synthetics.Test
-	setTime    time.Time
-	apiTimeout time.Duration
-	synClient  synthetics.SyntheticsAdminServiceClient
-	conf       *kt.KentikConfig
+	tr            *http.Transport
+	client        *http.Client
+	devices       map[kt.Cid]kt.Devices
+	synAgents     map[kt.AgentId]*synthetics.Agent
+	synAgentsByIP map[string]*synthetics.Agent
+	synTests      map[kt.TestId]*synthetics.Test
+	setTime       time.Time
+	apiTimeout    time.Duration
+	synClient     synthetics.SyntheticsAdminServiceClient
+	conf          *kt.KentikConfig
 }
 
 func NewKentikApi(ctx context.Context, conf *kt.KentikConfig, log logger.ContextL) (*KentikApi, error) {
@@ -337,12 +345,19 @@ func (api *KentikApi) getSynthInfo(ctx context.Context) error {
 	}
 
 	synAgents := map[kt.AgentId]*synthetics.Agent{}
+	synAgentsByIP := map[string]*synthetics.Agent{}
 	for _, agent := range ra.GetAgents() {
 		locala := agent
 		synAgents[kt.NewAgentId(agent.GetId())] = locala
+		lip := locala.GetLocalIp() // Store local ip seperately from public one, if a local is set.
+		if lip != "" {
+			synAgentsByIP[lip] = locala
+		}
+		synAgentsByIP[locala.GetIp()] = locala
 	}
 
 	api.synAgents = synAgents
+	api.synAgentsByIP = api.synAgentsByIP
 	api.synTests = synTests
 	api.Infof("Loaded %d Kentik Tests and %d Agents via API", len(api.synTests), len(api.synAgents))
 

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -413,16 +413,19 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]strin
 					dst.CustomStr["src_cloud_provider"] = a.GetCloudProvider()
 					dst.CustomStr["src_site"] = a.GetSiteName()
 
-					// Now, try looking up dest agent by dest IP.
-					if da := kc.apic.GetAgentByIP(dst.DstAddr); da != nil {
-						dst.CustomStr["dst_agent_name"] = da.GetAlias()
-						dst.DstAs = da.GetAsn()
-						dst.DstGeoRegion = da.GetRegion()
-						dst.DstGeoCity = da.GetCity()
-						dst.DstGeo = da.GetCountry()
-						dst.CustomStr["dst_cloud_region"] = da.GetCloudRegion()
-						dst.CustomStr["dst_cloud_provider"] = da.GetCloudProvider()
-						dst.CustomStr["dst_site"] = da.GetSiteName()
+					// Try getting dest agent info also, but we have to use IP to look up.
+					if dst.DstAddr != "" && dst.DstAddr != "<nil>" {
+						if da := kc.apic.GetAgentByIP(dst.DstAddr); da != nil {
+							dst.CustomStr["dst_agent_name"] = da.GetAlias()
+							dst.CustomStr["dst_agent_id"] = da.GetId()
+							dst.DstAs = da.GetAsn()
+							dst.DstGeoRegion = da.GetRegion()
+							dst.DstGeoCity = da.GetCity()
+							dst.DstGeo = da.GetCountry()
+							dst.CustomStr["dst_cloud_region"] = da.GetCloudRegion()
+							dst.CustomStr["dst_cloud_provider"] = da.GetCloudProvider()
+							dst.CustomStr["dst_site"] = da.GetSiteName()
+						}
 					}
 				} else {
 					dst.CustomStr["agent_name"] = ""

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -413,6 +413,17 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]strin
 					dst.CustomStr["src_cloud_provider"] = a.GetCloudProvider()
 					dst.CustomStr["src_site"] = a.GetSiteName()
 
+					// Now, try looking up dest agent by dest IP.
+					if da := kc.apic.GetAgentByIP(dst.DstAddr); da != nil {
+						dst.CustomStr["dst_agent_name"] = da.GetAlias()
+						dst.DstAs = da.GetAsn()
+						dst.DstGeoRegion = da.GetRegion()
+						dst.DstGeoCity = da.GetCity()
+						dst.DstGeo = da.GetCountry()
+						dst.CustomStr["dst_cloud_region"] = da.GetCloudRegion()
+						dst.CustomStr["dst_cloud_provider"] = da.GetCloudProvider()
+						dst.CustomStr["dst_site"] = da.GetSiteName()
+					}
 				} else {
 					dst.CustomStr["agent_name"] = ""
 				}


### PR DESCRIPTION
Adds in destination agent info to synth firehose if found. 

The Dest IP is looked up in a table of Agent IPs. If the IP is found, the target agent info is put into the feed, similar to how source agent info is added. Useful for agent<->agent mesh tests. 

Also bump snmp library version. 