### PR TITLE
Tweaking how bgp version and intrumentation.name get set

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -351,6 +351,9 @@ var (
 		"src_cloud_region":   true,
 		"src_cloud_provider": true,
 		"src_site":           true,
+		"dst_cloud_region":   true,
+		"dst_cloud_provider": true,
+		"dst_site":           true,
 	}
 )
 
@@ -370,6 +373,9 @@ func (f *NRMFormat) fromKSynth(in *kt.JCHF) []NRMetric {
 
 	// Hard code these.
 	attr["instrumentation.name"] = InstNameSynthetic
+	if tt, ok := attr["test_type"]; ok {
+		attr["instrumentation.name"] = tt
+	}
 
 	for k, v := range attr { // White list only a few attributes here.
 		if !synthWLAttr[k] {

--- a/pkg/inputs/snmp/x/arista/eapi.go
+++ b/pkg/inputs/snmp/x/arista/eapi.go
@@ -2,6 +2,7 @@ package arista
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -161,6 +162,7 @@ func (c *EAPIClient) parseBGP(sv *ShowBGP) ([]*kt.JCHF, error) {
 				"peer_state_idle_reason": state.PeerStateIdleReason,
 				"asn":                    vrf.ASN,
 				"peer_asn":               state.ASN,
+				"version":                strconv.Itoa(state.Version),
 			}
 			dst.CustomInt = map[string]int32{}
 			dst.CustomBigInt = map[string]int64{}
@@ -182,9 +184,6 @@ func (c *EAPIClient) parseBGP(sv *ShowBGP) ([]*kt.JCHF, error) {
 
 			dst.CustomBigInt["UpDownTime"] = int64(state.UpDownTime)
 			dst.CustomMetrics["UpDownTime"] = kt.MetricInfo{Oid: "eapi", Mib: "eapi", Profile: "eapi.bgp", Type: "eapi.bgp"}
-
-			dst.CustomBigInt["Version"] = int64(state.Version)
-			dst.CustomMetrics["Version"] = kt.MetricInfo{Oid: "eapi", Mib: "eapi", Profile: "eapi.bgp", Type: "eapi.bgp"}
 
 			dst.CustomBigInt["MsgReceived"] = int64(state.MsgReceived)
 			dst.CustomMetrics["MsgReceived"] = kt.MetricInfo{Oid: "eapi", Mib: "eapi", Profile: "eapi.bgp", Type: "eapi.bgp"}


### PR DESCRIPTION
BGP Version doesn't change so makes sense to make it an attribute.

Updating synth intrumentation.name to allow special handing for different test types. 