### PR TITLE
Add carbon formatter

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -33,7 +33,7 @@ func main() {
 		threads        = flag.Int("threads", 0, "Number of threads to run for processing")
 		threadsInput   = flag.Int("input_threads", 0, "Number of threads to run for input processing")
 		maxThreads     = flag.Int("max_threads", 0, "Dynamically grow threads up to this number")
-		format         = flag.String("format", "flat_json", "Format to convert kflow to: (json|flat_json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
+		format         = flag.String("format", "flat_json", "Format to convert kflow to: (json|flat_json|avro|netflow|influx|carbon|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
 		formatRollup   = flag.String("format_rollup", "", "Format to convert rollups to: (json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
 		compression    = flag.String("compression", "none", "compression algo to use (none|gzip|snappy|deflate|null)")
 		sinks          = flag.String("sinks", "stdout", "List of sinks to send data to. Options: (kafka|stdout|new_relic|kentik|net|http|splunk|prometheus|file|s3|gcloud)")

--- a/pkg/formats/carbon/carbon.go
+++ b/pkg/formats/carbon/carbon.go
@@ -1,0 +1,156 @@
+package carbon
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/kentik/ktranslate/pkg/formats/util"
+	"github.com/kentik/ktranslate/pkg/kt"
+	"github.com/kentik/ktranslate/pkg/rollup"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+)
+
+type CarbonFormat struct {
+	logger.ContextL
+	invalids map[string]bool
+	mux      sync.RWMutex
+}
+
+type CarbonData struct {
+	Type      string
+	Name      string
+	Value     int64
+	Unit      string
+	Tags      map[string]interface{}
+	Timestamp int64
+}
+
+// formatted using http://metrics20.org/spec/
+func (d *CarbonData) String() string {
+	tags := make([]string, len(d.Tags))
+	i := 0
+	for key, v := range d.Tags {
+		kval := strings.ReplaceAll(key, " ", "_")
+		switch t := v.(type) {
+		case string:
+			tags[i] = fmt.Sprintf("%s=%s", kval, strings.ReplaceAll(t, " ", "_"))
+		default:
+			tags[i] = fmt.Sprintf("%s=%v", kval, v)
+		}
+
+		i++
+	}
+
+	return fmt.Sprintf("metric=%s mtype=%s unit=%s  %s %d %d",
+		d.Name,
+		d.Type,
+		d.Unit,
+		strings.Join(tags, " "),
+		d.Value,
+		d.Timestamp)
+}
+
+type CarbonDataSet []CarbonData
+
+func (s CarbonDataSet) Bytes() []byte {
+	res := make([]string, 0)
+	for _, l := range s {
+		res = append(res, l.String())
+	}
+	return []byte(strings.Join(res, "\n"))
+}
+
+func NewFormat(log logger.Underlying, compression kt.Compression) (*CarbonFormat, error) {
+	jf := &CarbonFormat{
+		ContextL: logger.NewContextLFromUnderlying(logger.SContext{S: "carbonFormat"}, log),
+		invalids: map[string]bool{},
+	}
+
+	return jf, nil
+}
+
+func (f *CarbonFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
+	res := make([]CarbonData, 0, len(msgs))
+	for _, m := range msgs {
+		res = append(res, f.toCarbonMetric(m)...)
+	}
+
+	if len(res) == 0 {
+		return nil, nil
+	}
+
+	return kt.NewOutput(CarbonDataSet(res).Bytes()), nil
+}
+
+func (f *CarbonFormat) toCarbonMetric(in *kt.JCHF) []CarbonData {
+	switch in.EventType {
+	case kt.KENTIK_EVENT_TYPE:
+		return f.fromKflow(in)
+	default:
+		f.mux.Lock()
+		defer f.mux.Unlock()
+		if !f.invalids[in.EventType] {
+			f.Warnf("Invalid EventType: %s", in.EventType)
+			f.invalids[in.EventType] = true
+		}
+	}
+
+	return nil
+}
+
+// Not supported
+func (f *CarbonFormat) From(raw *kt.Output) ([]map[string]interface{}, error) {
+	values := make([]map[string]interface{}, 0)
+	return values, nil
+}
+
+// Not supported
+func (f *CarbonFormat) Rollup(rolls []rollup.Rollup) (*kt.Output, error) {
+	return nil, nil
+}
+
+func (f *CarbonFormat) fromKflow(in *kt.JCHF) []CarbonData {
+	attr := map[string]interface{}{}
+	metrics := map[string]kt.MetricInfo{"in_bytes": kt.MetricInfo{}, "out_bytes": kt.MetricInfo{}, "in_pkts": kt.MetricInfo{}, "out_pkts": kt.MetricInfo{}, "latency_ms": kt.MetricInfo{}}
+	util.SetAttr(attr, in, metrics, nil)
+	metricData := []CarbonData{}
+	for m, _ := range metrics {
+		v := int64(0)
+		mtype := ""
+		unit := ""
+		switch m {
+		case "in_bytes":
+			v = int64(in.InBytes * uint64(in.SampleRate))
+			mtype = "rate"
+			unit = "B/s"
+		case "out_bytes":
+			v = int64(in.OutBytes * uint64(in.SampleRate))
+			mtype = "rate"
+			unit = "B/s"
+		case "in_pkts":
+			v = int64(in.InPkts * uint64(in.SampleRate))
+			mtype = "rate"
+			unit = "pckt/s"
+		case "out_pkts":
+			v = int64(in.OutPkts * uint64(in.SampleRate))
+			mtype = "rate"
+			unit = "pckt/s"
+		case "latency_ms":
+			v = int64(in.CustomInt["appl_latency_ms"])
+			mtype = "gauge"
+			unit = "ms"
+		}
+		metricData = append(metricData, CarbonData{
+			Type:      mtype,
+			Name:      m,
+			Value:     v,
+			Unit:      unit,
+			Timestamp: in.Timestamp,
+			Tags:      attr,
+		})
+	}
+
+	return metricData
+}

--- a/pkg/formats/carbon/carbon_test.go
+++ b/pkg/formats/carbon/carbon_test.go
@@ -1,0 +1,30 @@
+package carbon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	lt "github.com/kentik/ktranslate/pkg/eggs/logger/testing"
+	"github.com/kentik/ktranslate/pkg/kt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeriToCarbon(t *testing.T) {
+	serBuf := make([]byte, 0)
+	assert := assert.New(t)
+	l := lt.NewTestContextL(logger.NilContext, t).GetLogger().GetUnderlyingLogger()
+
+	f, err := NewFormat(l, kt.CompressionNone)
+	assert.NoError(err)
+
+	res, err := f.To(kt.InputTesting, serBuf)
+	assert.NoError(err)
+	assert.NotNil(res)
+
+	pts := strings.Split(string(res.Body), "\n")
+	// with the carbon formatter each field (in_bytes, etc) is an individual metric
+	expected := 10
+	assert.Equal(len(pts), expected)
+}

--- a/pkg/formats/format.go
+++ b/pkg/formats/format.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
 
 	"github.com/kentik/ktranslate/pkg/formats/avro"
+	"github.com/kentik/ktranslate/pkg/formats/carbon"
 	"github.com/kentik/ktranslate/pkg/formats/elasticsearch"
 	"github.com/kentik/ktranslate/pkg/formats/influx"
 	"github.com/kentik/ktranslate/pkg/formats/json"
@@ -33,6 +34,7 @@ const (
 	FORMAT_JSON_FLAT            = "flat_json"
 	FORMAT_NETFLOW              = "netflow"
 	FORMAT_INFLUX               = "influx"
+	FORMAT_CARBON               = "carbon"
 	FORMAT_PROM                 = "prometheus"
 	FORMAT_NR                   = "new_relic"
 	FORMAT_NRM                  = "new_relic_metric"
@@ -52,6 +54,8 @@ func NewFormat(format Format, log logger.Underlying, compression kt.Compression)
 		return netflow.NewFormat(log, compression)
 	case FORMAT_INFLUX:
 		return influx.NewFormat(log, compression)
+	case FORMAT_CARBON:
+		return carbon.NewFormat(log, compression)
 	case FORMAT_PROM:
 		return prom.NewFormat(log, compression)
 	case FORMAT_NR, FORMAT_JSON_FLAT:


### PR DESCRIPTION
This adds a new `carbon` formatter, specifically [Carbon 2.0](http://metrics20.org/spec/).

Example Output:

```
metric=in_bytes mtype=rate unit=B/s  device_id=100 Type=kflow dst_addr=192.168.5.15 src_endpoint=216.176.96.90:8080 src_addr=216.176.96.90 sample_rate=1 eventType=KFlow dst_endpoint=192.168.5.15:52454 protocol=TCP provider=kentik-flow-device src_as_name=RTCCOM dst_route_prefix=0.0.0.0 input_port=54429 src_route_prefix=0.0.0.0 src_geo=US src_as=14574 l4_src_port=8080 l4_dst_port=52454 tcp_flags=27 dst_as_name=0 355 1655310976
```