### PR TITLE
#337 -- allow an option to remove non polling snmp devices automatically

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -629,7 +629,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If SNMP is configured, start this system too. Poll for metrics and metadata, also handle traps.
 	if kc.config.SNMPFile != "" {
 		if kc.config.SNMPDisco { // Here, we're just returning the list of devices on the network which might speak snmp.
-			_, err := snmp.Discover(ctx, kc.config.SNMPFile, kc.log)
+			_, err := snmp.Discover(ctx, kc.config.SNMPFile, kc.log, 0)
 			return err
 		}
 		assureInput()

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -365,6 +365,10 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 	if !isTest {
 		removeNum := conf.Global.PurgeDevices
 		for dip, d := range conf.Devices {
+			if d.PurgeDevice != 0 { // Let this override the global settings.
+				removeNum = d.PurgeDevice
+			}
+
 			if removeNum > 0 && pollDuration > 0 {
 				// Get time this would take.
 				removeTime := time.Now().Add(time.Duration(removeNum) * pollDuration * -1)

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	permissions = 0644
+	permissions      = 0644
+	RemoveTimeBuffer = -1 * 15 * 60 * time.Second // This is a 15 min buffer time on removing a device which isn't seen.
 )
 
 type SnmpDiscoDeviceStat struct {
@@ -32,7 +33,7 @@ type SnmpDiscoDeviceStat struct {
 	delta    int
 }
 
-func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (*SnmpDiscoDeviceStat, error) {
+func Discover(ctx context.Context, snmpFile string, log logger.ContextL, pollDuration time.Duration) (*SnmpDiscoDeviceStat, error) {
 	// First, parse the config file and see what we're doing.
 	log.Infof("SNMP Discovery, loading config from %s", snmpFile)
 	conf, err := parseConfig(ctx, snmpFile, log)
@@ -54,7 +55,7 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (*SnmpD
 	}
 
 	if conf.Disco.AddDevices { // Verify that the output is writeable before diving into discoing.
-		if _, err := addDevices(ctx, nil, snmpFile, conf, true, log); err != nil {
+		if _, err := addDevices(ctx, nil, snmpFile, conf, true, log, pollDuration); err != nil {
 			return nil, fmt.Errorf("There was an error when writing the %s SNMP configuration file: %v.", snmpFile, err)
 		}
 	}
@@ -128,7 +129,7 @@ func Discover(ctx context.Context, snmpFile string, log logger.ContextL) (*SnmpD
 
 	var stats *SnmpDiscoDeviceStat
 	if conf.Disco.AddDevices {
-		stats, err = addDevices(ctx, foundDevices, snmpFile, conf, false, log)
+		stats, err = addDevices(ctx, foundDevices, snmpFile, conf, false, log, pollDuration)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +147,7 @@ func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, snmpFile string, log
 	defer discoCheck.Stop()
 
 	check := func() {
-		stats, err := Discover(ctx, snmpFile, log)
+		stats, err := Discover(ctx, snmpFile, log, pt)
 		if err != nil {
 			log.Errorf("Discovery SNMP Error: %v", err)
 		} else {
@@ -302,7 +303,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 	foundDevices[result.Host.String()] = &device
 }
 
-func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, conf *kt.SnmpConfig, isTest bool, log logger.ContextL) (*SnmpDiscoDeviceStat, error) {
+func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, conf *kt.SnmpConfig, isTest bool, log logger.ContextL, pollDuration time.Duration) (*SnmpDiscoDeviceStat, error) {
 	// Now add the new.
 	stats := SnmpDiscoDeviceStat{}
 	if conf.Devices == nil {
@@ -356,6 +357,23 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 				stats.added--
 			} else {
 				byEngineID[d.EngineID] = d
+			}
+		}
+	}
+
+	// Remove any devices which havn't been up long enough if this is set.
+	if !isTest {
+		removeNum := conf.Global.PurgeDevices
+		for dip, d := range conf.Devices {
+			if removeNum > 0 && pollDuration > 0 {
+				// Get time this would take.
+				removeTime := time.Now().Add(time.Duration(removeNum) * pollDuration * -1)
+				removeTime = removeTime.Add(RemoveTimeBuffer)
+				if d.Checked.Before(removeTime) {
+					log.Warnf("Removing device %s because it hasn't been seen since %v. Max time %v", d.DeviceName, d.Checked, removeTime)
+					delete(conf.Devices, dip)
+					stats.added--
+				}
 			}
 		}
 	}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -186,6 +186,7 @@ type SnmpDeviceConfig struct {
 	RunPing             bool              `yaml:"response_time,omitempty"`
 	Ext                 *ExtensionSet     `yaml:"ext,omitempty"`
 	PingSec             int               `yaml:"ping_interval_sec,omitempty"`
+	PurgeDevice         int               `yaml:"purge_after_num"` // Delete this device if its not seen after X discovery attempts. Default is 0, which means things never get purged unless global value is true. Set to -1 to pin device always.
 	allUserTags         map[string]string
 	walker              SNMPTestWalker
 }
@@ -572,6 +573,9 @@ func (d *SnmpDeviceConfig) UpdateFrom(old *SnmpDeviceConfig, conf *SnmpConfig) {
 	}
 	if old.RunPing {
 		d.RunPing = old.RunPing
+	}
+	if old.PurgeDevice != 0 {
+		d.PurgeDevice = old.PurgeDevice
 	}
 	if d.UserTags == nil && old.UserTags != nil {
 		d.UserTags = map[string]string{}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -228,6 +228,7 @@ type SnmpGlobalConfig struct {
 	GlobalV3      *V3SNMPConfig     `yaml:"global_v3"`
 	RunPing       bool              `yaml:"response_time"`
 	PingSec       int               `yaml:"ping_interval_sec,omitempty"`
+	PurgeDevices  int               `yaml:"purge_devices_after_num"` // Delete any device if its not seen after X discovery attempts. Default is 0, which means things never get purged.
 	UserTags      map[string]string `yaml:"user_tags"`
 	MatchAttr     map[string]string `yaml:"match_attributes"`
 }


### PR DESCRIPTION
Looking at #337, ways to allow non found devices to be removed. 

Adding a config `global.purge_devices_after_num` which means that after N times that a device isn't seen in snmp polling, it will be removed. Doesn't do anything by default. Also right now will not do anything in a normal discovery, only auto-removes when the `-snmp_discovery_min` flag is set. 

Q: Is this what we want? Possibly should also remove on a normal discovery? 