### PR TITLE
Add "i" suffix to int field values in influx line

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -34,7 +34,7 @@ func (d *InfluxData) String() string {
 	fields := make([]string, len(d.Fields)+len(d.FieldsFloat))
 	i := 0
 	for k, v := range d.Fields {
-		fields[i] = k + "=" + strconv.FormatInt(v, 10)
+		fields[i] = k + "=" + strconv.FormatInt(v, 10) + "i"
 		i++
 	}
 	for k, v := range d.FieldsFloat {


### PR DESCRIPTION
Influx line protocol (specifically https://github.com/influxdata/line-protocol, the go package for parsing it) treats numeric field values as floats unless they have an `i` suffix. As SNMP counters are likely to overflow the $2^{53}$ integer precision of float64, this is important.