### PR TITLE
Support for or-ing filters together #347

### DIFF
--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -96,7 +96,7 @@ type KTranslate struct {
 	rollups      []rollup.Roller
 	doRollups    bool
 	doFilter     bool
-	filters      []filter.Filter
+	filters      []filter.FilterWrapper
 	geo          *patricia.MMMap
 	asn          *patricia.MMMap
 	resolver     *resolv.Resolver

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -19,6 +19,8 @@ const (
 	String FilterType = "string"
 	Int               = "int"
 	Addr              = "addr"
+
+	OrToken = " or "
 )
 
 var (
@@ -33,6 +35,8 @@ type Filter interface {
 	Filter(*kt.JCHF) bool
 }
 
+type FilterWrapper []Filter
+
 type FilterDef struct {
 	Dimension string
 	Operator  Operator
@@ -40,11 +44,21 @@ type FilterDef struct {
 	FType     FilterType
 }
 
+type FilterDefWrapper []FilterDef
+
 func (f *FilterDef) String() string {
 	return fmt.Sprintf("%s Filter: %s %s %s", f.FType, f.Dimension, f.Operator, f.Value)
 }
 
-type FilterFlag []FilterDef
+func (f FilterDefWrapper) String() string {
+	set := make([]string, len(f))
+	for i, f := range f {
+		set[i] = f.String()
+	}
+	return strings.Join(set, OrToken)
+}
+
+type FilterFlag []FilterDefWrapper
 
 func (ff *FilterFlag) String() string {
 	pts := make([]string, len(*ff))
@@ -55,49 +69,68 @@ func (ff *FilterFlag) String() string {
 }
 
 func (i *FilterFlag) Set(value string) error {
-	pts := strings.Split(value, ",")
-	if len(pts) < 4 {
-		return fmt.Errorf("Filter flag is defined by type dimension operator value")
+	inner := FilterDefWrapper{}
+	for _, orSet := range strings.Split(value, OrToken) {
+		pts := strings.Split(orSet, ",")
+		if len(pts) < 4 {
+			return fmt.Errorf("Filter flag is defined by type dimension operator value")
+		}
+		ptn := make([]string, len(pts))
+		for i, p := range pts {
+			ptn[i] = strings.TrimSpace(p)
+		}
+		inner = append(inner, FilterDef{
+			FType:     FilterType(ptn[0]),
+			Dimension: ptn[1],
+			Operator:  Operator(ptn[2]),
+			Value:     ptn[3],
+		})
 	}
-	ptn := make([]string, len(pts))
-	for i, p := range pts {
-		ptn[i] = strings.TrimSpace(p)
-	}
-	*i = append(*i, FilterDef{
-		FType:     FilterType(ptn[0]),
-		Dimension: ptn[1],
-		Operator:  Operator(ptn[2]),
-		Value:     ptn[3],
-	})
+	*i = append(*i, inner)
+
 	return nil
 }
 
-func GetFilters(log logger.Underlying) ([]Filter, error) {
-	filterSet := make([]Filter, 0)
-	for _, fd := range filters {
-		switch fd.FType {
-		case String:
-			newf, err := newStringFilter(log, fd)
-			if err != nil {
-				return nil, err
+func GetFilters(log logger.Underlying) ([]FilterWrapper, error) {
+	filterSet := make([]FilterWrapper, 0)
+	for _, fSet := range filters {
+		orSet := []Filter{}
+		for _, fd := range fSet {
+			switch fd.FType {
+			case String:
+				newf, err := newStringFilter(log, fd)
+				if err != nil {
+					return nil, err
+				}
+				orSet = append(orSet, newf)
+			case Int:
+				newf, err := newIntFilter(log, fd)
+				if err != nil {
+					return nil, err
+				}
+				orSet = append(orSet, newf)
+			case Addr:
+				newf, err := newAddrFilter(log, fd)
+				if err != nil {
+					return nil, err
+				}
+				orSet = append(orSet, newf)
+			default:
+				return nil, fmt.Errorf("Invalid type: %s. Valid Types: %s|%s|%s", fd.FType, String, Int, Addr)
 			}
-			filterSet = append(filterSet, newf)
-		case Int:
-			newf, err := newIntFilter(log, fd)
-			if err != nil {
-				return nil, err
-			}
-			filterSet = append(filterSet, newf)
-		case Addr:
-			newf, err := newAddrFilter(log, fd)
-			if err != nil {
-				return nil, err
-			}
-			filterSet = append(filterSet, newf)
-		default:
-			return nil, fmt.Errorf("Invalid type: %s. Valid Types: %s|%s|%s", fd.FType, String, Int, Addr)
 		}
+		filterSet = append(filterSet, orSet)
 	}
 
 	return filterSet, nil
+}
+
+// This provides and OR wrapper, returning true if any of the filters in this wrapper eval to true.
+func (fs FilterWrapper) Filter(chf *kt.JCHF) bool {
+	for _, f := range fs {
+		if f.Filter(chf) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -13,42 +13,44 @@ import (
 func TestFilter(t *testing.T) {
 	l := lt.NewTestContextL(logger.NilContext, t).GetLogger().GetUnderlyingLogger()
 	assert := assert.New(t)
-	filters = []FilterDef{
-		FilterDef{
-			Dimension: "src_addr",
-			Operator:  "==",
-			Value:     "10.2.2.1",
-			FType:     "string",
-		},
-		FilterDef{
-			Dimension: "custom_bigint.fooII",
-			Operator:  "==",
-			Value:     "12",
-			FType:     "int",
-		},
-		FilterDef{
-			Dimension: "src_addr",
-			Operator:  "%",
-			Value:     "10.2.2.0/24",
-			FType:     "addr",
-		},
-		FilterDef{
-			Dimension: "src_addr",
-			Operator:  "%",
-			Value:     "10.2.3.0/24",
-			FType:     "addr",
-		},
-		FilterDef{
-			Dimension: "custom_bigint.foo",
-			Operator:  "!=",
-			Value:     "13",
-			FType:     "int",
-		},
-		FilterDef{
-			Dimension: "src_addr",
-			Operator:  "%",
-			Value:     "10.2",
-			FType:     "string",
+	filters = []FilterDefWrapper{
+		[]FilterDef{
+			FilterDef{
+				Dimension: "src_addr",
+				Operator:  "==",
+				Value:     "10.2.2.1",
+				FType:     "string",
+			},
+			FilterDef{
+				Dimension: "custom_bigint.fooII",
+				Operator:  "==",
+				Value:     "12",
+				FType:     "int",
+			},
+			FilterDef{
+				Dimension: "src_addr",
+				Operator:  "%",
+				Value:     "10.2.2.0/24",
+				FType:     "addr",
+			},
+			FilterDef{
+				Dimension: "src_addr",
+				Operator:  "%",
+				Value:     "10.2.3.0/24",
+				FType:     "addr",
+			},
+			FilterDef{
+				Dimension: "custom_bigint.foo",
+				Operator:  "!=",
+				Value:     "13",
+				FType:     "int",
+			},
+			FilterDef{
+				Dimension: "src_addr",
+				Operator:  "%",
+				Value:     "10.2",
+				FType:     "string",
+			},
 		},
 	}
 	fs, err := GetFilters(l)


### PR DESCRIPTION
Allow OR'ing filters together like

```
--filters 'int,input_port,==,4 or int,output_port,==,0'
```

This will create 2 filters, which will pass if either one is true. 

Between `--filters` flags, current AND logic applies. So for example:

```
--filters 'int,input_port,==,4 or int,output_port,==,0' --filters 'int,protocol,==,7'
```

Will pass if (input_port = 4 OR output_port = 0) AND (protocol = 7)

Note -- the or string is ` or ` with the 2 spaces being required. 
