### PR TITLE
Allow some mibs to be set conditionally

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics_test.go
+++ b/pkg/inputs/snmp/metrics/device_metrics_test.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/kentik/ktranslate/pkg/inputs/snmp/mibs"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func TestCheckCondition(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := map[string]bool{
+		"":         true,
+		"name1=2":  false,
+		"name1=66": true,
+	}
+
+	resultSet := []wrapper{
+		wrapper{
+			oid:      "1.2",
+			mib:      &kt.Mib{Tag: "name1"},
+			variable: gosnmp.SnmpPDU{Value: 66, Name: "1.2.5"},
+		},
+		wrapper{
+			oid:      "1.1",
+			mib:      &kt.Mib{Tag: "name2"},
+			variable: gosnmp.SnmpPDU{Value: 3, Name: "1.1.5"},
+		},
+	}
+
+	for in, expt := range tests {
+		oid := mibs.OID{Condition: in}
+		mib := &kt.Mib{
+			Condition: oid.GetCondition(),
+			Tag:       "name2",
+		}
+		w := wrapper{
+			variable: gosnmp.SnmpPDU{Value: 3, Name: "1.1.5"},
+			mib:      mib,
+			oid:      "1.1",
+		}
+
+		res := w.checkCondition(".5", resultSet)
+		assert.Equal(expt, res, "%s", in)
+	}
+}

--- a/pkg/inputs/snmp/metrics/device_metrics_test.go
+++ b/pkg/inputs/snmp/metrics/device_metrics_test.go
@@ -35,7 +35,7 @@ func TestCheckCondition(t *testing.T) {
 	for in, expt := range tests {
 		oid := mibs.OID{Condition: in}
 		mib := &kt.Mib{
-			Condition: oid.GetCondition(),
+			Condition: oid.GetCondition(nil),
 			Tag:       "name2",
 		}
 		w := wrapper{

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -875,7 +875,7 @@ func (o *OID) GetCondition(log logger.ContextL) *kt.MibCondition {
 		if len(pts) == 2 {
 			val, err := strconv.Atoi(pts[1])
 			if err != nil {
-				log.Errorf("Skipping invalid profile condition in %s: %s. RHS (%s) must be an int.", o.Name, o.Condition, pts[1])
+				log.Errorf("Skipping invalid profile condition in %s: %s. RHS (%s) must be an int and operator must be '='.", o.Name, o.Condition, pts[1])
 			} else {
 				return &kt.MibCondition{
 					TargetName:  pts[0],
@@ -883,7 +883,7 @@ func (o *OID) GetCondition(log logger.ContextL) *kt.MibCondition {
 				}
 			}
 		} else {
-			log.Errorf("Skipping invalid profile condition in %s: %s", o.Name, o.Condition)
+			log.Errorf("Skipping invalid profile condition in %s: %s. RHS must be an int and operator must be '='.", o.Name, o.Condition)
 		}
 	}
 	return nil

--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ type OID struct {
 	MatchAttr  []string         `yaml:"match_attributes,omitempty"`
 	Format     string           `yaml:"format,omitempty"`
 	AllowDup   bool             `yaml:"allow_duplicate,omitempty"`
+	Condition  string           `yaml:"condition,omitempty"`
 }
 
 type Tag struct {
@@ -436,6 +438,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				FromExtended: metric.fromExtended,
 				Format:       metric.Symbol.Format,
 				AllowDup:     metric.Symbol.AllowDup,
+				Condition:    metric.Symbol.GetCondition(),
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -458,6 +461,9 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				p.Warnf("Skipping mib with no name: %v", mib)
 				continue
 			}
+			if mib.Condition != nil {
+				p.Infof("SNMP: Condition of %s=%d for %s", mib.Condition.TargetName, mib.Condition.TargetValue, mib.Name)
+			}
 			if metric.IsInterface || strings.HasPrefix(metric.Symbol.Name, "if") {
 				interfaceMetrics[metric.Symbol.Oid] = mib
 			} else {
@@ -478,6 +484,7 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 				FromExtended: metric.fromExtended,
 				Format:       s.Format,
 				AllowDup:     s.AllowDup,
+				Condition:    s.GetCondition(),
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)
@@ -499,6 +506,9 @@ func (p *Profile) GetMetrics(enabledMibs []string, counterTimeSec int) (map[stri
 			if mib.Name == "" {
 				p.Warnf("Skipping mib with no name: %v", mib)
 				continue
+			}
+			if mib.Condition != nil {
+				p.Infof("SNMP: Condition of %s=%d for %s", mib.Condition.TargetName, mib.Condition.TargetValue, mib.Name)
 			}
 			if metric.IsInterface || strings.HasPrefix(s.Name, "if") {
 				interfaceMetrics[s.Oid] = mib
@@ -857,4 +867,18 @@ func (o *OID) GetTableName() string {
 		return o.Name[0 : len(o.Name)-5]
 	}
 	return o.Name
+}
+
+func (o *OID) GetCondition() *kt.MibCondition {
+	if o.Condition != "" {
+		pts := strings.Split(o.Condition, "=")
+		if len(pts) == 2 {
+			val, _ := strconv.Atoi(pts[1])
+			return &kt.MibCondition{
+				TargetName:  pts[0],
+				TargetValue: int64(val),
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -318,6 +318,11 @@ const (
 	Integer32         = 16
 )
 
+type MibCondition struct {
+	TargetName  string
+	TargetValue int64
+}
+
 type Mib struct {
 	Oid          string
 	Name         string
@@ -336,6 +341,7 @@ type Mib struct {
 	OtherTables  map[string]bool
 	Format       string
 	AllowDup     bool
+	Condition    *MibCondition
 }
 
 func (mb *Mib) String() string {


### PR DESCRIPTION
Per #342 , need to be able to drop some rows if a condition is not met. 

This sets up a mib like:

```
      - OID: 1.3.6.1.4.1.2021.10.1.5.1
        name: laLoadInt1
        poll_time_sec: 60
        tag: CPU
        condition: MemoryCache=4
```

The `condition` attribute means that for this metric, only when the corresponding metric is set for a common index will this metric get passed on. Looking at the issue for example:

```
standby status
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.3.68157449 = INTEGER: 2 ## hot standby
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.3.69206025 = INTEGER: 4 ## providing service

cpu usage
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.5.68157449 = INTEGER: 10
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.5.69206025 = INTEGER: 29

memory usage
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.7.68157449 = INTEGER: 13
1.3.6.1.4.1.2011.5.25.31.1.1.1.1.7.69206025 = INTEGER: 52
```

We only want to pass on memory usage and cpu usage when this condition (standby status) = 4

To make this work, set this value in the snmp profile section for memory and cpu:

`condition: StandbyStatus=4` 

Then, if and only if there's a metric with the name of StandbyStatus, and if this metric has a common index with me, and this metric value is 4 will I get passed on. 
