### PR TITLE
Allow user to customize names of ent fields

### DIFF
--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -37,6 +37,7 @@ type KentikDriver struct {
 	registry     go_metrics.Registry
 	resolv       *resolv.Resolver
 	ctx          context.Context
+	config       *EntConfig
 }
 
 type FlowMetric struct {
@@ -60,6 +61,10 @@ func NewKentikDriver(ctx context.Context, proto FlowSource, maxBatchSize int, lo
 	}
 	go kt.run(ctx) // Process flows and send them on.
 	return &kt
+}
+
+func (t *KentikDriver) SetConfig(c *EntConfig) {
+	t.config = c
 }
 
 func (t *KentikDriver) Init(ctx context.Context) error {
@@ -246,25 +251,25 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 		case "MPLSLastLabel":
 			in.CustomBigInt[field] = int64(fmsg.MPLSLastLabel)
 		case "CustomInteger1":
-			in.CustomBigInt[field] = int64(fmsg.CustomInteger1)
+			in.CustomBigInt[t.config.NameMap[field]] = int64(fmsg.CustomInteger1)
 		case "CustomInteger2":
-			in.CustomBigInt[field] = int64(fmsg.CustomInteger2)
+			in.CustomBigInt[t.config.NameMap[field]] = int64(fmsg.CustomInteger2)
 		case "CustomInteger3":
-			in.CustomBigInt[field] = int64(fmsg.CustomInteger3)
+			in.CustomBigInt[t.config.NameMap[field]] = int64(fmsg.CustomInteger3)
 		case "CustomInteger4":
-			in.CustomBigInt[field] = int64(fmsg.CustomInteger4)
+			in.CustomBigInt[t.config.NameMap[field]] = int64(fmsg.CustomInteger4)
 		case "CustomInteger5":
-			in.CustomBigInt[field] = int64(fmsg.CustomInteger5)
+			in.CustomBigInt[t.config.NameMap[field]] = int64(fmsg.CustomInteger5)
 		case "CustomBytes1":
-			in.CustomStr[field] = fmt.Sprintf("%s", string(fmsg.CustomBytes1))
+			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes1))
 		case "CustomBytes2":
-			in.CustomStr[field] = fmt.Sprintf("%s", string(fmsg.CustomBytes2))
+			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes2))
 		case "CustomBytes3":
-			in.CustomStr[field] = fmt.Sprintf("%s", string(fmsg.CustomBytes3))
+			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes3))
 		case "CustomBytes4":
-			in.CustomStr[field] = fmt.Sprintf("%s", string(fmsg.CustomBytes4))
+			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes4))
 		case "CustomBytes5":
-			in.CustomStr[field] = fmt.Sprintf("%s", string(fmsg.CustomBytes5))
+			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes5))
 		}
 	}
 


### PR DESCRIPTION
Support user ability to re-map ent fields into user defined names. (Instead of CustomBytes1 and so on).

Supports a config file like

```
{
  "flow_config": {
    "ipfix": {
      "mapping": [
        {
          "field": 801,
          "destination": "CustomInteger1",
          "penprovided": true,
          "pen": 9
        },
        {
          "field": 802,
          "destination": "CustomBytes1",
          "penprovided": true,
          "pen": 9
        },
        {
          "field": 803,
          "destination": "CustomBytes2",
          "penprovided": true,
          "pen": 9
        },
        {
          "field": 804,
          "destination": "CustomBytes3",
          "penprovided": true,
          "pen": 9
        },
        {
          "field": 805,
          "destination": "CustomBytes4",
          "penprovided": true,
          "pen": 9
        }
      ]
    }
  },
  "name_map": {
    "CustomInteger1": "VPC Log Version",
    "CustomBytes1": "AWS Account",
    "CustomBytes2": "AWS Interface",
    "CustomBytes3": "AWS Action",
    "CustomBytes4": "AWS Log Status"
  }
}
```

If the NameMap entry isn't found for a given field, the destination isn't updated. 

This also extends support for Netflow9 and SFlow custom fields. See https://github.com/netsampler/goflow2/blob/main/docs/protocols.md#add-new-custom-fields for more information. 

