### PR TITLE
Fix latency loss meraki, Also fix mixed v2/v3 snmp creds

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -223,27 +223,29 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 	}
 
 	// Loop over all possibe v2c options here if any are set.
-	for _, community := range conf.Disco.DefaultCommunities {
-		device = kt.SnmpDeviceConfig{
-			DeviceName: result.Name,
-			DeviceIP:   result.Host.String(),
-			Community:  community,
-			UseV1:      conf.Disco.UseV1,
-			Debug:      conf.Disco.Debug,
-			Port:       uint16(conf.Disco.Ports[0]),
-			Checked:    time.Now(),
+	if md == nil { // Only check these if v3 hasn't found anything.
+		for _, community := range conf.Disco.DefaultCommunities {
+			device = kt.SnmpDeviceConfig{
+				DeviceName: result.Name,
+				DeviceIP:   result.Host.String(),
+				Community:  community,
+				UseV1:      conf.Disco.UseV1,
+				Debug:      conf.Disco.Debug,
+				Port:       uint16(conf.Disco.Ports[0]),
+				Checked:    time.Now(),
+			}
+			serv, err := snmp_util.InitSNMP(&device, timeout, conf.Global.Retries, posit, log)
+			if err != nil {
+				log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
+				return
+			}
+			md, err = metadata.GetBasicDeviceMetadata(log, serv)
+			if err != nil {
+				log.Warnf("Cannot get device metadata on %s: %v. Check for correct snmp credentials.", result.Host.String(), err)
+				continue
+			}
+			break // We're good to go here.
 		}
-		serv, err := snmp_util.InitSNMP(&device, timeout, conf.Global.Retries, posit, log)
-		if err != nil {
-			log.Warnf("There was an error when starting SNMP interface component -- %v.", err)
-			return
-		}
-		md, err = metadata.GetBasicDeviceMetadata(log, serv)
-		if err != nil {
-			log.Warnf("Cannot get device metadata on %s: %v. Check for correct snmp credentials.", result.Host.String(), err)
-			continue
-		}
-		break // We're good to go here.
 	}
 
 	if md == nil { // No way to establish comminications

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -674,6 +674,11 @@ func getUsage(u uplink) (int64, int64) {
 func getLatencyLoss(u uplink) (float64, float64) {
 	latency := float64(0)
 	loss := float64(0)
+
+	if len(u.LatencyLoss.TimeSeries) == 0 { // Kinda a noop but 0 is best here.
+		return 0, 0
+	}
+
 	for _, t := range u.LatencyLoss.TimeSeries {
 		latency += t.LatencyMS
 		loss += t.LossPercent


### PR DESCRIPTION
2 parts here.

1) Fixing a case where having mixed v2 and v3 snmp creds will case valid v3 creds to get skipped. 

2) Adding a guard for meraki API so that empty lists will not create a NaN value via divide by 0.