### PR TITLE
Allow global user tags to be defined on a per provider basis

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -209,11 +209,17 @@ func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 			}
 		}
 
-		// Tweak any per provider tags here.
+		// Tweak any per provider tags and match attributes here.
 		for key, tag := range device.UserTags {
 			delete(device.UserTags, key)
 			if nk, ok := matchesPrefix(key, device.Provider); ok {
 				device.UserTags[nk] = tag // We do use this tag, go ahead and update the value to the one returned.
+			}
+		}
+		for key, match := range device.MatchAttr {
+			delete(device.MatchAttr, key)
+			if nk, ok := matchesPrefix(key, device.Provider); ok {
+				device.MatchAttr[nk] = match // We do use this match, go ahead and update the value to the one returned.
 			}
 		}
 

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -205,18 +205,7 @@ func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JC
 		}
 
 		// Tweak any per provider tags and match attributes here.
-		for key, tag := range device.UserTags {
-			delete(device.UserTags, key)
-			if nk, ok := matchesPrefix(key, device.Provider); ok {
-				device.UserTags[nk] = tag // We do use this tag, go ahead and update the value to the one returned.
-			}
-		}
-		for key, match := range device.MatchAttr {
-			delete(device.MatchAttr, key)
-			if nk, ok := matchesPrefix(key, device.Provider); ok {
-				device.MatchAttr[nk] = match // We do use this match, go ahead and update the value to the one returned.
-			}
-		}
+		setDeviceTagsAndMatch(device)
 
 		// Create this device in Kentik if the option is set.
 		err := apic.EnsureDevice(ctx, device)
@@ -470,4 +459,19 @@ func matchesPrefix(tag string, provider kt.Provider) (string, bool) {
 	}
 
 	return "", false
+}
+
+func setDeviceTagsAndMatch(device *kt.SnmpDeviceConfig) {
+	for key, tag := range device.UserTags {
+		delete(device.UserTags, key)
+		if nk, ok := matchesPrefix(key, device.Provider); ok {
+			device.UserTags[nk] = tag // We do use this tag, go ahead and update the value to the one returned.
+		}
+	}
+	for key, match := range device.MatchAttr {
+		delete(device.MatchAttr, key)
+		if nk, ok := matchesPrefix(key, device.Provider); ok {
+			device.MatchAttr[nk] = match // We do use this match, go ahead and update the value to the one returned.
+		}
+	}
 }

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -50,6 +50,14 @@ func TestSetTagsMatch(t *testing.T) {
 							"match": "provider",
 						},
 					},
+					"bar": kt.ProviderMap{
+						UserTags: map[string]string{
+							"tag": "provider",
+						},
+						MatchAttr: map[string]string{
+							"match": "provider",
+						},
+					},
 				},
 			},
 			Devices: map[string]*kt.SnmpDeviceConfig{
@@ -82,7 +90,7 @@ func TestSetTagsMatch(t *testing.T) {
 				},
 			},
 		},
-		"two": kt.SnmpConfig{
+		"two": kt.SnmpConfig{ // No provider, just gobal and device.
 			Global: &kt.SnmpGlobalConfig{
 				UserTags: map[string]string{
 					"tag": "global",
@@ -116,7 +124,7 @@ func TestSetTagsMatch(t *testing.T) {
 
 	for test, ms := range tests {
 		for p, m := range ms.Global.ProviderMap {
-			m.Init(p, ms.Global) // Set up any provider based user and match tags here.
+			m.Init(p, &ms) // Set up any provider based user and match tags here.
 		}
 		for k, v := range ms.Global.UserTags {
 			for _, device := range ms.Devices {
@@ -141,8 +149,8 @@ func TestSetTagsMatch(t *testing.T) {
 
 		for expt, device := range ms.Devices {
 			setDeviceTagsAndMatch(device)
-			assert.Equal(expt, device.UserTags["tag"], "%s -> %s", test, device.Provider)
-			assert.Equal(expt, device.MatchAttr["match"], "%s -> %s", test, device.Provider)
+			assert.Equal(expt, device.UserTags["tag"], "%s -> %s %v", test, device.Provider, device.UserTags)
+			assert.Equal(expt, device.MatchAttr["match"], "%s -> %s %v", test, device.Provider, device.MatchAttr)
 		}
 	}
 }

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -82,9 +82,39 @@ func TestSetTagsMatch(t *testing.T) {
 				},
 			},
 		},
+		"two": kt.SnmpConfig{
+			Global: &kt.SnmpGlobalConfig{
+				UserTags: map[string]string{
+					"tag": "global",
+				},
+				MatchAttr: map[string]string{
+					"match": "global",
+				},
+			},
+			Devices: map[string]*kt.SnmpDeviceConfig{
+				"device": &kt.SnmpDeviceConfig{
+					Provider: "foo",
+					UserTags: map[string]string{
+						"tag": "device", // This should be device tag because its set at device level.
+					},
+					MatchAttr: map[string]string{
+						"match": "device",
+					},
+				},
+				"global": &kt.SnmpDeviceConfig{
+					Provider: "fooA",
+					UserTags: map[string]string{
+						"tagA": "device", // This should fall back to global level because niether provider or device set.
+					},
+					MatchAttr: map[string]string{
+						"matchA": "device",
+					},
+				},
+			},
+		},
 	}
 
-	for _, ms := range tests {
+	for test, ms := range tests {
 		for p, m := range ms.Global.ProviderMap {
 			m.Init(p, ms.Global) // Set up any provider based user and match tags here.
 		}
@@ -111,8 +141,8 @@ func TestSetTagsMatch(t *testing.T) {
 
 		for expt, device := range ms.Devices {
 			setDeviceTagsAndMatch(device)
-			assert.Equal(expt, device.UserTags["tag"], "%s", device.Provider)
-			assert.Equal(expt, device.MatchAttr["match"], "%s", device.Provider)
+			assert.Equal(expt, device.UserTags["tag"], "%s -> %s", test, device.Provider)
+			assert.Equal(expt, device.MatchAttr["match"], "%s -> %s", test, device.Provider)
 		}
 	}
 }

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -120,6 +120,29 @@ func TestSetTagsMatch(t *testing.T) {
 				},
 			},
 		},
+		"three": kt.SnmpConfig{ // No provider, just gobal and device.
+			Global: &kt.SnmpGlobalConfig{},
+			Devices: map[string]*kt.SnmpDeviceConfig{
+				"device": &kt.SnmpDeviceConfig{
+					Provider: "foo",
+					UserTags: map[string]string{
+						"tag": "device", // This should be device tag because its set at device level.
+					},
+					MatchAttr: map[string]string{
+						"match": "device",
+					},
+				},
+				"": &kt.SnmpDeviceConfig{
+					Provider: "fooA",
+					UserTags: map[string]string{
+						"tagA": "device", // This should fall back to global level because niether provider or device set.
+					},
+					MatchAttr: map[string]string{
+						"matchA": "device",
+					},
+				},
+			},
+		},
 	}
 
 	for test, ms := range tests {

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,18 +12,19 @@ import (
 func TestMatchesPrefix(t *testing.T) {
 	assert := assert.New(t)
 
-	tests := map[string]bool{
-		"tagName":               true,
-		"provider:tagName":      true,
-		"provider:foo:tagName":  true,
-		"provider:bar:tagName":  false,
-		"provider:foo:tagName1": true,
+	tests := map[string][]string{
+		"tagName":               []string{"tagName", "true"},
+		"provider:tagName":      []string{"provider:tagName", "true"},
+		"provider:foo:tagName":  []string{"tagName", "true"},
+		"provider:bar:tagName":  []string{"", "false"},
+		"provider:foo:tagName1": []string{"tagName1", "true"},
 	}
 
 	provider := kt.Provider("foo")
 
 	for in, expt := range tests {
-		res := matchesPrefix(in, provider)
-		assert.Equal(expt, res, "%s <-> %s", in, provider)
+		newTag, res := matchesPrefix(in, provider)
+		assert.Equal(expt[0], newTag, "%s <-> %s", in, provider)
+		assert.Equal(expt[1], fmt.Sprintf("%v", res), "%s <-> %s", in, provider)
 	}
 }

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -1,0 +1,28 @@
+package snmp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func TestMatchesPrefix(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := map[string]bool{
+		"tagName":               true,
+		"provider:tagName":      true,
+		"provider:foo:tagName":  true,
+		"provider:bar:tagName":  false,
+		"provider:foo:tagName1": true,
+	}
+
+	provider := kt.Provider("foo")
+
+	for in, expt := range tests {
+		res := matchesPrefix(in, provider)
+		assert.Equal(expt, res, "%s <-> %s", in, provider)
+	}
+}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -239,7 +239,7 @@ type SnmpGlobalConfig struct {
 	PurgeDevices  int                    `yaml:"purge_devices_after_num"` // Delete any device if its not seen after X discovery attempts. Default is 0, which means things never get purged.
 	UserTags      map[string]string      `yaml:"user_tags"`
 	MatchAttr     map[string]string      `yaml:"match_attributes"`
-	ProviderMap   map[string]ProviderMap `yaml:"provider_maps"`
+	ProviderMap   map[string]ProviderMap `yaml:"providers"`
 }
 
 type SnmpConfig struct {


### PR DESCRIPTION
This allows the global tags setting for snmp to be prefixed with a given provider. Only devices who have this provider will get assigned these tags. Currently uses the form `provider:foo:tagName` to prefix these. If the provider is `foo`, then the tag `tagName` will get applied. 