### PR TITLE
Support wildcards in trap oids

### DIFF
--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -77,9 +77,19 @@ func (db *MibDB) Close() {
 }
 
 func (db *MibDB) GetTrap(oid string) *Trap {
-	if t, ok := db.traps[oid]; ok {
+	if t, ok := db.traps[oid]; ok { // If things directly match, return right away.
 		return &t
 	}
+
+	// Now walk resursivly up the tree, seeing what profiles are found via a wildcard
+	pts := strings.Split(oid, ".")
+	for i := len(pts); i > 0; i-- {
+		check := strings.Join(pts[0:i], ".") + ".*"
+		if t, ok := db.traps[check]; ok {
+			return &t
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -154,6 +154,10 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 				dst.CustomStr["TrapOID"] = toid
 				if trap != nil {
 					dst.CustomStr["TrapName"] = trap.Name
+					idx := snmp_util.GetIndex(toid, trap.Oid)
+					if idx != "" {
+						dst.CustomStr["Index"] = idx
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses https://github.com/kentik/snmp-profiles/pull/365

This allows trap oids like 

```
  - trap_oid: 1.3.6.1.6.3.1.1.5.5.*
    trap_name: authenticationFailure
```

Where any oid with the prefix of 1.3.6.1.6.3.1.1.5.5 will get matched with this trap. 

I think this will allow the linked issue to get closed. 


