### PR TITLE
chore/nr snmp base

### DIFF
--- a/deployment/docker/snmp-base-nr.yaml
+++ b/deployment/docker/snmp-base-nr.yaml
@@ -1,0 +1,27 @@
+# Recommended default minimalist config for sending data to New Relic
+---
+devices:
+trap:
+  listen: 127.0.0.1:1620
+  community: hello
+discovery:
+  cidrs:
+  - 10.10.0.0/24
+  ignore_list: []
+  debug: false
+  ports:
+  - 161
+  default_communities:
+  - public
+  default_v3: null
+  add_devices: true
+  add_mibs: true
+  threads: 4
+  replace_devices: true
+  check_all_ips: true
+global:
+  poll_time_sec: 300
+  mibs_enabled:
+  - IF-MIB
+  timeout_ms: 3000
+  retries: 0

--- a/deployment/docker/snmp-base-nr.yaml
+++ b/deployment/docker/snmp-base-nr.yaml
@@ -20,6 +20,7 @@ discovery:
   check_all_ips: true
 global:
   poll_time_sec: 300
+  mib_profile_dir: /etc/ktranslate/profiles
   mibs_enabled:
   - IF-MIB
   timeout_ms: 3000

--- a/deployment/docker/snmp-base-nr.yaml
+++ b/deployment/docker/snmp-base-nr.yaml
@@ -3,7 +3,6 @@
 devices:
 trap:
   listen: 127.0.0.1:1620
-  community: hello
 discovery:
   cidrs:
   - 10.10.0.0/24

--- a/deployment/kubernetes/ktranslate-nr.yaml
+++ b/deployment/kubernetes/ktranslate-nr.yaml
@@ -113,7 +113,6 @@ data:
     devices:
     trap:
       listen: 0.0.0.0:1620
-      community: hello
     discovery:
       cidrs:
       - 10.10.0.0/24

--- a/deployment/kubernetes/ktranslate-nr.yaml
+++ b/deployment/kubernetes/ktranslate-nr.yaml
@@ -1,3 +1,6 @@
+# Recommended default config for sending SNMP data to New Relic
+# Includes discovery on startup with a 6 hour recurring interval
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,9 +31,11 @@ spec:
               key: nr_account_id
         args:
           - --metalisten=0.0.0.0:8083
-          - --snmp=/etc/ktranslate/snmp.yml
+          - --snmp=/etc/ktranslate/snmp-base.yaml
           - --metrics=jchf
           - --tee_logs=true
+          - --snmp_discovery_on_start=true
+          - --snmp_discovery_min=360
           - nr1.snmp
         resources:
           limits:
@@ -59,8 +64,8 @@ spec:
           periodSeconds: 5
         volumeMounts:
           - name: ktranslate-config
-            mountPath: /etc/ktranslate/snmp.yml
-            subPath: snmp.yml
+            mountPath: /etc/ktranslate/snmp-base.yaml
+            subPath: snmp-base.yaml
       volumes:
         - name: ktranslate-config
           configMap:
@@ -104,23 +109,28 @@ kind: ConfigMap
 metadata:
   name: ktranslate-config
 data:
-  snmp.yml: |
+  snmp-base.yaml: |
     devices:
-      switch:
-        device_name: switch
-        device_ip: 10.10.0.10
-        flow_only: true
-        user_tags: {}
     trap:
       listen: 0.0.0.0:1620
       community: hello
-      version: ""
-      transport: ""
+    discovery:
+      cidrs:
+      - 10.10.0.0/24
+      ignore_list: []
+      debug: false
+      ports:
+      - 161
+      default_communities:
+      - public
+      default_v3: null
+      add_devices: true
+      add_mibs: true
+      threads: 4
+      replace_devices: true
+      check_all_ips: true
     global:
-      poll_time_sec: 30
-      drop_if_outside_poll: false
-      mib_profile_dir: /etc/ktranslate/profiles
-      mibs_db: /etc/ktranslate/mibs.db
+      poll_time_sec: 300
       mibs_enabled:
       - IF-MIB
       timeout_ms: 3000

--- a/deployment/kubernetes/ktranslate-nr.yaml
+++ b/deployment/kubernetes/ktranslate-nr.yaml
@@ -130,6 +130,7 @@ data:
       check_all_ips: true
     global:
       poll_time_sec: 300
+      mib_profile_dir: /etc/ktranslate/profiles
       mibs_enabled:
       - IF-MIB
       timeout_ms: 3000


### PR DESCRIPTION
* adding new minimalist example for `snmp-base.yaml` to the `/deployment` dir to show recommended settings for NR 
* updating NR k8s example to add discovery settings

questions:
* @jbeveland27 - are these the right settings to go forward on?
* @i3149 - will this minimalist config work? several fields that we don't ever change have been redacted, do we need to put them back or update ktranslate to have default values for them by chance?
* @i3149 - please confirm k8s supports discovery. I assume it does but can't recall why the settings weren't in the config example already.