### PR TITLE
String-valued fields must be "quoted" and escaped differently than tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ config/profiles
 
 #generated on build
 cmd/version/generated_version.go
+
+.vscode/*.log

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -27,7 +27,7 @@ func TestSeriToInflux(t *testing.T) {
 	assert.Equal(len(pts), len(kt.InputTesting))
 }
 
-func TestInfluxEscape(t *testing.T) {
+func TestInfluxEscapeTag(t *testing.T) {
 	var tests = []struct {
 		input string
 		want  string
@@ -41,8 +41,25 @@ func TestInfluxEscape(t *testing.T) {
 		{"as\r\ndf", "as\\\r\\\ndf"},
 	}
 	for _, test := range tests {
-		if got := influxEscape(test.input); got != test.want {
-			t.Errorf("influxEscape(%q) = %q; want %q", test.input, got, test.want)
+		if got := influxEscapeTag(test.input); got != test.want {
+			t.Errorf("influxEscapeTag(%q) = %q; want %q", test.input, got, test.want)
+		}
+	}
+}
+
+func TestInfluxEscapeField(t *testing.T) {
+	var tests = []struct {
+		input string
+		want  string
+	}{
+		{"asdf", "asdf"},
+		{"as df", "as df"},
+		{"as\"df", "as\\\"df"},
+		{"as\\df", "as\\\\df"},
+	}
+	for _, test := range tests {
+		if got := influxEscapeField(test.input); got != test.want {
+			t.Errorf("influxEscapeField(%q) = %q; want %q", test.input, got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
The influx parser throws errors like "at line 168:251: field value has unrecognized type" when a field's value is an unquoted string.