### PR TITLE
Put \n at the end of every influx line, not just between them

### DIFF
--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -23,7 +23,9 @@ func TestSeriToInflux(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(res)
 
-	pts := strings.Split(string(res.Body), "\n")
+	assert.Equal(byte('\n'), res.Body[len(res.Body)-1])
+
+	pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
 	assert.Equal(len(pts), len(kt.InputTesting))
 }
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kentik/ktranslate/pull/340/commits/10e11361137865a47e4a856ea315660eabefb05c, which I made and then apparently accidentally overwrote in the same PR.

I came back to this because I was seeing joined-up influx lines in the _file_ output from ktranslate.