### PR TITLE
Cleaning up inherited tags on disco

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -416,6 +416,11 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 
 	sort.Strings(conf.Global.MibsEnabled) // Put them in a common ordering.
 
+	// Remove any provider based tags and matches.
+	if !isTest {
+		cleanForSave(conf)
+	}
+
 	// Write out to seperate files any sections which need this.
 	if conf.Disco.CidrOrig != "" {
 		t, err := yaml.Marshal(conf.Disco.Cidrs)

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -497,3 +497,31 @@ func setDeviceTagsAndMatch(device *kt.SnmpDeviceConfig) {
 	prune(device.UserTags)
 	prune(device.MatchAttr)
 }
+
+// Remove any dangling in memory items which should not be propigated to disk.
+func cleanForSave(cfg *kt.SnmpConfig) {
+	if cfg == nil {
+		return
+	}
+
+	set := func(m map[string]string, p kt.Provider) {
+		for k, v := range m {
+			if nk, ok := matchesPrefix(k, p); ok {
+				delete(m, k)
+				m[nk] = v
+			} else { // Just delete.
+				delete(m, k)
+			}
+		}
+	}
+
+	if cfg.Global != nil {
+		set(cfg.Global.UserTags, kt.GlobalProvider)
+		set(cfg.Global.MatchAttr, kt.GlobalProvider)
+	}
+
+	for _, device := range cfg.Devices {
+		set(device.UserTags, kt.DeviceProvider)
+		set(device.MatchAttr, kt.DeviceProvider)
+	}
+}


### PR DESCRIPTION
There's a nasty bug where with the new inherited tag system will corrupt global and device level tags after a discovery is run.

This fix strips out the corrupt tag and match values. 