### PR TITLE
Influx: use github.com/influxdata/line-protocol/v2 Encoder instead of strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gosnmp/gosnmp v1.35.0
 	github.com/honeycombio/libhoney-go v1.15.6
+	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/json-iterator/go v1.1.12
 	github.com/judwhite/go-svc v1.2.1
 	github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945
@@ -79,7 +80,6 @@ require (
 	github.com/google/gopacket v1.1.17 // indirect
 	github.com/googleapis/gax-go/v2 v2.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0 // indirect
-	github.com/influxdata/line-protocol/v2 v2.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/google/gopacket v1.1.17 // indirect
 	github.com/googleapis/gax-go/v2 v2.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0 // indirect
+	github.com/influxdata/line-protocol/v2 v2.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,12 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
+github.com/frankban/quicktest v1.11.0/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
+github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
@@ -343,6 +347,12 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=
+github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937/go.mod h1:BKR9c0uHSmRgM/se9JhFHtTT7JTO67X23MtKMHtZcpo=
+github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod h1:6+9Xt5Sq1rWx+glMgxhcg2c0DUaehK+5TDcPZ76GypY=
+github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
+github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
+github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/go.sum
+++ b/go.sum
@@ -161,7 +161,6 @@ github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpm
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/frankban/quicktest v1.11.0/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
-github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
@@ -348,6 +347,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=
+github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937 h1:MHJNQ+p99hFATQm6ORoLmpUCF7ovjwEFshs/NHzAbig=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937/go.mod h1:BKR9c0uHSmRgM/se9JhFHtTT7JTO67X23MtKMHtZcpo=
 github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod h1:6+9Xt5Sq1rWx+glMgxhcg2c0DUaehK+5TDcPZ76GypY=
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -570,14 +570,14 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	}
 
 	// Set up formatter
-	fmtr, err := formats.NewFormat(kc.config.Format, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.Compression)
+	fmtr, err := formats.NewFormat(kc.config.Format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, kc.config.Compression)
 	if err != nil {
 		return err
 	}
 	kc.format = fmtr
 
 	if kc.config.FormatRollup != "" { // Rollups default to using the same format as main, but can be seperated out.
-		fmtr, err := formats.NewFormat(kc.config.FormatRollup, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.Compression)
+		fmtr, err := formats.NewFormat(kc.config.FormatRollup, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, kc.config.Compression)
 		if err != nil {
 			return err
 		}
@@ -689,7 +689,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If we're sending self metrics via a chan to sinks. This one always get sent via nrm.
 	if kc.config.MetricsChan != nil {
 		// Set up formatter
-		fmtr, err := formats.NewFormat(formats.FORMAT_NRM, kc.log.GetLogger().GetUnderlyingLogger(), kc.config.Compression)
+		fmtr, err := formats.NewFormat(formats.FORMAT_NRM, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, kc.config.Compression)
 		if err != nil {
 			return err
 		}

--- a/pkg/formats/format.go
+++ b/pkg/formats/format.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kentik/ktranslate/pkg/formats/splunk"
 	"github.com/kentik/ktranslate/pkg/kt"
 	"github.com/kentik/ktranslate/pkg/rollup"
+
+	go_metrics "github.com/kentik/go-metrics"
 )
 
 type Formatter interface {
@@ -42,7 +44,7 @@ const (
 	FORMAT_KFLOW                = "kflow"
 )
 
-func NewFormat(format Format, log logger.Underlying, compression kt.Compression) (Formatter, error) {
+func NewFormat(format Format, log logger.Underlying, registry go_metrics.Registry, compression kt.Compression) (Formatter, error) {
 	switch format {
 	case FORMAT_AVRO:
 		return avro.NewFormat(log, compression)
@@ -53,7 +55,7 @@ func NewFormat(format Format, log logger.Underlying, compression kt.Compression)
 	case FORMAT_NETFLOW:
 		return netflow.NewFormat(log, compression)
 	case FORMAT_INFLUX:
-		return influx.NewFormat(log, compression)
+		return influx.NewFormat(log, registry, compression)
 	case FORMAT_CARBON:
 		return carbon.NewFormat(log, compression)
 	case FORMAT_PROM:

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -218,9 +218,39 @@ func (f *InfluxFormat) Rollup(rolls []rollup.Rollup) (*kt.Output, error) {
 		mets := strings.Split(roll.EventType, ":")
 		if len(mets) > 2 {
 			enc.StartLine(roll.Name)
+			if enc.Err() != nil {
+				panic(enc.Err())
+			}
+
+			dims := roll.GetDims()
+			tags := map[string]string{}
+			for i, pt := range strings.Split(roll.Dimension, roll.KeyJoin) {
+				tags[dims[i]] = pt
+			}
+			keys := make([]string, 0, len(tags))
+			for k := range tags {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				enc.AddTag(k, tags[k])
+				if enc.Err() != nil {
+					panic(enc.Err())
+				}
+			}
+
 			enc.AddField(mets[1], lineprotocol.IntValue(int64(roll.Metric)))
+			if enc.Err() != nil {
+				panic(enc.Err())
+			}
 			enc.AddField("count", lineprotocol.IntValue(int64(roll.Count)))
+			if enc.Err() != nil {
+				panic(enc.Err())
+			}
 			enc.EndLine(ts)
+			if enc.Err() != nil {
+				panic(enc.Err())
+			}
 		}
 	}
 

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -253,7 +253,7 @@ func (f *InfluxFormat) fromKSynth(in *kt.JCHF) []InfluxData {
 		}
 	}
 
-	return []InfluxData{InfluxData{
+	return []InfluxData{{
 		Name:      *Prefix,
 		Fields:    ms,
 		Timestamp: in.Timestamp * 1000000000,
@@ -264,12 +264,12 @@ func (f *InfluxFormat) fromKSynth(in *kt.JCHF) []InfluxData {
 func (f *InfluxFormat) fromKflow(in *kt.JCHF) []InfluxData {
 	// Map the basic strings into here.
 	attr := map[string]interface{}{}
-	metrics := map[string]kt.MetricInfo{"in_bytes": kt.MetricInfo{}, "out_bytes": kt.MetricInfo{}, "in_pkts": kt.MetricInfo{}, "out_pkts": kt.MetricInfo{}, "latency_ms": kt.MetricInfo{}}
+	metrics := map[string]kt.MetricInfo{"in_bytes": {}, "out_bytes": {}, "in_pkts": {}, "out_pkts": {}, "latency_ms": {}}
 	f.mux.RLock()
 	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
 	f.mux.RUnlock()
 	ms := map[string]int64{}
-	for m, _ := range metrics {
+	for m := range metrics {
 		switch m {
 		case "in_bytes":
 			ms[m] = int64(in.InBytes * uint64(in.SampleRate))
@@ -284,7 +284,7 @@ func (f *InfluxFormat) fromKflow(in *kt.JCHF) []InfluxData {
 		}
 	}
 
-	return []InfluxData{InfluxData{
+	return []InfluxData{{
 		Name:      *Prefix,
 		Fields:    ms,
 		Timestamp: in.Timestamp * 1000000000,

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -136,13 +136,13 @@ line:
 				v := l.Tags[k]
 				s, ok := v.(string)
 				if !ok {
-					s = fmt.Sprintf("%s", v)
+					s = fmt.Sprintf("%v", v)
 				}
 				if s != "" {
 					enc.AddTag(k, s)
 				}
 				if enc.Err() != nil {
-					f.report(enc.Err(), "tag '%s'='%s'", k, s)
+					f.report(enc.Err(), "tag '%s'='%v'", k, s)
 					continue line
 				}
 			}

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -133,8 +133,14 @@ func (s InfluxDataSet) Bytes() []byte {
 
 			}
 			for k, v := range l.Fields {
-				if val, ok := lineprotocol.NewValue(v); ok {
-					enc.AddField(k, val)
+				enc.AddField(k, lineprotocol.IntValue(v))
+				if enc.Err() != nil {
+					panic(enc.Err())
+				}
+			}
+			for k, v := range l.FieldsFloat {
+				if fv, ok := lineprotocol.FloatValue(v); ok {
+					enc.AddField(k, fv)
 					if enc.Err() != nil {
 						panic(enc.Err())
 					}

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -116,21 +116,16 @@ func (s InfluxDataSet) Bytes() []byte {
 			sort.Strings(keys)
 			for _, k := range keys {
 				v := l.Tags[k]
-				switch t := v.(type) {
-				case string:
-					if t != "" {
-						enc.AddTag(k, fmt.Sprintf("%s", v))
-					}
-				default:
-					s := fmt.Sprintf("%s", v)
-					if s != "" {
-						enc.AddTag(k, s)
-					}
+				s, ok := v.(string)
+				if !ok {
+					s = fmt.Sprintf("%s", v)
+				}
+				if s != "" {
+					enc.AddTag(k, s)
 				}
 				if enc.Err() != nil {
 					panic(enc.Err())
 				}
-
 			}
 			for k, v := range l.Fields {
 				enc.AddField(k, lineprotocol.IntValue(v))

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	go_metrics "github.com/kentik/go-metrics"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
 	lt "github.com/kentik/ktranslate/pkg/eggs/logger/testing"
 	"github.com/kentik/ktranslate/pkg/kt"
@@ -16,7 +17,7 @@ func TestSeriToInflux(t *testing.T) {
 	assert := assert.New(t)
 	l := lt.NewTestContextL(logger.NilContext, t).GetLogger().GetUnderlyingLogger()
 
-	f, err := NewFormat(l, kt.CompressionNone)
+	f, err := NewFormat(l, go_metrics.DefaultRegistry, kt.CompressionNone)
 	assert.NoError(err)
 
 	prefix := "notempty"

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -19,6 +19,8 @@ func TestSeriToInflux(t *testing.T) {
 	f, err := NewFormat(l, kt.CompressionNone)
 	assert.NoError(err)
 
+	prefix := "notempty"
+	Prefix = &prefix
 	res, err := f.To(kt.InputTesting, serBuf)
 	assert.NoError(err)
 	assert.NotNil(res)
@@ -27,41 +29,4 @@ func TestSeriToInflux(t *testing.T) {
 
 	pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
 	assert.Equal(len(pts), len(kt.InputTesting))
-}
-
-func TestInfluxEscapeTag(t *testing.T) {
-	var tests = []struct {
-		input string
-		want  string
-	}{
-		{"asdf", "asdf"},
-		{"as df", "as\\ df"},
-		{"as,df", "as\\,df"},
-		{"as=df", "as\\=df"},
-		{"as, df", "as\\,\\ df"},
-		{"as\ndf", "as\\\ndf"},
-		{"as\r\ndf", "as\\\r\\\ndf"},
-	}
-	for _, test := range tests {
-		if got := influxEscapeTag(test.input); got != test.want {
-			t.Errorf("influxEscapeTag(%q) = %q; want %q", test.input, got, test.want)
-		}
-	}
-}
-
-func TestInfluxEscapeField(t *testing.T) {
-	var tests = []struct {
-		input string
-		want  string
-	}{
-		{"asdf", "asdf"},
-		{"as df", "as df"},
-		{"as\"df", "as\\\"df"},
-		{"as\\df", "as\\\\df"},
-	}
-	for _, test := range tests {
-		if got := influxEscapeField(test.input); got != test.want {
-			t.Errorf("influxEscapeField(%q) = %q; want %q", test.input, got, test.want)
-		}
-	}
 }


### PR DESCRIPTION
I am still hitting edge cases with influx encoding. Rather than continue to read https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/ ever more closely and keep tweaking the string handling in influx.go, I think it would be better to switch to the "official" encoder.

Right now I have it checking the error state of the encoder after each step and panicking if it is non-nil. This is quite verbose and, while helpful during debugging, may not be how we want to handle errors in production. Feedback welcome.