### PR TITLE
Fix tag provider

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -397,19 +397,17 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 		}
 
 		// Load a mibdb if we have one. We have to do this here first because we need to get device provider info out.
-		if ms.Global != nil {
-			mdb, err := mibs.NewMibDB(ms.Global.MibDB, ms.Global.MibProfileDir, false, log)
-			if err != nil {
-				return nil, err
-			}
+		mdb, err := mibs.NewMibDB(ms.Global.MibDB, ms.Global.MibProfileDir, false, log)
+		if err != nil {
+			return nil, err
+		}
 
-			for _, device := range ms.Devices {
-				profile := mdb.FindProfile(device.OID, device.Description, device.MibProfile)
-				if profile != nil {
-					// Use the profile's provider if it is set.
-					if profile.Provider != "" {
-						device.Provider = profile.Provider
-					}
+		for _, device := range ms.Devices {
+			profile := mdb.FindProfile(device.OID, device.Description, device.MibProfile)
+			if profile != nil {
+				// Use the profile's provider if it is set.
+				if profile.Provider != "" {
+					device.Provider = profile.Provider
 				}
 			}
 		}

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -411,15 +411,13 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 						device.Provider = profile.Provider
 					}
 				}
-
-				// Tweak any per provider tags and match attributes here now that we have the actual provider.
-				setDeviceTagsAndMatch(device)
 			}
 		}
 	}
 
 	// Correctly format all the user tags needed here:
 	for _, device := range ms.Devices {
+		setDeviceTagsAndMatch(device) // Tweak any per provider tags and match attributes here now that we have the actual provider.
 		device.InitUserTags(ServiceName)
 	}
 


### PR DESCRIPTION
Turns out that there's two maps of user tags. One public and one private. 

This code moves the profile parsing into profile-setup, where its needed to actually set the private map. 