### PR TITLE
Allowing discovery on start without looping

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -144,10 +144,6 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 
 func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, log logger.ContextL, pollTimeMin int, checkNow bool, cfg *ktranslate.SNMPInputConfig) {
 	pt := time.Duration(pollTimeMin) * time.Minute
-	log.Infof("Running SNMP Discovery Loop every %v", pt)
-	discoCheck := time.NewTicker(pt)
-	defer discoCheck.Stop()
-
 	check := func() {
 		stats, err := Discover(ctx, log, pt, cfg)
 		if err != nil {
@@ -165,6 +161,13 @@ func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, log logger.ContextL,
 	if checkNow {
 		check()
 	}
+	if pollTimeMin == 0 { // Don't actually keep running discovery, just exit now.
+		return
+	}
+
+	log.Infof("Running SNMP Discovery Loop every %v", pt)
+	discoCheck := time.NewTicker(pt)
+	defer discoCheck.Stop()
 
 	for {
 		select {

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -151,7 +151,7 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 	}
 
 	// We only want to run a disco on start when restartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
-	runOnStart := *snmpDiscoSt
+	runOnStart := cfg.DiscoveryOnStart
 	if restartCount > 0 {
 		runOnStart = false
 	}
@@ -159,8 +159,8 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 	// Now, wait for sigusr2 to re-do or if there's a discovery with new devices.
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, kt.SIGUSR2)
-	if v := cfg.DiscoveryIntervalMinutes; v > 0 { // If we are re-running snmp discovery every interval, start the ticker here.
-		go RunDiscoOnTimer(ctxSnmp, c, log, v, cfg.DiscoveryOnStart, cfg)
+	if v := cfg.DiscoveryIntervalMinutes; v > 0 || runOnStart { // If we are re-running snmp discovery every interval AND/OR running on start, start the ticker here.
+		go RunDiscoOnTimer(ctxSnmp, c, log, v, runOnStart, cfg)
 	}
 
 	// Block here

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -150,6 +150,12 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 		log.Errorf("There was an error when polling for SNMP devices: %v.", err)
 	}
 
+	// We only want to run a disco on start when resartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
+	runOnStart := *snmpDiscoSt
+	if restartCount > 0 {
+		runOnStart = false
+	}
+
 	// Now, wait for sigusr2 to re-do or if there's a discovery with new devices.
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, kt.SIGUSR2)

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -150,7 +150,7 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 		log.Errorf("There was an error when polling for SNMP devices: %v.", err)
 	}
 
-	// We only want to run a disco on start when resartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
+	// We only want to run a disco on start when restartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
 	runOnStart := *snmpDiscoSt
 	if restartCount > 0 {
 		runOnStart = false

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -421,17 +421,14 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 		}
 
 		// Load a mibdb if we have one. We have to do this here first because we need to get device provider info out.
-		mdb, err := mibs.NewMibDB(ms.Global.MibDB, ms.Global.MibProfileDir, false, log)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, device := range ms.Devices {
-			profile := mdb.FindProfile(device.OID, device.Description, device.MibProfile)
-			if profile != nil {
-				// Use the profile's provider if it is set.
-				if profile.Provider != "" {
-					device.Provider = profile.Provider
+		if mibdb != nil {
+			for _, device := range ms.Devices {
+				profile := mibdb.FindProfile(device.OID, device.Description, device.MibProfile)
+				if profile != nil {
+					// Use the profile's provider if it is set.
+					if profile.Provider != "" {
+						device.Provider = profile.Provider
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Now you can set the flag `-snmp_discovery_on_start` separately without also setting `-snmp_discovery_min`. 

Also fixes a bug where if a new device is discovered on startup discovery actually happens twice. 