### PR TITLE
Remove chars 0-0x1F and 0x7F from tag values

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -1,6 +1,7 @@
 package influx
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"sort"
@@ -148,7 +149,7 @@ line:
 					s = fmt.Sprintf("%v", v)
 				}
 				if s != "" {
-					enc.AddTag(k, s)
+					enc.AddTag(k, prepareTagValue(s))
 				}
 				if enc.Err() != nil {
 					f.report(enc.Err(), "tag '%s'='%v'", k, s)
@@ -179,6 +180,30 @@ line:
 		}
 	}
 	return enc.Bytes()
+}
+
+var invalidTagChars string
+var invalidTagCharsOnce sync.Once
+
+func prepareTagValue(s string) string {
+	invalidTagCharsOnce.Do(func() {
+		b := []byte{}
+		for i := 0; i < 32; i++ {
+			b = append(b, byte(i))
+		}
+		b = append(b, 0x7f)
+		invalidTagChars = string(b)
+	})
+	if strings.ContainsAny(s, invalidTagChars) {
+		var clean bytes.Buffer
+		for _, c := range s {
+			if !strings.ContainsRune(invalidTagChars, c) {
+				clean.WriteRune(c)
+			}
+		}
+		return clean.String()
+	}
+	return s
 }
 
 func NewFormat(log logger.Underlying, registry go_metrics.Registry, compression kt.Compression) (*InfluxFormat, error) {

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -149,7 +149,7 @@ line:
 					s = fmt.Sprintf("%v", v)
 				}
 				if s != "" {
-					enc.AddTag(k, prepareTagValue(s))
+					enc.AddTag(k, prepareTagValueMap(s))
 				}
 				if enc.Err() != nil {
 					f.report(enc.Err(), "tag '%s'='%v'", k, s)

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -199,11 +199,26 @@ func prepareTagValue(s string) string {
 		for _, c := range s {
 			if !strings.ContainsRune(invalidTagChars, c) {
 				clean.WriteRune(c)
+			} else {
+				clean.WriteRune(' ')
 			}
 		}
 		return clean.String()
 	}
 	return s
+}
+
+func prepareTagValueMap(s string) string {
+	swap := func(r rune) rune {
+		switch {
+		case r >= 0x00 && r <= 0x1f:
+			return ' '
+		case r == 0x7f:
+			return ' '
+		}
+		return r
+	}
+	return strings.Map(swap, s)
 }
 
 func NewFormat(log logger.Underlying, registry go_metrics.Registry, compression kt.Compression) (*InfluxFormat, error) {

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -31,3 +31,30 @@ func TestSeriToInflux(t *testing.T) {
 	pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
 	assert.Equal(len(pts), len(kt.InputTesting))
 }
+
+func TestNewline(t *testing.T) {
+	assert := assert.New(t)
+	l := lt.NewTestContextL(logger.NilContext, t).GetLogger().GetUnderlyingLogger()
+
+	f, err := NewFormat(l, go_metrics.DefaultRegistry, kt.CompressionNone)
+	assert.NoError(err)
+
+	input := InfluxDataSet{
+		InfluxData{
+			Name:        "measurement",
+			FieldsFloat: map[string]float64{},
+			Fields:      map[string]int64{"moltue": 42},
+			Tags: map[string]interface{}{
+				"tag1": `line1
+line2`,
+			},
+			Timestamp: 0,
+		},
+	}
+	res := f.Bytes(input)
+	assert.NotNil(res)
+	str := string(res)
+	assert.Contains(str, "measurement")
+	assert.Contains(str, "line1")
+	assert.Contains(str, "line2")
+}

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -58,3 +58,38 @@ line2`,
 	assert.Contains(str, "line1")
 	assert.Contains(str, "line2")
 }
+
+const (
+	clean = "the quick red fox jumps over the lazy brown dogs"
+	dirty = `the quick red fox
+			jumps over
+			the lazy brown dogs`
+)
+
+func BenchmarkPrepareTagValueContainsAnyClean(b *testing.B) {
+	benchmarkPrepareTagValueContainsAny(b, clean)
+}
+
+func BenchmarkPrepareTagValueContainsAnyDirty(b *testing.B) {
+	benchmarkPrepareTagValueContainsAny(b, dirty)
+}
+
+func benchmarkPrepareTagValueContainsAny(b *testing.B, s string) {
+	for i := 0; i < b.N; i++ {
+		prepareTagValue(s)
+	}
+}
+
+func BenchmarkPrepareTagValueMapClean(b *testing.B) {
+	benchmarkPrepareTagValueMap(b, clean)
+}
+
+func BenchmarkPrepareTagValueMapDirty(b *testing.B) {
+	benchmarkPrepareTagValueMap(b, dirty)
+}
+
+func benchmarkPrepareTagValueMap(b *testing.B, s string) {
+	for i := 0; i < b.N; i++ {
+		prepareTagValueMap(s)
+	}
+}


### PR DESCRIPTION
I was hoping that InfluxDB's influx encoder would take care of all character encoding issues, but I should have actually read the code first. If you give it a tag value with an "invalid" character, it doesn't escape it or even remove it - it just flags it as an error and outputs nothing for that whole line.

So we need to filter tag values to remove disallowed characters - 0x00-0x1F (which includes \n and \r) plus 0x7F - before sending the tag value to the encoder.

Where this is coming up: Cisco devices have multiline strings for SysDescr.