### PR TITLE
Fixing printf style logging for netflow callback logging.

### DIFF
--- a/pkg/inputs/flow/log.go
+++ b/pkg/inputs/flow/log.go
@@ -11,30 +11,30 @@ type KentikLog struct {
 }
 
 func (l *KentikLog) Printf(f string, vars ...interface{}) {
-	l.l.Infof(f, vars)
+	l.l.Infof(f, vars...)
 }
 func (l *KentikLog) Errorf(f string, vars ...interface{}) {
-	l.l.Errorf(f, vars)
+	l.l.Errorf(f, vars...)
 }
 func (l *KentikLog) Warnf(f string, vars ...interface{}) {
-	l.l.Warnf(f, vars)
+	l.l.Warnf(f, vars...)
 }
 func (l *KentikLog) Warn(vars ...interface{}) {
-	l.l.Warnf("%v", vars)
+	l.l.Warnf("%v", vars...)
 }
 func (l *KentikLog) Error(vars ...interface{}) {
-	l.l.Errorf("%v", vars)
+	l.l.Errorf("%v", vars...)
 }
 func (l *KentikLog) Debug(vars ...interface{}) {
-	l.l.Debugf("%v", vars)
+	l.l.Debugf("%v", vars...)
 }
 func (l *KentikLog) Debugf(f string, vars ...interface{}) {
-	l.l.Debugf(f, vars)
+	l.l.Debugf(f, vars...)
 }
 func (l *KentikLog) Infof(f string, vars ...interface{}) {
-	l.l.Infof(f, vars)
+	l.l.Infof(f, vars...)
 }
 func (l *KentikLog) Fatalf(f string, vars ...interface{}) {
-	l.l.Errorf(f, vars)
+	l.l.Errorf(f, vars...)
 	panic(fmt.Sprintf(f, vars...))
 }


### PR DESCRIPTION
Fixes log lines in flow like:

```
2022-08-04T04:40:18.167 ktranslate/ [Error] flow Error from: [NetFlow 8 36.263µs Error decoding version: EOF] (%!v(MISSING)) duration: %!v(MISSING). %!v(MISSING)
```
