### PR TITLE
Fixing a case where an empty tag is added on discovery

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -543,7 +543,9 @@ func cleanForSave(cfg *kt.SnmpConfig) {
 		for k, v := range m {
 			if nk, ok := matchesPrefix(k, p); ok {
 				delete(m, k)
-				m[nk] = v
+				if v != "" {
+					m[nk] = v
+				}
 			} else { // Just delete.
 				delete(m, k)
 			}


### PR DESCRIPTION
Before, `container_service` would get set as empty, if the flag itself isn't set. 