### PR TITLE
Moving if utilization % to look like other if metrics in influx

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -506,7 +506,7 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								getMib(attrNew, ip)
 								results = append(results, InfluxData{
-									Name:        *Prefix + "if",
+									Name:        *Prefix + "IF-MIB::if",
 									FieldsFloat: map[string]float64{"IfInUtilization": float64(inBytes*8*100) / float64(uptimeSpeed)},
 									Timestamp:   in.Timestamp * 1000000000,
 									Tags:        attrNew,
@@ -527,7 +527,7 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								getMib(attrNew, ip)
 								results = append(results, InfluxData{
-									Name:        *Prefix + "if",
+									Name:        *Prefix + "IF-MIB::if",
 									FieldsFloat: map[string]float64{"IfOutUtilization": float64(outBytes*8*100) / float64(uptimeSpeed)},
 									Timestamp:   in.Timestamp * 1000000000,
 									Tags:        attrNew,


### PR DESCRIPTION
This should cover

```
the second one comes from snmp-profile if-mib.yaml which is good
[@314](https://kentik.slack.com/team/U06CAJBJR)
 and 
[@tdanner](https://kentik.slack.com/team/U037X8HS6K0)
, I understand that utilization metrics are additionally calculated as they are not in the snmp-profile specification, but does it make sense to glue these together with the rest of the interface metrics and having just one record instead of two? I guess its better if we do it at the ktranslate level, than on kmetrics ingest, but its your call? (edited)
```