### PR TITLE
Remove leading `.` from SNMP indexes (fixes #390)

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -216,7 +216,7 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 		dst.EventType = kt.KENTIK_EVENT_SNMP_DEV_METRIC
 		dst.Provider = dm.conf.Provider
 		dst.CustomStr["Error"] = dmr.Error
-		dst.CustomStr[kt.IndexVar] = idx
+		dst.CustomStr[kt.IndexVar] = strings.TrimPrefix(idx, ".")
 		dst.DeviceName = dm.conf.DeviceName
 		dst.SrcAddr = dm.conf.DeviceIP
 		dst.Timestamp = time.Now().Unix()


### PR DESCRIPTION
Note that doing it this way affects all outputs, not just influx. If this is a problem, I could look at doing it just for influx. However, I prefer the no-leading-dot style and would rather apply it universally if that is not too disruptive.