### PR TITLE
Only stripping metrics from attributes in influx

### DIFF
--- a/pkg/formats/carbon/carbon.go
+++ b/pkg/formats/carbon/carbon.go
@@ -113,7 +113,7 @@ func (f *CarbonFormat) fromKflow(in *kt.JCHF) []*CarbonData {
 		"out_pkts":   kt.MetricInfo{},
 		"latency_ms": kt.MetricInfo{},
 	}
-	util.SetAttr(attr, in, metrics, nil)
+	util.SetAttr(attr, in, metrics, nil, false)
 	metricData := []*CarbonData{}
 	for m, _ := range metrics {
 		v := int64(0)

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -371,7 +371,7 @@ func (f *InfluxFormat) fromKSynth(in *kt.JCHF) []InfluxData {
 	metrics := util.GetSynMetricNameSet(in.CustomInt["result_type"])
 	attr := map[string]interface{}{}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], true)
 	f.mux.RUnlock()
 	ms := map[string]int64{}
 
@@ -399,7 +399,7 @@ func (f *InfluxFormat) fromKflow(in *kt.JCHF) []InfluxData {
 	attr := map[string]interface{}{}
 	metrics := map[string]kt.MetricInfo{"in_bytes": {}, "out_bytes": {}, "in_pkts": {}, "out_pkts": {}, "latency_ms": {}}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], true)
 	f.mux.RUnlock()
 	ms := map[string]int64{}
 	for m := range metrics {
@@ -429,7 +429,7 @@ func (f *InfluxFormat) fromSnmpDeviceMetric(in *kt.JCHF) []InfluxData {
 	metrics := in.CustomMetrics
 	attr := map[string]interface{}{}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], true)
 	f.mux.RUnlock()
 	ip := attr["src_addr"]
 
@@ -472,7 +472,7 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 	attr := map[string]interface{}{}
 	f.mux.RLock()
 	defer f.mux.RUnlock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], true)
 	ip := attr["src_ip"]
 
 	profileName := "snmp"

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -362,7 +362,7 @@ func (f *NRMFormat) fromKSynth(in *kt.JCHF) []NRMetric {
 	metrics := util.GetSynMetricNameSet(in.CustomInt["result_type"])
 	attr := map[string]interface{}{}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := make([]NRMetric, 0, len(metrics))
 	lost := 0.0
@@ -424,7 +424,7 @@ func (f *NRMFormat) fromKflow(in *kt.JCHF) []NRMetric {
 	attr := map[string]interface{}{}
 	metrics := map[string]kt.MetricInfo{"in_bytes": kt.MetricInfo{}, "out_bytes": kt.MetricInfo{}, "in_pkts": kt.MetricInfo{}, "out_pkts": kt.MetricInfo{}, "latency_ms": kt.MetricInfo{}}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := make([]NRMetric, 0)
 
@@ -462,7 +462,7 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 	attr := map[string]interface{}{}
 	f.mux.RLock()
 	defer f.mux.RUnlock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	if f.lastMetadata[in.DeviceName] == nil {
 		f.Debugf("Missing device metadata for %s", in.DeviceName)
 	}
@@ -506,7 +506,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 	attr := map[string]interface{}{}
 	f.mux.RLock()
 	defer f.mux.RUnlock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	if f.lastMetadata[in.DeviceName] == nil {
 		f.Debugf("Missing interface metadata for %s", in.DeviceName)
 	}
@@ -611,7 +611,7 @@ func (f *NRMFormat) fromKtranslate(in *kt.JCHF) []NRMetric {
 	attr := map[string]interface{}{}
 	metrics := map[string]kt.MetricInfo{"name": kt.MetricInfo{}, "value": kt.MetricInfo{}, "count": kt.MetricInfo{}, "one-minute": kt.MetricInfo{}, "95-percentile": kt.MetricInfo{}, "du": kt.MetricInfo{}}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := make([]NRMetric, 0)
 

--- a/pkg/formats/prom/prom.go
+++ b/pkg/formats/prom/prom.go
@@ -208,7 +208,7 @@ func (f *PromFormat) fromKSynth(in *kt.JCHF) []PromData {
 	metrics := util.GetSynMetricNameSet(in.CustomInt["result_type"])
 	attr := map[string]interface{}{}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := map[string]int64{}
 
@@ -240,7 +240,7 @@ func (f *PromFormat) fromKflow(in *kt.JCHF) []PromData {
 	attr := map[string]interface{}{}
 	metrics := map[string]kt.MetricInfo{"in_bytes": kt.MetricInfo{}, "out_bytes": kt.MetricInfo{}, "in_pkts": kt.MetricInfo{}, "out_pkts": kt.MetricInfo{}, "latency_ms": kt.MetricInfo{}}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := map[string]int64{}
 	for m, _ := range metrics {
@@ -274,7 +274,7 @@ func (f *PromFormat) fromSnmpDeviceMetric(in *kt.JCHF) []PromData {
 	metrics := in.CustomMetrics
 	attr := map[string]interface{}{}
 	f.mux.RLock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	f.mux.RUnlock()
 	ms := map[string]int64{}
 	for m, _ := range metrics {
@@ -300,7 +300,7 @@ func (f *PromFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []PromData {
 	attr := map[string]interface{}{}
 	f.mux.RLock()
 	defer f.mux.RUnlock()
-	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName])
+	util.SetAttr(attr, in, metrics, f.lastMetadata[in.DeviceName], false)
 	ms := map[string]int64{}
 	msF := map[string]float64{}
 	for m, _ := range metrics {

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -40,7 +40,7 @@ const (
 	MAX_ATTR_FOR_SNMP = 64
 )
 
-func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.MetricInfo, lastMetadata *kt.LastMetadata) {
+func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.MetricInfo, lastMetadata *kt.LastMetadata, stripMetrics bool) {
 	mapr := in.Flatten()
 	for k, v := range mapr {
 		if DroppedAttrs[k] {
@@ -50,7 +50,7 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.Met
 		if _, ok := metrics[k]; ok { // Skip because this one is a metric, not an attribute.
 			continue
 		}
-		if strings.HasPrefix(k, kt.StringPrefix) {
+		if stripMetrics && strings.HasPrefix(k, kt.StringPrefix) {
 			if _, ok := metrics[k[len(kt.StringPrefix):]]; ok { // Skip because this one is a metric, not an attribute.
 				continue
 			}

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -294,7 +294,7 @@ func TestDropOnFilter(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		SetAttr(test.attr, test.in, test.metrics, &test.lm)
+		SetAttr(test.attr, test.in, test.metrics, &test.lm, false)
 		isIf := false
 		for k, _ := range test.attr {
 			if strings.HasPrefix(k, "if_") {


### PR DESCRIPTION
Actually #391 breaks New Relic. This puts a guard in so that only influx will remove string metrics as tags. 