### PR TITLE
Fixing a few things which can crash ktrans when getting synth data

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -163,7 +163,7 @@ func (api *KentikApi) getDeviceInfo(ctx context.Context, apiUrl string) ([]byte,
 }
 
 func (api *KentikApi) UpdateTests(ctx context.Context) {
-	if api == nil {
+	if api == nil || api.conf == nil {
 		return
 	}
 

--- a/pkg/cat/kentik.go
+++ b/pkg/cat/kentik.go
@@ -202,7 +202,7 @@ func (kc *KTranslate) handleFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If we have a kentik sink, send on here.
-	if kc.kentikConfig != nil {
+	if kc.kentik != nil {
 		go kc.kentik.SendKentik(evt, cid, senderId, offset)
 	}
 


### PR DESCRIPTION
With these fixes, you can see `,"eventType":"KSynth",` data for synth firehose again. 