### PR TITLE
Allow internal ktrans metrics to be sent via influx format

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -33,6 +33,7 @@ var (
 	maxThreads     int
 	format         string
 	formatRollup   string
+	formatMetric   string
 	compression    string
 	sinks          string
 	maxFlows       int
@@ -71,6 +72,7 @@ func init() {
 	flag.IntVar(&maxThreads, "max_threads", 1, "Dynamically grow threads up to this number")
 	flag.StringVar(&format, "format", "flat_json", "Format to convert kflow to: (json|flat_json|avro|netflow|influx|carbon|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
 	flag.StringVar(&formatRollup, "format_rollup", "", "Format to convert rollups to: (json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
+	flag.StringVar(&formatMetric, "format_metric", "", "Format to convert metrics to: (json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow)")
 	flag.StringVar(&compression, "compression", "none", "compression algo to use (none|gzip|snappy|deflate|null)")
 	flag.StringVar(&sinks, "sinks", "stdout", "List of sinks to send data to. Options: (kafka|stdout|new_relic|kentik|net|http|splunk|prometheus|file|s3|gcloud)")
 	flag.IntVar(&maxFlows, "max_flows_per_message", 10000, "Max number of flows to put in each emitted message")
@@ -289,6 +291,8 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.Format = val
 			case "format_rollup":
 				cfg.FormatRollup = val
+			case "format_metric":
+				cfg.FormatMetric = val
 			case "compression":
 				cfg.Compression = val
 			case "sinks":

--- a/config.go
+++ b/config.go
@@ -194,6 +194,7 @@ type Config struct {
 	MaxThreads          int
 	Format              string
 	FormatRollup        string
+	FormatMetric        string
 	Compression         string
 	Sinks               string
 	MaxFlowsPerMessage  int

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -723,7 +723,12 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	// If we're sending self metrics via a chan to sinks. This one always get sent via nrm.
 	if kc.metricsChan != nil {
 		// Set up formatter
-		fmtr, err := formats.NewFormat(formats.FORMAT_NRM, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config)
+		format := formats.Format(formats.FORMAT_NRM)
+		if kc.config.FormatMetric != "" {
+			format = formats.Format(kc.config.FormatMetric)
+		}
+
+		fmtr, err := formats.NewFormat(format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config)
 		if err != nil {
 			return err
 		}

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -417,7 +417,7 @@ func (f *InfluxFormat) fromKtranslate(in *kt.JCHF) []InfluxData {
 			})
 		}
 	case "timer":
-		if in.CustomStr["force"] == "true" || in.CustomBigInt["value"] > 0 {
+		if in.CustomStr["force"] == "true" || in.CustomBigInt["95-percentile"] > 0 {
 			ms = append(ms, InfluxData{
 				Name:        *Prefix + "ktranslate",
 				FieldsFloat: map[string]float64{name: float64(in.CustomBigInt["95-percentile"]) / 100},

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -656,7 +656,7 @@ func (f *NRMFormat) fromKtranslate(in *kt.JCHF) []NRMetric {
 			})
 		}
 	case "timer":
-		if in.CustomStr["force"] == "true" || in.CustomBigInt["value"] > 0 {
+		if in.CustomStr["force"] == "true" || in.CustomBigInt["95-percentile"] > 0 {
 			ms = append(ms, NRMetric{
 				Name:       "kentik.ktranslate." + in.CustomStr["name"],
 				Type:       NR_GAUGE_TYPE,

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -658,7 +658,7 @@ func (f *NRMFormat) fromKtranslate(in *kt.JCHF) []NRMetric {
 	case "timer":
 		if in.CustomStr["force"] == "true" || in.CustomBigInt["value"] > 0 {
 			ms = append(ms, NRMetric{
-				Name:       "kentik.ktranslate." + in.CustomStr["95-percentile"],
+				Name:       "kentik.ktranslate." + in.CustomStr["name"],
 				Type:       NR_GAUGE_TYPE,
 				Value:      float64(in.CustomBigInt["95-percentile"]) / 100,
 				Attributes: attr,


### PR DESCRIPTION
Connected to #364, allow internal metrics to be sent via the influx format with these flags: 

`-metrics jchf -format_metric influx`

```
ktranslate,device_name=mabel,eventType=KTranslateMetric,force=true,host=ribeye,provider=kentik-agent,type=gauge,ver=dirty-a17b4203afedb34b524398d6dfdac55a1b3b0d7c snmp_missing_meta=0,snmp_missing=0 3114432885464748544
ktranslate,device_name=mabel,eventType=KTranslateMetric,host=ribeye,provider=kentik-agent,type=gauge,ver=dirty-a17b4203afedb34b524398d6dfdac55a1b3b0d7c snmp_fail=1 3114432885464748544
ktranslate,device_name=ribeye,eventType=KTranslateMetric,host=ribeye,provider=kentik-agent,type=meter,ver=dirty-a17b4203afedb34b524398d6dfdac55a1b3b0d7c baseserver_healthcheck_execution_total=0.01,inputq=0.67 3114432885464748544
ktranslate,device_name=mabel,eventType=KTranslateMetric,host=ribeye,provider=kentik-agent,type=meter,ver=dirty-a17b4203afedb34b524398d6dfdac55a1b3b0d7c device_metrics=0.81,metadata=0.07,interface_metrics=1.76 3114432885464748544
ktranslate,device_name=ribeye,eventType=KTranslateMetric,force=true,host=ribeye,provider=kentik-agent,type=gauge,ver=dirty-a17b4203afedb34b524398d6dfdac55a1b3b0d7c inputq_len=0,outputq_len=0 3114432885464748544
```