### PR TITLE
Default nr1.syslog to not do snmp polling

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -211,10 +211,11 @@ func applyMode(cfg *ktranslate.Config, mode string) error {
 	case "nr1.discovery":
 		cfg.EnableSNMPDiscovery = true
 		setNr()
-	case "nr1.syslog": // Tune for syslog.
+	case "nr1.syslog": // Tune for syslog. Don't want any sampling so can't use setNR directly.
 		cfg.Compression = "gzip"
 		cfg.Sinks = "new_relic"
 		cfg.Format = "new_relic_metric"
+		cfg.SNMPInput.FlowOnly = true // Don't do snmp polling.
 		if cfg.SyslogInput.ListenAddr == "" {
 			cfg.SyslogInput.ListenAddr = "0.0.0.0:5143"
 		}


### PR DESCRIPTION
This change defaults the `nr1.syslog` mode to not also poll snmp. 

I think this keeps things a little cleaner and should prevent double polling if users also have a `nr1.snmp` configured ktrans instance. 