### PR TITLE
Allow same key multiple tables

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -211,10 +211,11 @@ func applyMode(cfg *ktranslate.Config, mode string) error {
 	case "nr1.discovery":
 		cfg.EnableSNMPDiscovery = true
 		setNr()
-	case "nr1.syslog": // Tune for syslog.
+	case "nr1.syslog": // Tune for syslog. Don't want any sampling so can't use setNR directly.
 		cfg.Compression = "gzip"
 		cfg.Sinks = "new_relic"
 		cfg.Format = "new_relic_metric"
+		cfg.SNMPInput.FlowOnly = true // Don't do snmp polling.
 		if cfg.SyslogInput.ListenAddr == "" {
 			cfg.SyslogInput.ListenAddr = "0.0.0.0:5143"
 		}

--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -47,7 +47,7 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 		if len(deviceMetadataMibs) > 0 {
 			log.Infof("Custom device metadata")
 			for n, d := range deviceMetadataMibs {
-				log.Infof("   -> : %s -> %s", n, d.Name)
+				log.Infof("   -> : %s -> %s:%s", n, d.Mib, d.GetName())
 				for k, v := range d.MatchAttr {
 					attrMap[k] = v
 				}
@@ -218,7 +218,13 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 
 			for _, table := range dst.CustomTables {
 				for k, v := range table.Customs {
-					dst.CustomMetrics[k] = kt.MetricInfo{Table: v.TableName, Tables: v.TableNames}
+					if _, ok := dst.CustomMetrics[k]; !ok {
+						dst.CustomMetrics[k] = kt.MetricInfo{Table: v.TableName, Tables: v.TableNames}
+					} else {
+						for newKey, _ := range v.TableNames {
+							dst.CustomMetrics[k].Tables[newKey] = true
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This one goes with https://github.com/kentik/snmp-profiles/pull/411

It allows the same tag to be used across mibs (when their tables line up). I think this makes sense and will not cause cross table junking up of attributes. 