### PR TITLE
adding IfInBitRate, IfInPktRate, IfOutBitRate, IfOutPktRate to IF-MIB…

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -579,8 +579,10 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 			if speed, ok := ii["Speed"]; ok {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
+					uptime_time := in.CustomBigInt["Uptime"]
 					if uptimeSpeed > 0 {
 						attrNew := util.CopyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+						attrNew_bitrate := util.CopyAttrForSnmp(attr, "IfInBitRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
 						if inBytes, ok := in.CustomBigInt["ifHCInOctets"]; ok {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								getMib(attrNew, ip)
@@ -591,6 +593,31 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 									Tags:        attrNew,
 								})
 							}
+							if !util.DropOnFilter(attrNew_bitrate, f.lastMetadata[in.DeviceName], true) {
+								getMib(attrNew_bitrate, ip)
+								results = append(results, InfluxData{
+									Name:        *Prefix + "IF-MIB::if",
+									FieldsFloat: map[string]float64{"IfInBitRate": float64(inBytes*8*100) / float64(uptime_time)},
+									Timestamp:   in.Timestamp * 1000000000,
+									Tags:        attrNew_bitrate,
+								})
+							}
+						}
+						attrNew_pktrate := util.CopyAttrForSnmp(attr, "IfInPktRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+						if ifHCInUcastPkts, ok := in.CustomBigInt["ifHCInUcastPkts"]; ok {
+							if ifHCInMulticastPkts, ok := in.CustomBigInt["ifHCInMulticastPkts"]; ok {
+								if ifHCInBroadcastPkts, ok := in.CustomBigInt["ifHCInBroadcastPkts"]; ok {
+									if !util.DropOnFilter(attrNew_pktrate, f.lastMetadata[in.DeviceName], true) {
+										getMib(attrNew_pktrate, ip)
+										results = append(results, InfluxData{
+											Name:        *Prefix + "IF-MIB::if",
+											FieldsFloat: map[string]float64{"IfInPktRate": float64((ifHCInUcastPkts + ifHCInMulticastPkts + ifHCInBroadcastPkts)*100) / float64(uptime_time)},
+											Timestamp:   in.Timestamp * 1000000000,
+											Tags:        attrNew_pktrate,
+										})
+									}
+								}
+							}
 						}
 					}
 				}
@@ -600,8 +627,10 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 			if speed, ok := oi["Speed"]; ok {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
+					uptime_time := in.CustomBigInt["Uptime"]
 					if uptimeSpeed > 0 {
 						attrNew := util.CopyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+						attrNew_bitrate := util.CopyAttrForSnmp(attr, "IfOutBitRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
 						if outBytes, ok := in.CustomBigInt["ifHCOutOctets"]; ok {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								getMib(attrNew, ip)
@@ -611,6 +640,31 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 									Timestamp:   in.Timestamp * 1000000000,
 									Tags:        attrNew,
 								})
+							}
+							if !util.DropOnFilter(attrNew_bitrate, f.lastMetadata[in.DeviceName], true) {
+								getMib(attrNew_bitrate, ip)
+								results = append(results, InfluxData{
+									Name:        *Prefix + "IF-MIB::if",
+									FieldsFloat: map[string]float64{"IfOutBitRate": float64(outBytes*8*100) / float64(uptime_time)},
+									Timestamp:   in.Timestamp * 1000000000,
+									Tags:        attrNew_bitrate,
+								})
+							}
+						}
+						attrNew_pktrate := util.CopyAttrForSnmp(attr, "IfOutPktRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+						if ifHCOutUcastPkts, ok := in.CustomBigInt["ifHCOutUcastPkts"]; ok {
+							if ifHCOutMulticastPkts, ok := in.CustomBigInt["ifHCOutMulticastPkts"]; ok {
+								if ifHCOutBroadcastPkts, ok := in.CustomBigInt["ifHCOutBroadcastPkts"]; ok {
+									if !util.DropOnFilter(attrNew_pktrate, f.lastMetadata[in.DeviceName], true) {
+										getMib(attrNew_pktrate, ip)
+										results = append(results, InfluxData{
+											Name:        *Prefix + "IF-MIB::if",
+											FieldsFloat: map[string]float64{"IfOutPktRate": float64((ifHCOutUcastPkts + ifHCOutMulticastPkts + ifHCOutBroadcastPkts)*100) / float64(uptime_time)},
+											Timestamp:   in.Timestamp * 1000000000,
+											Tags:        attrNew_pktrate,
+										})
+									}
+								}
 							}
 						}
 					}

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -573,107 +573,64 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 		}
 	}
 
-	// Grap capacity utilization if possible.
+	// Grap varioius rates computed over time here if possible.
 	if f.lastMetadata[in.DeviceName] != nil {
-		if ii, ok := f.lastMetadata[in.DeviceName].InterfaceInfo[in.InputPort]; ok {
-			if speed, ok := ii["Speed"]; ok {
-				if ispeed, ok := speed.(int32); ok {
-					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
-					uptime_time := in.CustomBigInt["Uptime"]
-					if uptimeSpeed > 0 {
-						attrNew := util.CopyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						attrNew_bitrate := util.CopyAttrForSnmp(attr, "IfInBitRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						if inBytes, ok := in.CustomBigInt["ifHCInOctets"]; ok {
-							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
-								getMib(attrNew, ip)
-								results = append(results, InfluxData{
-									Name:        *Prefix + "IF-MIB::if",
-									FieldsFloat: map[string]float64{"IfInUtilization": float64(inBytes*8*100) / float64(uptimeSpeed)},
-									Timestamp:   in.Timestamp * 1000000000,
-									Tags:        attrNew,
-								})
-							}
-							if !util.DropOnFilter(attrNew_bitrate, f.lastMetadata[in.DeviceName], true) {
-								getMib(attrNew_bitrate, ip)
-								results = append(results, InfluxData{
-									Name:        *Prefix + "IF-MIB::if",
-									FieldsFloat: map[string]float64{"IfInBitRate": float64(inBytes*8*100) / float64(uptime_time)},
-									Timestamp:   in.Timestamp * 1000000000,
-									Tags:        attrNew_bitrate,
-								})
-							}
+		f.setRates("In", in, results, attr, profileName, ip)
+		f.setRates("Out", in, results, attr, profileName, ip)
+	}
+
+	return results
+}
+
+func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxData, attr map[string]interface{}, profileName string, ip interface{}) {
+	var port kt.IfaceID
+	if direction == "In" {
+		port = in.InputPort
+	} else {
+		port = in.OutputPort
+	}
+	utilName := fmt.Sprintf("If%sUtilization", direction)
+	bitRate := fmt.Sprintf("If%sBitRate", direction)
+	pktRate := fmt.Sprintf("If%sPktRate", direction)
+	totalBytes := in.CustomBigInt[fmt.Sprintf("ifHC%sOctets", direction)]
+	totalPkts := in.CustomBigInt[fmt.Sprintf("ifHC%sUcastPkts", direction)] + in.CustomBigInt[fmt.Sprintf("ifHC%sMulticastPkts", direction)] + in.CustomBigInt[fmt.Sprintf("ifHC%sBroadcastPkts", direction)]
+
+	if ii, ok := f.lastMetadata[in.DeviceName].InterfaceInfo[port]; ok {
+		if speed, ok := ii["Speed"]; ok {
+			if ispeed, ok := speed.(int32); ok {
+				uptime := in.CustomBigInt["Uptime"]
+				uptimeSpeed := uptime * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
+				if uptimeSpeed > 0 {
+					attrNew := util.CopyAttrForSnmp(attr, utilName, kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+					if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
+						getMib(attrNew, ip)
+						if totalBytes > 0 {
+							results = append(results, InfluxData{
+								Name:        *Prefix + "IF-MIB::if",
+								FieldsFloat: map[string]float64{utilName: float64(totalBytes*8*100) / float64(uptimeSpeed)},
+								Timestamp:   in.Timestamp * 1000000000,
+								Tags:        attrNew,
+							})
+							results = append(results, InfluxData{
+								Name:        *Prefix + "IF-MIB::if",
+								FieldsFloat: map[string]float64{bitRate: float64(totalBytes*8*100) / float64(uptime)},
+								Timestamp:   in.Timestamp * 1000000000,
+								Tags:        attrNew,
+							})
 						}
-						attrNew_pktrate := util.CopyAttrForSnmp(attr, "IfInPktRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						if ifHCInUcastPkts, ok := in.CustomBigInt["ifHCInUcastPkts"]; ok {
-							if ifHCInMulticastPkts, ok := in.CustomBigInt["ifHCInMulticastPkts"]; ok {
-								if ifHCInBroadcastPkts, ok := in.CustomBigInt["ifHCInBroadcastPkts"]; ok {
-									if !util.DropOnFilter(attrNew_pktrate, f.lastMetadata[in.DeviceName], true) {
-										getMib(attrNew_pktrate, ip)
-										results = append(results, InfluxData{
-											Name:        *Prefix + "IF-MIB::if",
-											FieldsFloat: map[string]float64{"IfInPktRate": float64((ifHCInUcastPkts + ifHCInMulticastPkts + ifHCInBroadcastPkts)*100) / float64(uptime_time)},
-											Timestamp:   in.Timestamp * 1000000000,
-											Tags:        attrNew_pktrate,
-										})
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		if oi, ok := f.lastMetadata[in.DeviceName].InterfaceInfo[in.OutputPort]; ok {
-			if speed, ok := oi["Speed"]; ok {
-				if ispeed, ok := speed.(int32); ok {
-					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
-					uptime_time := in.CustomBigInt["Uptime"]
-					if uptimeSpeed > 0 {
-						attrNew := util.CopyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						attrNew_bitrate := util.CopyAttrForSnmp(attr, "IfOutBitRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						if outBytes, ok := in.CustomBigInt["ifHCOutOctets"]; ok {
-							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
-								getMib(attrNew, ip)
-								results = append(results, InfluxData{
-									Name:        *Prefix + "IF-MIB::if",
-									FieldsFloat: map[string]float64{"IfOutUtilization": float64(outBytes*8*100) / float64(uptimeSpeed)},
-									Timestamp:   in.Timestamp * 1000000000,
-									Tags:        attrNew,
-								})
-							}
-							if !util.DropOnFilter(attrNew_bitrate, f.lastMetadata[in.DeviceName], true) {
-								getMib(attrNew_bitrate, ip)
-								results = append(results, InfluxData{
-									Name:        *Prefix + "IF-MIB::if",
-									FieldsFloat: map[string]float64{"IfOutBitRate": float64(outBytes*8*100) / float64(uptime_time)},
-									Timestamp:   in.Timestamp * 1000000000,
-									Tags:        attrNew_bitrate,
-								})
-							}
-						}
-						attrNew_pktrate := util.CopyAttrForSnmp(attr, "IfOutPktRate", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
-						if ifHCOutUcastPkts, ok := in.CustomBigInt["ifHCOutUcastPkts"]; ok {
-							if ifHCOutMulticastPkts, ok := in.CustomBigInt["ifHCOutMulticastPkts"]; ok {
-								if ifHCOutBroadcastPkts, ok := in.CustomBigInt["ifHCOutBroadcastPkts"]; ok {
-									if !util.DropOnFilter(attrNew_pktrate, f.lastMetadata[in.DeviceName], true) {
-										getMib(attrNew_pktrate, ip)
-										results = append(results, InfluxData{
-											Name:        *Prefix + "IF-MIB::if",
-											FieldsFloat: map[string]float64{"IfOutPktRate": float64((ifHCOutUcastPkts + ifHCOutMulticastPkts + ifHCOutBroadcastPkts)*100) / float64(uptime_time)},
-											Timestamp:   in.Timestamp * 1000000000,
-											Tags:        attrNew_pktrate,
-										})
-									}
-								}
-							}
+						if totalPkts > 0 {
+							results = append(results, InfluxData{
+								Name:        *Prefix + "IF-MIB::if",
+								FieldsFloat: map[string]float64{pktRate: float64(totalPkts*100) / float64(uptime)},
+								Timestamp:   in.Timestamp * 1000000000,
+								Tags:        attrNew,
+							})
 						}
 					}
 				}
 			}
 		}
 	}
-
-	return results
 }
 
 func getMib(attr map[string]interface{}, ip interface{}) string {


### PR DESCRIPTION
…::in measurement in Influx output
closes #404 

seems to be working:

```
IF-MIB::if,device_name=edge01.iad1,if_Alias=CORE:edge01-qfx\ 802.1q\ Trunk,if_Description=ae0,if_Index=564,if_MTU=1518,if_PhysAddress=5c:5e:ab:01:47:c0,if_Speed=40000,if_Type=ieee8023adLag,if_interface_name=ae0,instrumentation.name=juniper-mx-router,tags.dc=iad1,tags.kentik.model=MX80,tags.kentik.vendor=Juniper\ Networks,tags.site=iad,tags.type=edge ifInErrors=0i,ifHCInUcastPkts=61385352i,ifHCOutBroadcastPkts=0i,ifHCInOctets=53564747891i,ifOutDiscards=0i,ifHCOutOctets=53547600083i,ifOutErrorPercent=0i,ifHCOutMulticastPkts=0i,if_AdminStatus=1i,ifInErrorPercent=0i,ifInDiscards=0i,ifOutErrors=0i,ifHCOutUcastPkts=61360860i,if_OperStatus=1i,ifHCInBroadcastPkts=0i,ifHCInMulticastPkts=12311i,IfInBitRate=7.20319353047571e+09,IfInPktRate=1.0320669524289797e+06,IfOutUtilization=18.002218888216508,IfOutBitRate=7.200887555286603e+09,IfOutPktRate=1.0314483106404438e+06,IfInUtilization=18.007983826189275,if_OperStatus_str="up",if_AdminStatus_str="up" 1661466250000000000
```