### PR TITLE
Trying a reverse dns lookup if trap sender is not known

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -658,7 +658,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 		}
 		assureInput()
 		kc.metrics.SnmpDeviceData = kt.NewSnmpMetricSet(kc.registry)
-		err := snmp.StartSNMPPolls(ctx, kc.inputChan, kc.metrics.SnmpDeviceData, kc.registry, kc.apic, kc.log, kc.config.SNMPInput)
+		err := snmp.StartSNMPPolls(ctx, kc.inputChan, kc.metrics.SnmpDeviceData, kc.registry, kc.apic, kc.log, kc.config.SNMPInput, kc.resolver)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #398 
Passes in the dns resolver to ktrans trap handler and will use this if the IP of a trap sender is not known. 

Make sure to also set `--dns=local` as a flag. 