### PR TITLE
Allow Meraki Filter by Network and Org

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -205,7 +205,7 @@ func (f *NRMFormat) toNRMetric(in *kt.JCHF) []NRMetric {
 		return f.fromSnmpMetadata(in)
 	case kt.KENTIK_EVENT_KTRANS_METRIC:
 		return f.fromKtranslate(in)
-	case kt.KENTIK_EVENT_SNMP_TRAP:
+	case kt.KENTIK_EVENT_SNMP_TRAP, kt.KENTIK_EVENT_EXT:
 		// This is actually an event, send out as an event to sink directly.
 		err := events.SendEvent(in, f.doGz, f.EventChan)
 		if err != nil {

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -321,7 +321,7 @@ func (p *Poller) StartExtensionOnlyLoop(ctx context.Context) {
 	counterAlignment := time.Duration(p.counterTimeSec) * time.Second
 
 	if p.extension != nil {
-		p.log.Infof("Running only extenion %s", p.extension.GetName())
+		p.log.Infof("Running only extension %s", p.extension.GetName())
 		go p.extension.Run(ctx, counterAlignment)
 	}
 

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -321,6 +321,7 @@ func (p *Poller) StartExtensionOnlyLoop(ctx context.Context) {
 	counterAlignment := time.Duration(p.counterTimeSec) * time.Second
 
 	if p.extension != nil {
+		p.log.Infof("Running only extenion %s", p.extension.GetName())
 		go p.extension.Run(ctx, counterAlignment)
 	}
 

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -513,7 +513,7 @@ func (c *MerakiClient) parseClients(cs []*client) ([]*kt.JCHF, error) {
 				"device_type":        client.DeviceType,
 				"recent_device_name": client.RecentDeviceName,
 				"dhcp_hostname":      client.DhcpHostname,
-				"mdsn_name":          client.MdnsName,
+				"mdns_name":          client.MdnsName,
 				"application":        appU.Application,
 			}
 			dst.CustomInt = map[string]int32{

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -879,8 +879,8 @@ func getUsage(u uplink) (int64, int64) {
 	sent := int64(0)
 	rcv := int64(0)
 	for _, t := range u.Usage {
-		sent += int64(t.Sent * 1000)    // Kilobytes -> Bytes
-		rcv += int64(t.Received * 1000) // Same.
+		sent += int64(t.Sent)
+		rcv += int64(t.Received)
 	}
 
 	return sent, rcv

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -274,7 +274,7 @@ func (c *MerakiClient) parseOrgLog(l *orgLog, network networkDesc, org orgDesc) 
 		"old_value":    l.OldValue,
 	}
 	dst.EventType = kt.KENTIK_EVENT_EXT // This gets sent as event, not metric.
-	//dst.Provider = c.conf.Provider // @TODO, pick a provider for this one.
+	dst.Provider = kt.ProviderMerakiCloud
 
 	c.conf.SetUserTags(dst.CustomStr)
 	return dst
@@ -521,7 +521,7 @@ func (c *MerakiClient) parseClients(cs []*client) ([]*kt.JCHF, error) {
 			}
 			dst.CustomBigInt = map[string]int64{}
 			dst.EventType = kt.KENTIK_EVENT_SNMP_DEV_METRIC
-			//dst.Provider = c.conf.Provider // @TODO, pick a provider for this one.
+			dst.Provider = kt.ProviderMerakiCloud
 
 			if client.device.Serial != "" {
 				dst.DeviceName = client.device.Name // Here, device is this device's name.
@@ -848,7 +848,7 @@ func (c *MerakiClient) parseUplinks(uplinkMap map[string]deviceUplink) ([]*kt.JC
 			dst.CustomInt = map[string]int32{}
 			dst.CustomBigInt = map[string]int64{}
 			dst.EventType = kt.KENTIK_EVENT_SNMP_DEV_METRIC
-			//dst.Provider = c.conf.Provider // @TODO, pick a provider for this one.
+			dst.Provider = kt.ProviderMerakiCloud
 
 			dst.Timestamp = time.Now().Unix()
 			dst.CustomMetrics = map[string]kt.MetricInfo{}

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -525,7 +525,7 @@ func (c *MerakiClient) getUplinks(dur time.Duration) ([]*kt.JCHF, error) {
 			}
 
 			if uplink.network == nil {
-				// Skip this uplink.
+				// Skip this uplink because its from a network we don't care about.
 				continue
 				//c.log.Errorf("Missing Network for Uplink %s -- %s", uplink.NetworkID, uplink.Serial)
 			}
@@ -591,7 +591,8 @@ func (c *MerakiClient) getUplinkLatencyLoss(dur time.Duration, uplinkMap map[str
 			if uu, ok := uplinkMap[uplink.Serial]; ok { // We've matched the serial, now add this loss.
 				uu.SetLatencyLoss(uplink)
 			} else {
-				c.log.Errorf("Missing Uplink %s In LatencyLoss", uplink.Serial)
+				// Not on a network we care about.
+				// c.log.Errorf("Missing Uplink %s In LatencyLoss", uplink.Serial)
 			}
 		}
 	}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -148,12 +148,13 @@ type EAPIConfig struct {
 }
 
 type MerakiConfig struct {
-	ApiKey         string   `yaml:"api_key"`         // Required.
-	Host           string   `yaml:"host"`            // Optional, defaults to api.meraki.com
-	MonitorUplinks bool     `yaml:"monitor_uplinks"` // This will be the default if neither is set.
-	MonitorDevices bool     `yaml:"monitor_devices"`
-	Orgs           []string `yaml:"organizations"` // Only monitor orgs in this list, if set.
-	Networks       []string `yaml:"networks"`      // Only monitor networks in this list, if set.
+	ApiKey            string   `yaml:"api_key"`         // Required.
+	Host              string   `yaml:"host"`            // Optional, defaults to api.meraki.com
+	MonitorUplinks    bool     `yaml:"monitor_uplinks"` // This will be the default if neither is set.
+	MonitorDevices    bool     `yaml:"monitor_devices"`
+	MonitorOrgChanges bool     `yaml:"monitor_org_changes"`
+	Orgs              []string `yaml:"organizations"` // Only monitor orgs in this list, if set.
+	Networks          []string `yaml:"networks"`      // Only monitor networks in this list, if set.
 }
 
 // Contain various extensions to snmp which can be used to get data.

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -148,10 +148,12 @@ type EAPIConfig struct {
 }
 
 type MerakiConfig struct {
-	ApiKey         string `yaml:"api_key"`         // Required.
-	Host           string `yaml:"host"`            // Optional, defaults to api.meraki.com
-	MonitorUplinks bool   `yaml:"monitor_uplinks"` // This will be the default if neither is set.
-	MonitorDevices bool   `yaml:"monitor_devices"`
+	ApiKey         string   `yaml:"api_key"`         // Required.
+	Host           string   `yaml:"host"`            // Optional, defaults to api.meraki.com
+	MonitorUplinks bool     `yaml:"monitor_uplinks"` // This will be the default if neither is set.
+	MonitorDevices bool     `yaml:"monitor_devices"`
+	Orgs           []string `yaml:"organizations"` // Only monitor orgs in this list, if set.
+	Networks       []string `yaml:"networks"`      // Only monitor networks in this list, if set.
 }
 
 // Contain various extensions to snmp which can be used to get data.

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -67,6 +67,7 @@ const (
 	ProviderFibreChannel       Provider = "kentik-fibre-channel"
 	ProviderTrapUnknown        Provider = "kentik-trap-device"
 	ProviderHttpDevice         Provider = "kentik-http"
+	ProviderMerakiCloud        Provider = "meraki-cloud-controller"
 )
 
 const (

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -25,6 +25,7 @@ const (
 	KENTIK_EVENT_SNMP_INT_METRIC = "KSnmpInterfaceMetric"
 	KENTIK_EVENT_SNMP_METADATA   = "KSnmpInterfaceMetadata"
 	KENTIK_EVENT_SNMP_TRAP       = "KSnmpTrap"
+	KENTIK_EVENT_EXT             = "KExtEvent"
 	KENTIK_EVENT_JSON            = "KJson"
 	KENTIK_EVENT_KTRANS_METRIC   = "KTranslateMetric"
 


### PR DESCRIPTION
Given a device config like:

```
  meraki_cloud_controller:
    device_name: meraki_cloud_controller
    device_ip: snmp.meraki.com
    ext:
      ext_only: true
      meraki_config:
        api_key: my-meraki-api-key
        monitor_uplinks: false
        monitor_devices: false
        monitor_org_changes: true
        networks:
          - "Network 1"
          - "Network 2"
        organizations:
          - "Org 1"
```

This PR allows only the specified networks and organizations to be polled. 