### PR TITLE
Adding asa,nbar,pan ent field support as native flow

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -90,7 +90,7 @@ func init() {
 	flag.StringVar(&sslKeyFile, "ssl_key_file", "", "SSL Key file to use for serving HTTPS traffic")
 	flag.StringVar(&tagMapType, "tag_map_type", "", "type of mapping to use for tag values. file|null")
 	flag.StringVar(&vpcSource, "vpc", kt.LookupEnvString("KENTIK_VPC", ""), "Run VPC Flow Ingest")
-	flag.StringVar(&flowSource, "nf.source", "", "Run NetFlow Ingest Directly. Valid values here are netflow5|netflow9|ipfix|sflow")
+	flag.StringVar(&flowSource, "nf.source", "", "Run NetFlow Ingest Directly. Valid values here are netflow5|netflow9|ipfix|sflow|nbar|asa|pan")
 	flag.BoolVar(&teeLog, "tee_logs", false, "Tee log messages to sink")
 	flag.StringVar(&appMap, "application_map", "", "File containing custom application mappings")
 	flag.StringVar(&syslog, "syslog.source", "", "Run Syslog Server at this IP:Port or unix socket.")

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -579,13 +579,15 @@ func (kc *KTranslate) doEnrichments(ctx context.Context, citycache map[uint32]st
 		}
 
 		// See if we know what service this is based on proto and port.
-		if msg.L4SrcPort < msg.L4DstPort {
-			if app, ok := kc.rule.GetService(sip, msg.L4SrcPort, ic.PROTO_NUMS[msg.Protocol]); ok {
-				msg.CustomStr["application"] = app
-			}
-		} else {
-			if app, ok := kc.rule.GetService(dip, msg.L4DstPort, ic.PROTO_NUMS[msg.Protocol]); ok {
-				msg.CustomStr["application"] = app
+		if _, ok := msg.CustomStr["application"]; !ok {
+			if msg.L4SrcPort < msg.L4DstPort {
+				if app, ok := kc.rule.GetService(sip, msg.L4SrcPort, ic.PROTO_NUMS[msg.Protocol]); ok {
+					msg.CustomStr["application"] = app
+				}
+			} else {
+				if app, ok := kc.rule.GetService(dip, msg.L4DstPort, ic.PROTO_NUMS[msg.Protocol]); ok {
+					msg.CustomStr["application"] = app
+				}
 			}
 		}
 

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -579,8 +579,8 @@ func (kc *KTranslate) doEnrichments(ctx context.Context, citycache map[uint32]st
 		}
 
 		// See if we know what service this is based on proto and port.
-		if _, ok := msg.CustomStr["application"]; !ok {
-			if msg.L4SrcPort < msg.L4DstPort {
+		if msg.CustomStr["application"] == "" {
+			if msg.L4SrcPort > 0 && msg.L4SrcPort < msg.L4DstPort {
 				if app, ok := kc.rule.GetService(sip, msg.L4SrcPort, ic.PROTO_NUMS[msg.Protocol]); ok {
 					msg.CustomStr["application"] = app
 				}

--- a/pkg/inputs/flow/specials.go
+++ b/pkg/inputs/flow/specials.go
@@ -101,7 +101,7 @@ func loadNBar(cfg *ktranslate.FlowInputConfig) EntConfig {
 			},
 		},
 		NameMap: map[string]string{
-			"CustomBytes1": "Application Name",
+			"CustomBytes1": "application",
 			"CustomBytes2": "Application Category",
 			"CustomBytes3": "Application Subcategory",
 			"CustomBytes4": "Application Group",

--- a/pkg/inputs/flow/specials.go
+++ b/pkg/inputs/flow/specials.go
@@ -1,0 +1,170 @@
+package flow
+
+import (
+	"strings"
+
+	"github.com/kentik/ktranslate"
+
+	"github.com/netsampler/goflow2/producer"
+)
+
+func loadASA(cfg *ktranslate.FlowInputConfig) EntConfig {
+	config := EntConfig{
+		FlowConfig: producer.ProducerConfig{
+			IPFIX: producer.IPFIXProducerConfig{
+				Mapping: []producer.NetFlowMapField{
+					producer.NetFlowMapField{
+						Type:        231,
+						Destination: "CustomInteger1",
+					},
+					producer.NetFlowMapField{
+						Type:        232,
+						Destination: "CustomInteger2",
+					},
+					producer.NetFlowMapField{
+						Type:        298,
+						Destination: "CustomInteger3",
+					},
+					producer.NetFlowMapField{
+						Type:        299,
+						Destination: "CustomInteger4",
+					},
+					producer.NetFlowMapField{
+						Type:        233,
+						Destination: "CustomInteger5",
+					},
+					producer.NetFlowMapField{
+						Type:        33000,
+						Destination: "CustomBytes1",
+					},
+					producer.NetFlowMapField{
+						Type:        33001,
+						Destination: "CustomBytes2",
+					},
+				},
+			},
+		},
+		NameMap: map[string]string{
+			"CustomInteger1": "in_bytes",
+			"CustomInteger2": "out_bytes",
+			"CustomInteger3": "in_pkts",
+			"CustomInteger4": "out_pkts",
+			"CustomInteger5": "Firewall Event",
+			"CustomBytes1":   "Ingress ACL",
+			"CustomBytes2":   "Egress ACL",
+		},
+	}
+
+	for field, _ := range config.NameMap {
+		if !strings.Contains(cfg.MessageFields, field) {
+			cfg.MessageFields = cfg.MessageFields + "," + field
+		}
+	}
+
+	return config
+}
+
+func loadNBar(cfg *ktranslate.FlowInputConfig) EntConfig {
+	config := EntConfig{
+		FlowConfig: producer.ProducerConfig{
+			IPFIX: producer.IPFIXProducerConfig{
+				Mapping: []producer.NetFlowMapField{
+					producer.NetFlowMapField{
+						Type:        96,
+						Destination: "CustomBytes1",
+					},
+					producer.NetFlowMapField{
+						Type:        12232,
+						Destination: "CustomBytes2",
+						PenProvided: true,
+						Pen:         9,
+					},
+					producer.NetFlowMapField{
+						Type:        12233,
+						Destination: "CustomBytes3",
+						PenProvided: true,
+						Pen:         9,
+					},
+					producer.NetFlowMapField{
+						Type:        12234,
+						Destination: "CustomBytes4",
+						PenProvided: true,
+						Pen:         9,
+					},
+					producer.NetFlowMapField{
+						Type:        12243,
+						Destination: "CustomBytes5",
+						PenProvided: true,
+						Pen:         9,
+					},
+				},
+			},
+		},
+		NameMap: map[string]string{
+			"CustomBytes1": "Application Name",
+			"CustomBytes2": "Application Category",
+			"CustomBytes3": "Application Subcategory",
+			"CustomBytes4": "Application Group",
+			"CustomBytes5": "Application Traffic Class",
+		},
+	}
+
+	for field, _ := range config.NameMap {
+		if !strings.Contains(cfg.MessageFields, field) {
+			cfg.MessageFields = cfg.MessageFields + "," + field
+		}
+	}
+
+	return config
+}
+
+func loadPAN(cfg *ktranslate.FlowInputConfig) EntConfig {
+	config := EntConfig{
+		FlowConfig: producer.ProducerConfig{
+			IPFIX: producer.IPFIXProducerConfig{
+				Mapping: []producer.NetFlowMapField{
+					producer.NetFlowMapField{
+						Type:        32,
+						Destination: "CustomInteger1",
+					},
+					producer.NetFlowMapField{
+						Type:        148,
+						Destination: "CustomInteger2",
+					},
+					producer.NetFlowMapField{
+						Type:        233,
+						Destination: "CustomInteger3",
+					},
+					producer.NetFlowMapField{
+						Type:        61,
+						Destination: "CustomInteger4",
+					},
+					producer.NetFlowMapField{
+						Type:        56701,
+						Destination: "CustomBytes1",
+					},
+					producer.NetFlowMapField{
+						Type:        56702,
+						Destination: "CustomBytes2",
+					},
+				},
+			},
+		},
+		NameMap: map[string]string{
+			"CustomInteger1": "ICMP Type",
+			"CustomInteger2": "Flow ID",
+			"CustomInteger3": "Firewall Event",
+			"CustomInteger4": "Direction",
+			"CustomBytes1":   "Application ID",
+			"CustomBytes2":   "User ID",
+		},
+	}
+
+	for field, _ := range config.NameMap {
+		if !strings.Contains(cfg.MessageFields, field) {
+			cfg.MessageFields = cfg.MessageFields + "," + field
+		}
+	}
+
+	return config
+}


### PR DESCRIPTION
This is a way to get extended IPFIX fields from a few common senders: ASA, NBAR and Palo Alto.

The flag `-nf.source` is extended with 3 new values: `asa,nbar,pan`. 

These will accept specific flow from a Cisco ASA, Nbar and Palo Alto firewall. See the special.go file for how these fields are mapped in. Eliminates the need for a config json file to get passed in for every one of these boxes. 