### PR TITLE
allow simple listen with /service_info

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -539,6 +539,7 @@ func (kc *KTranslate) reduce(in []*kt.JCHF) []*kt.JCHF {
 func (kc *KTranslate) getRouter() http.Handler {
 	r := kmux.NewRouter()
 	r.HandleFunc(HttpAlertInboundPath, kc.handleFlow)
+	r.HandleFunc(HttpInfoPath, kc.HttpInfo)
 	r.HandleFunc(HttpHealthCheckPath, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "OK\n") // nolint: errcheck
 	})

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -31,6 +31,7 @@ import (
 const (
 	HttpHealthCheckPath         = "/check"
 	HttpAlertInboundPath        = "/chf"
+	HttpInfoPath                = "/service_info"
 	HttpCompanyID               = "sid"
 	HttpAlertKey                = "key"
 	MaxProxyListenerBufferAlloc = 10 * 1024 * 1024 // 10MB


### PR DESCRIPTION
What do you think about this? 

Piggybacks on the existing `listen` handler to have a very basic hc port here too. Defaults to `127.0.0.1:8081` unless otherwise specified. 

Closes #412.

For example:

```
curl 127.0.0.1:8081/service_info | jq .
{
  "Flows": 0,
  "DroppedFlows": 0,
  "FlowsOut": 0,
  "Errors": 0,
  "AlphaQ": 0,
  "JCHFQ": 8000,
  "AlphaQDrop": 0,
  "InputQ": 0,
  "InputQLen": 0,
  "OutputQLen": 0,
  "Sinks": {
    "stdout": {}
  },
  "SnmpDeviceData": {},
  "Inputs": {}
}
```