### PR TITLE
Remembering that append on an array in go returns a new address

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -575,14 +575,14 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 
 	// Grap varioius rates computed over time here if possible.
 	if f.lastMetadata[in.DeviceName] != nil {
-		f.setRates("In", in, results, attr, profileName, ip)
-		f.setRates("Out", in, results, attr, profileName, ip)
+		results = f.setRates("In", in, results, attr, profileName, ip)
+		results = f.setRates("Out", in, results, attr, profileName, ip)
 	}
 
 	return results
 }
 
-func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxData, attr map[string]interface{}, profileName string, ip interface{}) {
+func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxData, attr map[string]interface{}, profileName string, ip interface{}) []InfluxData {
 	var port kt.IfaceID
 	if direction == "In" {
 		port = in.InputPort
@@ -631,6 +631,8 @@ func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxD
 			}
 		}
 	}
+
+	return results
 }
 
 func getMib(attr map[string]interface{}, ip interface{}) string {


### PR DESCRIPTION
 (I guess)

This adds in 

```
IF-MIB::if,device_name=mabel,if_Description=eth1,if_Index=4,if_PhysAddress=00:11:32:ee:8f:2a,if_Speed=1000,if_Type=ethernetcsmacd,if_interface_name=eth1,instrumentation.name=disk_station,tags.level=provider,tags.test=one,tags.type=nas ifHCOutBroadcastPkts=0i,ifHCOutMulticastPkts=0i,ifHCInBroadcastPkts=0i,ifInDiscards=0i,ifHCInUcastPkts=288i,ifHCOutUcastPkts=287i,if_AdminStatus=1i,ifOutDiscards=0i,ifHCInMulticastPkts=66i,IfOutPktRate=15.614798694232862,IfInPktRate=19.26006528835691,if_AdminStatus_str="up" 1662065557000000000
``` 

For realz. 