### PR TITLE
Support more complex traps with indexes

### DIFF
--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -98,6 +98,15 @@ func (db *MibDB) GetForKey(oid string) (*kt.Mib, error) {
 		return res, nil
 	}
 
+	// Now walk resursivly up the tree, seeing what profiles are found via a wildcard
+	pts := strings.Split(oid, ".")
+	for i := len(pts); i > 0; i-- {
+		check := strings.Join(pts[0:i], ".") + ".*"
+		if t, ok := db.trapMibs[check]; ok {
+			return t, nil
+		}
+	}
+
 	if db.db == nil { // We might not have set up a db here.
 		return nil, nil
 	}
@@ -109,7 +118,7 @@ func (db *MibDB) GetForKey(oid string) (*kt.Mib, error) {
 		return nil, err
 	}
 
-	pts := strings.SplitN(string(data), " ", 2)
+	pts = strings.SplitN(string(data), " ", 2)
 	if len(pts) >= 2 {
 		res := reType.FindAllStringSubmatch(pts[1], -1)
 		if len(res) > 0 {


### PR DESCRIPTION
Given a trap like 

```
-------
traps:
  - trap_oid: 1.3.6.1.4.1.12196.13.3.1.2
    trap_name: rSstateChange
    events:
      # Unique VS Id
      - name: vSidx
        OID: 1.3.6.1.4.1.12196.13.1.1.1.*
      # IP address of VS Differented by AddressType
      - name: vSip
        OID: 1.3.6.1.4.1.12196.13.1.1.2.*
      # VS port number
      - name: vSport
        OID: 1.3.6.1.4.1.12196.13.1.1.3.*
      # VS address type
      - name: vSaddrtype
        OID: 1.3.6.1.4.1.12196.13.1.1.4.*
      # Name of the VS
      - name: vSname
        OID: 1.3.6.1.4.1.12196.13.1.1.13.*
      # IP address of RS
      - name: rSip
        OID: 1.3.6.1.4.1.12196.13.2.1.2.*
      # RS port number
      - name: rSport
        OID: 1.3.6.1.4.1.12196.13.2.1.3.*
      # RS address type
      - name: rSaddrtype
        OID: 1.3.6.1.4.1.12196.13.2.1.4.*
      # Unique Id of RS
      - name: rSidx
        OID: 1.3.6.1.4.1.12196.13.2.1.5.*
      # current state of RS
      - name: rSstate
        OID: 1.3.6.1.4.1.12196.13.2.1.8.*
```

And input of 

```
snmptrap -v 2c -c hello 127.0.0.1:1620 '' 1.3.6.1.4.1.12196.13.3.1.2 1.3.6.1.4.1.12196.13.1.1.1.26 s 26 1.3.6.1.4.1.12196.13.1.1.2.26 s 192.2.3.4 1.3.6.1.4.1.12196.13.1.1.3.26 s 443 1.3.6.1.4.1.12196.13.1.1.4.26 s ipv4 1.3.6.1.4.1.12196.13.1.1.13.26 s servnameabc
```

This will produce output of:

```
  {
    "device_name": "127.0.0.1",
    "instrumentation.name": "netflow-events",
    "eventType": "KSnmpTrap",
    "TrapName": "rSstateChange",
    "provider": "kentik-trap-device",
    "vSaddrtype": "ipv4",
    "vSport": "443",
    "vSidx": "26",
    "vSip": "192.2.3.4",
    "instrumentation.provider": "kentik",
    "TrapOID": ".1.3.6.1.4.1.12196.13.3.1.2",
    "vSname": "servnameabc",
    ".1.3.6.1.2.1.1.3.0": 69940552,
    "src_addr": "127.0.0.1",
    "collector.name": "ktranslate"
  }
```