### PR TITLE
Write out an id file with ed25519 key if id_file flag is set. #415

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -560,6 +560,8 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.Server.OllyDataset = val
 			case "olly_write_key":
 				cfg.Server.OllyWriteKey = val
+			case "id_file":
+				cfg.Server.IDFileLocation = val
 			// pkg/api
 			case "api_device_file":
 				cfg.API.DeviceFile = val

--- a/config.go
+++ b/config.go
@@ -124,13 +124,13 @@ type ServerConfig struct {
 	privKey         []byte
 }
 
-// Allows a pub/priv keypair to be passed in to this server config.
+// SetKeys allows a pub/priv keypair to be passed in to this server config.
 func (s *ServerConfig) SetKeys(pub []byte, priv []byte) { s.pubKey = pub; s.privKey = priv }
 
-// Lets you get the public key out of the config.
+// GetPubKey lets you get the public key out of the config.
 func (s *ServerConfig) GetPubKey() []byte { return s.pubKey }
 
-// uses the key to sign the passed in message.
+// Sign uses the key to sign the passed in message.
 func (s *ServerConfig) Sign(msg []byte) []byte { return ed25519.Sign(s.privKey, msg) }
 
 // APIConfig is the config for the API service

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package ktranslate
 
 import (
+	"crypto/ed25519"
 	"os"
 
 	yaml "gopkg.in/yaml.v3"
@@ -123,8 +124,14 @@ type ServerConfig struct {
 	privKey         []byte
 }
 
+// Allows a pub/priv keypair to be passed in to this server config.
 func (s *ServerConfig) SetKeys(pub []byte, priv []byte) { s.pubKey = pub; s.privKey = priv }
-func (s *ServerConfig) GetPubKey() []byte               { return s.pubKey }
+
+// Lets you get the public key out of the config.
+func (s *ServerConfig) GetPubKey() []byte { return s.pubKey }
+
+// uses the key to sign the passed in message.
+func (s *ServerConfig) Sign(msg []byte) []byte { return ed25519.Sign(s.privKey, msg) }
 
 // APIConfig is the config for the API service
 type APIConfig struct {

--- a/config.go
+++ b/config.go
@@ -118,7 +118,13 @@ type ServerConfig struct {
 	MetaListenAddr  string
 	OllyDataset     string
 	OllyWriteKey    string
+	IDFileLocation  string
+	pubKey          []byte
+	privKey         []byte
 }
+
+func (s *ServerConfig) SetKeys(pub []byte, priv []byte) { s.pubKey = pub; s.privKey = priv }
+func (s *ServerConfig) GetPubKey() []byte               { return s.pubKey }
 
 // APIConfig is the config for the API service
 type APIConfig struct {
@@ -378,6 +384,7 @@ func DefaultConfig() *Config {
 			MetaListenAddr:  "localhost:0",
 			OllyDataset:     "",
 			OllyWriteKey:    "",
+			IDFileLocation:  "",
 		},
 		API: &APIConfig{
 			DeviceFile: "",

--- a/pkg/eggs/baseserver/id.go
+++ b/pkg/eggs/baseserver/id.go
@@ -1,0 +1,77 @@
+package baseserver
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+func (bs *BaseServer) checkIDFile(ctx context.Context) {
+	if bs.BaseServerConfiguration.IDFileLocation == "" {
+		return
+	}
+
+	// Try reading this file.
+	_, err := os.Stat(bs.BaseServerConfiguration.IDFileLocation)
+	if err != nil { // Create the file in this case.
+		if os.IsNotExist(err) {
+			bs.createIDFile()
+			return
+		}
+	}
+
+	// Get it and convert to pub/private keypair.
+	fileC, err := os.ReadFile(bs.BaseServerConfiguration.IDFileLocation)
+	if err != nil {
+		bs.Fail(fmt.Sprintf("service error with id from %s: %v", bs.BaseServerConfiguration.IDFileLocation, err))
+	}
+
+	sDec := make([]byte, base64.StdEncoding.DecodedLen(len(fileC)))
+	n, err := base64.StdEncoding.Decode(sDec, fileC)
+	if err != nil {
+		bs.Fail(fmt.Sprintf("decode error with id: %v", err))
+	}
+	sDec = sDec[:n]
+
+	pub := sDec[0:ed25519.PublicKeySize]
+	priv := sDec[ed25519.PublicKeySize:ed25519.PrivateKeySize]
+	sig := sDec[ed25519.PublicKeySize+ed25519.PrivateKeySize : ed25519.PublicKeySize+ed25519.PrivateKeySize+ed25519.SignatureSize]
+	msg := sDec[ed25519.PublicKeySize+ed25519.PrivateKeySize+ed25519.SignatureSize:]
+
+	// Verify signature of file
+	if !ed25519.Verify(pub, msg, sig) {
+		bs.Fail(fmt.Sprintf("Invalid ID file detected at %s", bs.BaseServerConfiguration.IDFileLocation))
+	}
+
+	bs.config.SetKeys(pub, priv)
+	bs.Logger.Infof(bs.LogPrefix, "Loaded existing id %x from file %s", pub, bs.BaseServerConfiguration.IDFileLocation)
+}
+
+func (bs *BaseServer) createIDFile() {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		bs.Fail(fmt.Sprintf("service create key err %s", err))
+	}
+
+	msg := []byte("kentik/ktranslate")
+	sig := ed25519.Sign(priv, msg)
+
+	full := make([]byte, len(pub)+len(priv)+len(sig)+len(msg))
+	copy(full, pub)
+	copy(full[len(pub):], priv)
+	copy(full[len(pub)+len(priv):], sig)
+	copy(full[len(pub)+len(priv)+len(sig):], msg)
+
+	sEnc := make([]byte, base64.StdEncoding.EncodedLen(len(full)))
+	base64.StdEncoding.Encode(sEnc, full)
+
+	err = os.WriteFile(bs.BaseServerConfiguration.IDFileLocation, sEnc, 0644)
+	if err != nil {
+		bs.Fail(fmt.Sprintf("encode error write to %s with id: %v", bs.BaseServerConfiguration.IDFileLocation, err))
+	}
+
+	bs.config.SetKeys(pub, priv)
+	bs.Logger.Infof(bs.LogPrefix, "Created new id %x from file %s", pub, bs.BaseServerConfiguration.IDFileLocation)
+}

--- a/pkg/eggs/baseserver/id.go
+++ b/pkg/eggs/baseserver/id.go
@@ -67,7 +67,7 @@ func (bs *BaseServer) createIDFile() {
 	sEnc := make([]byte, base64.StdEncoding.EncodedLen(len(full)))
 	base64.StdEncoding.Encode(sEnc, full)
 
-	err = os.WriteFile(bs.BaseServerConfiguration.IDFileLocation, sEnc, 0644)
+	err = os.WriteFile(bs.BaseServerConfiguration.IDFileLocation, sEnc, 0600)
 	if err != nil {
 		bs.Fail(fmt.Sprintf("encode error write to %s with id: %v", bs.BaseServerConfiguration.IDFileLocation, err))
 	}


### PR DESCRIPTION
This adds the flag and config option `id_file` / `IDFileLocation`

If set, a ed25519 pub/private keypair will get written out to the specified location. On reload of the program, a short signed message also in this file will get verified. Not doing anything with the id yet, but it should be persisted across runs. 

Note with docker / k8s its up to the user to do the right thing and set this file somewhere which will persist.  

Closes #415.