### PR TITLE
Extend the data pulled from kentik to insert snmp info into device data

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -294,7 +294,6 @@ func NewKentikApiFromLocalDevices(localDevices map[string]*kt.Device, log logger
 	api.setTime = time.Now()
 	api.Infof("Loaded %d Kentik devices via local file", num)
 	api.devices = resDev
-
 	return api
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -294,6 +294,7 @@ func NewKentikApiFromLocalDevices(localDevices map[string]*kt.Device, log logger
 	api.setTime = time.Now()
 	api.Infof("Loaded %d Kentik devices via local file", num)
 	api.devices = resDev
+
 	return api
 }
 

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -29,6 +29,9 @@ type Device struct {
 	MaxFlowRate   int                   `json:"max_flow_rate"`
 	Customs       []Column              `json:"custom_column_data,omitempty"`
 	CustomStr     string                `json:"custom_columns"`
+	SnmpCommunity string                `json:"device_snmp_community"`
+	SnmpIp        string                `json:"device_snmp_ip"`
+	SnmpV3        *V3SNMPConfig         `json:"device_snmp_v3_conf"`
 	allUserTags   map[string]string
 }
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -128,13 +128,13 @@ type TopValue struct {
 }
 
 type V3SNMPConfig struct {
-	UserName                 string `yaml:"user_name"`
-	AuthenticationProtocol   string `yaml:"authentication_protocol"`
-	AuthenticationPassphrase string `yaml:"authentication_passphrase"`
-	PrivacyProtocol          string `yaml:"privacy_protocol"`
-	PrivacyPassphrase        string `yaml:"privacy_passphrase"`
-	ContextEngineID          string `yaml:"context_engine_id"`
-	ContextName              string `yaml:"context_name"`
+	UserName                 string `yaml:"user_name" json:"UserName"`
+	AuthenticationProtocol   string `yaml:"authentication_protocol" json:"AuthenticationProtocol"`
+	AuthenticationPassphrase string `yaml:"authentication_passphrase" json:"AuthenticationPassphrase"`
+	PrivacyProtocol          string `yaml:"privacy_protocol" json:"PrivacyProtocol"`
+	PrivacyPassphrase        string `yaml:"privacy_passphrase" json:"PrivacyPassphrase"`
+	ContextEngineID          string `yaml:"context_engine_id" json:"ContextEngineID"`
+	ContextName              string `yaml:"context_name" json:"ContextName"`
 	useGlobal                bool
 	origStr                  string
 }


### PR DESCRIPTION
Add in fields to the API client schema to get snmp credential info from kentik (if set).