### PR TITLE
WIP -- look at allowing regex to be named fields #402

### DIFF
--- a/pkg/inputs/snmp/metadata/interface_metadata.go
+++ b/pkg/inputs/snmp/metadata/interface_metadata.go
@@ -247,7 +247,7 @@ func (im *InterfaceMetadata) Poll(ctx context.Context, conf *kt.SnmpDeviceConfig
 				case SNMP_ifPhysAddress:
 					switch variable.Type {
 					case gosnmp.OctetString:
-						_, sval := snmp_util.GetFromConv(variable, "hwaddr", im.log)
+						_, sval, _ := snmp_util.GetFromConv(variable, "hwaddr", im.log)
 						data.ExtraInfo[SNMP_ifPhysAddress] = sval
 					}
 				case SNMP_ifLastChange:

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -165,7 +165,7 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 		case gosnmp.OctetString, gosnmp.BitString:
 			value := string(wrapper.variable.Value.([]byte))
 			if wrapper.mib.Conversion != "" { // Adjust for any hard coded values here.
-				ival, sval := snmp_util.GetFromConv(wrapper.variable, wrapper.mib.Conversion, dm.log)
+				ival, sval, _ := snmp_util.GetFromConv(wrapper.variable, wrapper.mib.Conversion, dm.log)
 				if ival > 0 {
 					dmr.customBigInt[oidName] = ival
 					dmr.customStr[kt.StringPrefix+oidName] = sval

--- a/pkg/inputs/snmp/util/vendor/powerset.go
+++ b/pkg/inputs/snmp/util/vendor/powerset.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-func HandlePowersetStatus(bv []byte) (int64, string) {
+func HandlePowersetStatus(bv []byte) (int64, string, map[string]string) {
 	actives := make([]*UpsCode, len(upsCodes))
 
 	for i, v := range bv {
@@ -43,12 +43,12 @@ func HandlePowersetStatus(bv []byte) (int64, string) {
 
 	for i := len(severities); i > 0; i-- {
 		if len(severity[i]) > 0 { // Return the highest severity present which has flags set.
-			return int64(i), severities[i-1] + ": " + strings.Join(severity[i], ",")
+			return int64(i), severities[i-1] + ": " + strings.Join(severity[i], ","), nil
 		}
 	}
 
 	// Generally assume you don't get here.
-	return 0, ""
+	return 0, "", nil
 }
 
 type UpsCode struct {


### PR DESCRIPTION
What do you guys think about this? 

Rather than allowing duplicate oids which would be a real nightmare to support, this instead allows named [regexes](https://github.com/StefanSchroeder/Golang-Regex-Tutorial/blob/master/01-chapter2.markdown#named-matches) to be matched on multiple submatches. For example:

```
      - column:
          OID: .1.0.8802.1.1.2.1.3.4.0
          name: extendedDesc
          conversion: "regexp:Juniper Networks, Inc. (?P<os_name>\\S+?) , version (?P<os_version>\\S+)"
```

Results in

```
kentik.flowdevice,SysDescr=Juniper\ Networks\,\ Inc.\ mx80-48t\ internet\ router\,\ kernel\ JUNOS\ 13.3R9.13\,\ Build\ date:\ 2016-03-01\ 09:06:52\ UTC\ Copyright\ (c)\ 1996-2016\ Juniper\ Networks\,\ Inc.,SysLocation=iad1-dc3-5012,SysName=edge01.iad1,SysObjectID=.1.3.6.1.4.1.2636.1.1.1.2.57,device_ip=209.50.158.253,device_name=edge01.iad1,instrumentation.name=juniper-mx-router,os_name=mx80-48t,os_version=13.3R9.13,src_addr=209.50.158.253 Uptime=2036791728i 1662686373000000000
```

Pulling out the fields `os_name=mx80-48t` and `os_version=13.3R9.13` via the single entry of `.1.0.8802.1.1.2.1.3.4.0`. 

Closes #402 