### PR TITLE
tweaking how prefix for influx is set

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -24,7 +24,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&measurementPrefix, "influxdb_measurement_prefix", "kentik.flow", "Prefix metric names with this")
+	flag.StringVar(&measurementPrefix, "influxdb_measurement_prefix", "", "Prefix metric names with this")
 
 }
 
@@ -460,7 +460,7 @@ func (f *InfluxFormat) fromKSynth(in *kt.JCHF) []InfluxData {
 	}
 
 	return []InfluxData{{
-		Name:      f.config.MeasurementPrefix,
+		Name:      f.config.MeasurementPrefix + "ksynth",
 		Fields:    ms,
 		Timestamp: in.Timestamp * 1000000000,
 		Tags:      attr,
@@ -491,7 +491,7 @@ func (f *InfluxFormat) fromKflow(in *kt.JCHF) []InfluxData {
 	}
 
 	return []InfluxData{{
-		Name:      f.config.MeasurementPrefix,
+		Name:      f.config.MeasurementPrefix + "flow",
 		Fields:    ms,
 		Timestamp: in.Timestamp * 1000000000,
 		Tags:      attr,


### PR DESCRIPTION
This goes back to a default of empty string for influx prefix, but also uses `ksynth` and `kflow` to fix flow and ksynth cases in influx. 