### PR TITLE
Fixing gap with bad snmpv3 server

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -229,7 +229,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 	}
 
 	// Loop over all possibe v2c options here if any are set.
-	if md == nil { // Only check these if v3 hasn't found anything.
+	if md == nil || md.SysObjectID == "" { // Only check these if v3 hasn't found anything.
 		for _, community := range conf.Disco.DefaultCommunities {
 			device = kt.SnmpDeviceConfig{
 				DeviceName: result.Name,


### PR DESCRIPTION
I found a case where a bad snmp server can trick the client into thinking there's a working v3 connection when actually it should be trying v2. This adds another guard to keep the disco discoing. 