### PR TITLE
Fixing a bug with how config file plays with syslog

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -219,6 +219,7 @@ func applyMode(cfg *ktranslate.Config, mode string) error {
 		if cfg.SyslogInput.ListenAddr == "" {
 			cfg.SyslogInput.ListenAddr = "0.0.0.0:5143"
 		}
+		cfg.SyslogInput.Enable = true
 	case "nr1.snmp": // Tune for snmp sending.
 		cfg.Compression = "gzip"
 		cfg.Sinks = "new_relic"


### PR DESCRIPTION
Fixes a bug where `nr1.syslog` wasn't actually turning on syslog. This was introduced when a common config file was added. 

Fixes #435 