### PR TITLE
influx: use kflow timestamp

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -462,7 +462,7 @@ func (f *InfluxFormat) fromKSynth(in *kt.JCHF) []InfluxData {
 	return []InfluxData{{
 		Name:      f.config.MeasurementPrefix + "ksynth",
 		Fields:    ms,
-		Timestamp: in.Timestamp * 1000000000,
+		Timestamp: in.Timestamp,
 		Tags:      attr,
 	}}
 }
@@ -493,7 +493,7 @@ func (f *InfluxFormat) fromKflow(in *kt.JCHF) []InfluxData {
 	return []InfluxData{{
 		Name:      f.config.MeasurementPrefix + "flow",
 		Fields:    ms,
-		Timestamp: in.Timestamp * 1000000000,
+		Timestamp: in.Timestamp,
 		Tags:      attr,
 	}}
 }
@@ -523,14 +523,14 @@ func (f *InfluxFormat) fromSnmpDeviceMetric(in *kt.JCHF) []InfluxData {
 				results = append(results, InfluxData{
 					Name:        f.config.MeasurementPrefix + mib,
 					FieldsFloat: map[string]float64{m: float64(float64(in.CustomBigInt[m]) / 1000)},
-					Timestamp:   in.Timestamp * 1000000000,
+					Timestamp:   in.Timestamp,
 					Tags:        attrNew,
 				})
 			} else {
 				results = append(results, InfluxData{
 					Name:      f.config.MeasurementPrefix + mib,
 					Fields:    map[string]int64{m: int64(in.CustomBigInt[m])},
-					Timestamp: in.Timestamp * 1000000000,
+					Timestamp: in.Timestamp,
 					Tags:      attrNew,
 				})
 			}
@@ -567,14 +567,14 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 				results = append(results, InfluxData{
 					Name:        f.config.MeasurementPrefix + mib,
 					FieldsFloat: map[string]float64{m: float64(float64(in.CustomBigInt[m]) / 1000)},
-					Timestamp:   in.Timestamp * 1000000000,
+					Timestamp:   in.Timestamp,
 					Tags:        attrNew,
 				})
 			} else {
 				results = append(results, InfluxData{
 					Name:      f.config.MeasurementPrefix + mib,
 					Fields:    map[string]int64{m: int64(in.CustomBigInt[m])},
-					Timestamp: in.Timestamp * 1000000000,
+					Timestamp: in.Timestamp,
 					Tags:      attrNew,
 				})
 				if sv, ok := in.CustomStr[kt.StringPrefix+m]; ok {
@@ -619,13 +619,13 @@ func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxD
 							results = append(results, InfluxData{
 								Name:        f.config.MeasurementPrefix + "IF-MIB::if",
 								FieldsFloat: map[string]float64{utilName: float64(totalBytes*8*100) / float64(uptimeSpeed)},
-								Timestamp:   in.Timestamp * 1000000000,
+								Timestamp:   in.Timestamp,
 								Tags:        attrNew,
 							})
 							results = append(results, InfluxData{
 								Name:        f.config.MeasurementPrefix + "IF-MIB::if",
 								FieldsFloat: map[string]float64{bitRate: float64(totalBytes*8*100) / float64(uptime)},
-								Timestamp:   in.Timestamp * 1000000000,
+								Timestamp:   in.Timestamp,
 								Tags:        attrNew,
 							})
 						}
@@ -633,7 +633,7 @@ func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxD
 							results = append(results, InfluxData{
 								Name:        f.config.MeasurementPrefix + "IF-MIB::if",
 								FieldsFloat: map[string]float64{pktRate: float64(totalPkts*100) / float64(uptime)},
-								Timestamp:   in.Timestamp * 1000000000,
+								Timestamp:   in.Timestamp,
 								Tags:        attrNew,
 							})
 						}


### PR DESCRIPTION
This updates the InfluxDB formatter to use the kflow timestamp.

Before:
```
unable to parse 'flow,SamplerAddress=172.20.0.4,Type=NETFLOW_V5,device_name=172.20.0.4,dst_addr=10.12.190.10,dst_as=53288,dst_as_name=Private\\ IP,dst_endpoint=10.12.190.10:
123,dst_geo=Private\\ IP,eventType=KFlow,l4_dst_port=123,l4_src_port=40,protocol=UDP,provider=kentik-flow-device,sample_rate=1,src_addr=247.104.20.202,src_as=41865,src_as_name=Private\\ IP,src_endpoint=247
.104.20.202:40,src_geo=Private\\ IP in_bytes=1001i,out_bytes=0i,in_pkts=654i,out_pkts=0i,latency_ms=0i 3574804366140354560': time outside range -9223372036854775806 - 9223372036854775806
```

After:
```
flow,SamplerAddress=172.20.0.4,Type=NETFLOW_V5,application=domain,device_name=172.20.0.4,dst_addr=10.12.233.210,dst_as=20412,dst_as_name=Private\ IP,dst_endpoint=10.12.233.210:53,d
st_geo=Private\ IP,eventType=KFlow,l4_dst_port=53,l4_src_port=9221,protocol=UDP,provider=kentik-flow-device,sample_rate=1,src_addr=59.220.158.122,src_endpoint=59.220.158.122:9221,src_geo=CN latency_ms=0i,i
n_bytes=602i,out_bytes=0i,in_pkts=177i,out_pkts=0i 1663781528000
```