### PR TITLE
Make Kentik / KFlow a normal sink

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -351,7 +351,7 @@ func applyFlags(cfg *ktranslate.Config) error {
 				}
 				cfg.EnableSNMPDiscovery = v
 			case "kentik_email":
-				cfg.KentikCreds = []ktranslate.KentikCred{ktranslate.KentikCred{ApiEmail: val, ApiToken: os.Getenv(ktranslate.KentikAPITokenEnvVar)}}
+				cfg.KentikCreds = []ktranslate.KentikCred{ktranslate.KentikCred{APIEmail: val, APIToken: os.Getenv(ktranslate.KentikAPITokenEnvVar)}}
 			case "api_root":
 				cfg.APIBaseURL = val
 			case "kentik_plan":

--- a/config.go
+++ b/config.go
@@ -195,9 +195,10 @@ type FlowInputConfig struct {
 	MappingFile          string
 }
 
+// KentikCred is information needed to auth the Kentik API.
 type KentikCred struct {
-	ApiEmail string
-	ApiToken string
+	APIEmail string
+	APIToken string
 }
 
 // Config is the ktranslate configuration

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -239,7 +239,7 @@ func (api *KentikApi) getDevices(ctx context.Context) error {
 	resDev := map[kt.Cid]kt.Devices{}
 	num := 0
 	for _, info := range api.config.KentikCreds {
-		res, err := api.getDeviceInfo(ctx, api.config.APIBaseURL+"/api/internal/devices", info.ApiEmail, info.ApiToken)
+		res, err := api.getDeviceInfo(ctx, api.config.APIBaseURL+"/api/internal/devices", info.APIEmail, info.APIToken)
 		if err != nil {
 			return err
 		}
@@ -262,7 +262,7 @@ func (api *KentikApi) getDevices(ctx context.Context) error {
 			num++
 		}
 
-		api.Infof("Loaded %d Kentik devices via API for %s", len(devices.Devices), info.ApiEmail)
+		api.Infof("Loaded %d Kentik devices via API for %s", len(devices.Devices), info.APIEmail)
 	}
 
 	api.setTime = time.Now()
@@ -362,8 +362,8 @@ func (api *KentikApi) getSynthInfo(ctx context.Context) error {
 	synAgentsByIP := map[string]*synthetics.Agent{}
 	for _, info := range api.config.KentikCreds {
 		md := metadata.New(map[string]string{
-			"X-CH-Auth-Email":     info.ApiEmail,
-			"X-CH-Auth-API-Token": info.ApiToken,
+			"X-CH-Auth-Email":     info.APIEmail,
+			"X-CH-Auth-API-Token": info.APIToken,
 		})
 		ctxo := metadata.NewOutgoingContext(ctx, md)
 
@@ -394,7 +394,7 @@ func (api *KentikApi) getSynthInfo(ctx context.Context) error {
 			synAgentsByIP[locala.GetIp()] = locala
 		}
 
-		api.Infof("Loaded %d Kentik Tests and %d Agents via API for %s", len(r.GetTests()), len(ra.GetAgents()), info.ApiEmail)
+		api.Infof("Loaded %d Kentik Tests and %d Agents via API for %s", len(r.GetTests()), len(ra.GetAgents()), info.APIEmail)
 	}
 
 	api.synAgents = synAgents
@@ -470,8 +470,8 @@ func (api *KentikApi) createDevice(ctx context.Context, create *deviceCreate, ur
 	}
 
 	userAgentString := USER_AGENT_BASE
-	req.Header.Add(API_EMAIL_HEADER, api.config.KentikCreds[0].ApiEmail)
-	req.Header.Add(API_PASSWORD_HEADER, api.config.KentikCreds[0].ApiToken)
+	req.Header.Add(API_EMAIL_HEADER, api.config.KentikCreds[0].APIEmail)
+	req.Header.Add(API_PASSWORD_HEADER, api.config.KentikCreds[0].APIToken)
 	req.Header.Add(HTTP_USER_AGENT, userAgentString+" AGENT")
 	req.Header.Add("Content-Type", "application/json")
 

--- a/pkg/cat/auth/auth.go
+++ b/pkg/cat/auth/auth.go
@@ -109,6 +109,16 @@ func (s *Server) GetDeviceMap() map[string]*kt.Device {
 	return s.devicesByIP
 }
 
+func (s *Server) AddDevices(devices map[string]*kt.Device) {
+	for _, device := range devices {
+		s.devicesByName[device.ID.Itoa()] = device
+		for _, ip := range device.SendingIps {
+			s.devicesByIP[ip.String()] = device
+		}
+	}
+	s.log.Infof("API server running %d devices after remote fetch", len(s.devicesByName))
+}
+
 func (s *Server) getDevice(query string) *kt.Device {
 	// Try finding this device directly by its ID
 	device, ok := s.devicesByName[query]

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -107,6 +107,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 	dst.TcpRetransmit = src.CHF.TcpRetransmit()
 	dst.SampleRate = src.CHF.SampleRate() / 100 // Reduce by 100 to get actual rate.
 	dst.DeviceId = kt.DeviceID(src.CHF.DeviceId())
+	dst.DeviceName = src.DeviceName
 	dst.CompanyId = kt.Cid(src.CompanyId)
 	dst.SrcNextHopAs = src.CHF.SrcNextHopAs()
 	dst.DstNextHopAs = src.CHF.DstNextHopAs()

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -121,27 +121,11 @@ func (kc *KTranslate) getProviderType(dst *kt.JCHF) kt.Provider {
 	return kt.ProviderFlowDevice
 }
 
-func (kc *KTranslate) flowToJCHF(ctx context.Context, citycache map[uint32]string, regioncache map[uint32]string, dst *kt.JCHF, src *Flow, currentTS int64, tagcache map[uint64]string) error {
+func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, currentTS int64, tagcache map[uint64]string) error {
 
 	dst.CustomStr = make(map[string]string)
 	dst.CustomInt = make(map[string]int32)
 	dst.CustomBigInt = make(map[string]int64)
-
-	// In the direct case, users can map their own asn/geo values into here.
-	if kc.geo != nil || kc.asn != nil {
-		srcAsnName, dstAsnName := kc.setGeoAsn(src)
-		if srcAsnName != "" {
-			dst.CustomStr["src_as_name"] = srcAsnName
-		} else {
-			dst.CustomStr["src_as_name"] = strconv.Itoa(int(src.CHF.SrcAs()))
-		}
-
-		if dstAsnName != "" {
-			dst.CustomStr["dst_as_name"] = dstAsnName
-		} else {
-			dst.CustomStr["dst_as_name"] = strconv.Itoa(int(src.CHF.DstAs()))
-		}
-	}
 
 	// dst.Timestamp = src.CHF.Timestamp() This is being strage, use current timestamp for now.
 	dst.Timestamp = currentTS
@@ -529,7 +513,7 @@ var (
 )
 
 // Updates asn and geo if set for any of these inputs.
-func (kc *KTranslate) doEnrichments(ctx context.Context, citycache map[uint32]string, regioncache map[uint32]string, msgs []*kt.JCHF) {
+func (kc *KTranslate) doEnrichments(ctx context.Context, msgs []*kt.JCHF) {
 	for _, msg := range msgs {
 		sip := net.ParseIP(msg.SrcAddr)
 		dip := net.ParseIP(msg.DstAddr)

--- a/pkg/cat/kentik.go
+++ b/pkg/cat/kentik.go
@@ -204,16 +204,11 @@ func (kc *KTranslate) handleFlow(w http.ResponseWriter, r *http.Request) {
 		offset = MSG_KEY_PREFIX
 		pts := strings.Split(senderId, ":")
 		if len(pts) == 3 {
-			cid, _ = strconv.Atoi(strings.TrimSpace(pts[1]))
+			cid, _ = strconv.Atoi(strings.TrimSpace(pts[0]))
 			deviceName = pts[1]
 			did, _ = strconv.Atoi(strings.TrimSpace(pts[2]))
 		}
 
-	}
-
-	// If we have a kentik sink, send on here.
-	if kc.kentik != nil {
-		go kc.kentik.SendKentik(context.Background(), evt, cid, senderId, offset)
 	}
 
 	// decompress and read (capnproto "packed" representation)

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kentik/ktranslate/pkg/maps"
 	"github.com/kentik/ktranslate/pkg/rollup"
 	ss "github.com/kentik/ktranslate/pkg/sinks"
-	//"github.com/kentik/ktranslate/pkg/sinks/kentik"
 	"github.com/kentik/ktranslate/pkg/util/enrich"
 	"github.com/kentik/ktranslate/pkg/util/gopatricia/patricia"
 	"github.com/kentik/ktranslate/pkg/util/resolv"

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/maps"
 	"github.com/kentik/ktranslate/pkg/rollup"
 	ss "github.com/kentik/ktranslate/pkg/sinks"
-	"github.com/kentik/ktranslate/pkg/sinks/kentik"
+	//"github.com/kentik/ktranslate/pkg/sinks/kentik"
 	"github.com/kentik/ktranslate/pkg/util/enrich"
 	"github.com/kentik/ktranslate/pkg/util/gopatricia/patricia"
 	"github.com/kentik/ktranslate/pkg/util/resolv"
@@ -169,11 +169,6 @@ func NewKTranslate(config *ktranslate.Config, log logger.ContextL, registry go_m
 		}
 		kc.sinks[sink] = snk
 		kc.log.Infof("Using sink %s", sink)
-
-		// Kentik gets special cased
-		if sink == ss.KentikSink {
-			kc.kentik = snk.(*kentik.KentikSink)
-		}
 	}
 
 	// IP based rules

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -619,6 +619,9 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 			return err
 		}
 		kc.apic = apic
+		if kc.auth != nil {
+			kc.auth.AddDevices(apic.GetDevicesAsMap(0)) // Load all these up to be authed also.
+		}
 	} else {
 		kc.apic = api.NewKentikApiFromLocalDevices(kc.auth.GetDeviceMap(), kc.log)
 	}

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -114,8 +114,9 @@ type hc struct {
 }
 
 type Flow struct {
-	CompanyId int
-	CHF       model.CHF
+	CompanyId  int
+	CHF        model.CHF
+	DeviceName string
 }
 
 type KKCMetric struct {

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -6,7 +6,6 @@ import (
 	go_metrics "github.com/kentik/go-metrics"
 	"github.com/kentik/ktranslate"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
-	"github.com/kentik/ktranslate/pkg/sinks/kentik"
 
 	"github.com/kentik/ktranslate/pkg/api"
 	"github.com/kentik/ktranslate/pkg/cat/auth"
@@ -60,7 +59,6 @@ type KTranslate struct {
 	sinks        map[sinks.Sink]sinks.SinkImpl
 	format       formats.Formatter
 	formatRollup formats.Formatter
-	kentik       *kentik.KentikSink // This one gets special handling
 	rollups      []rollup.Roller
 	doRollups    bool
 	doFilter     bool

--- a/pkg/formats/kflow/kflow.go
+++ b/pkg/formats/kflow/kflow.go
@@ -96,9 +96,8 @@ func (f *KflowFormat) To(flows []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 		return nil, err
 	}
 
-	f.Infof("Sending to %s", key)
 	z.Close()
-	return kt.NewOutputWithProviderAndCompany(buf.Bytes(), flows[0].Provider, flows[0].CompanyId, kt.EventOutput), nil
+	return kt.NewOutputWithProviderAndCompanySender(buf.Bytes(), flows[0].Provider, flows[0].CompanyId, kt.EventOutput, key[0:len(key)-1]), nil
 }
 
 func (f *KflowFormat) From(raw *kt.Output) ([]map[string]interface{}, error) {

--- a/pkg/formats/kflow/kflow.go
+++ b/pkg/formats/kflow/kflow.go
@@ -3,12 +3,15 @@ package kflow
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"net"
 
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
 	"github.com/kentik/ktranslate/pkg/kt"
 	"github.com/kentik/ktranslate/pkg/rollup"
+	patricia "github.com/kentik/ktranslate/pkg/util/gopatricia/patricia"
 	"github.com/kentik/ktranslate/pkg/util/ic"
 	model "github.com/kentik/ktranslate/pkg/util/kflow2"
 
@@ -133,7 +136,28 @@ func (f *KflowFormat) From(raw *kt.Output) ([]map[string]interface{}, error) {
 		case KTRANSLATE_PROTO:
 			flow := map[string]interface{}{
 				"timestamp": msg.Timestamp(),
+				"protocol":  ic.PROTO_NAMES[uint16(msg.Protocol())],
+				"src_geo":   fmt.Sprintf("%c%c", msg.SrcGeo()>>8, msg.SrcGeo()&0xFF),
 			}
+
+			// Now the addresses.
+			var addr net.IP
+			if msg.Ipv4DstAddr() > 0 {
+				addr = int2ip(msg.Ipv4DstAddr())
+			} else {
+				ipr, _ := msg.Ipv6DstAddr()
+				addr = net.IP(ipr)
+			}
+			flow["dst_addr"] = addr.String()
+
+			if msg.Ipv4SrcAddr() > 0 {
+				addr = int2ip(msg.Ipv4SrcAddr())
+			} else {
+				ipr, _ := msg.Ipv6SrcAddr()
+				addr = net.IP(ipr)
+			}
+			flow["src_addr"] = addr.String()
+
 			customs, _ := msg.Custom()
 			for i, customsLen := 0, customs.Len(); i < customsLen; i++ {
 				cust := customs.At(i)
@@ -176,6 +200,7 @@ func (ff *KflowFormat) pack(f *kt.JCHF, kflow model.CHF, list model.Custom_List,
 	kflow.SetAppProtocol(KTRANSLATE_PROTO)
 	kflow.SetTimestamp(f.Timestamp)
 	kflow.SetDstAs(f.DstAs)
+	kflow.SetDstGeo(patricia.PackGeo([]byte(f.DstGeo)))
 	kflow.SetHeaderLen(f.HeaderLen)
 	kflow.SetInBytes(f.InBytes)
 	kflow.SetInPkts(f.InPkts)
@@ -187,6 +212,7 @@ func (ff *KflowFormat) pack(f *kt.JCHF, kflow model.CHF, list model.Custom_List,
 	kflow.SetProtocol(uint32(ic.PROTO_NUMS[f.Protocol]))
 	kflow.SetSampledPacketSize(f.SampledPacketSize)
 	kflow.SetSrcAs(f.SrcAs)
+	kflow.SetSrcGeo(patricia.PackGeo([]byte(f.SrcGeo)))
 	kflow.SetTcpFlags(f.TcpFlags)
 	kflow.SetTos(f.Tos)
 	kflow.SetVlanIn(f.VlanIn)
@@ -203,6 +229,23 @@ func (ff *KflowFormat) pack(f *kt.JCHF, kflow model.CHF, list model.Custom_List,
 	kflow.SetDstSecondAsn(f.DstSecondAsn)
 	kflow.SetSrcThirdAsn(f.SrcThirdAsn)
 	kflow.SetDstThirdAsn(f.DstThirdAsn)
+
+	sip := net.ParseIP(f.SrcAddr)
+	dip := net.ParseIP(f.DstAddr)
+	if dip != nil {
+		if dip.To4() != nil {
+			kflow.SetIpv4DstAddr(binary.BigEndian.Uint32(dip.To4()))
+		} else {
+			kflow.SetIpv6DstAddr(dip)
+		}
+	}
+	if sip != nil {
+		if sip.To4() != nil {
+			kflow.SetIpv4SrcAddr(binary.BigEndian.Uint32(sip.To4()))
+		} else {
+			kflow.SetIpv6SrcAddr(sip)
+		}
+	}
 
 	next := 0
 	for key, val := range f.CustomStr {
@@ -273,4 +316,10 @@ func (ff *KflowFormat) getIds(flows []*kt.JCHF, kflow model.CHF, seg *capn.Segme
 
 	// And return the map we used.
 	return ids, nil
+}
+
+func int2ip(nn uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, nn)
+	return ip
 }

--- a/pkg/formats/kflow/kflow_test.go
+++ b/pkg/formats/kflow/kflow_test.go
@@ -31,6 +31,9 @@ func TestSeriToJflow(t *testing.T) {
 	assert.Equal(len(kt.InputTesting), len(out))
 	for i, _ := range out {
 		assert.Equal(kt.InputTesting[i].Timestamp, out[i]["timestamp"])
+		assert.Equal(kt.InputTesting[i].SrcAddr, out[i]["src_addr"])
+		assert.Equal(kt.InputTesting[i].SrcGeo, out[i]["src_geo"])
+		assert.Equal(kt.InputTesting[i].Protocol, out[i]["protocol"])
 		for k, v := range kt.InputTesting[i].CustomStr {
 			assert.Equal(v, out[i][k])
 		}

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -123,7 +123,7 @@ func (f *NRMFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 	}
 
 	if !f.doGz {
-		return kt.NewOutputWithProviderAndCompany(target, msgs[0].Provider, msgs[0].CompanyId, kt.MetricOutput), nil
+		return kt.NewOutputWithProviderAndCompanySender(target, msgs[0].Provider, msgs[0].CompanyId, kt.MetricOutput, ""), nil
 	}
 
 	buf := bytes.NewBuffer(serBuf)

--- a/pkg/kt/testing.go
+++ b/pkg/kt/testing.go
@@ -4,8 +4,8 @@ import ()
 
 var (
 	InputTesting = []*JCHF{
-		&JCHF{CompanyId: 10, SrcAddr: "10.2.2.1", Protocol: "TCP", DstAddr: "2001:db8::68", Timestamp: 1, L4DstPort: 80, OutputPort: IfaceID(20), EventType: KENTIK_EVENT_TYPE, CustomStr: map[string]string{"foo": "bar"}, CustomInt: map[string]int32{"fooI": 1}, CustomBigInt: map[string]int64{"fooII": 12}, InBytes: 12121, InPkts: 12, OutBytes: 13, OutPkts: 1, SrcEthMac: "90:61:ae:fb:c2:19", avroSet: map[string]interface{}{}},
-		&JCHF{CompanyId: 10, SrcAddr: "3.2.2.2", InBytes: 1, OutBytes: 12, InPkts: 12, OutPkts: 1, Protocol: "UDP", DstAddr: "2001:db8::69", SrcEthMac: "90:61:ae:fb:c2:20", Timestamp: 2, CustomStr: map[string]string{"tar": "far"}, EventType: KENTIK_EVENT_TYPE, avroSet: map[string]interface{}{}},
+		&JCHF{CompanyId: 10, SrcAddr: "10.2.2.1", Protocol: "TCP", DstAddr: "2001:db8::68", Timestamp: 1, L4DstPort: 80, SrcAs: 1111, SrcGeo: "US", OutputPort: IfaceID(20), EventType: KENTIK_EVENT_TYPE, CustomStr: map[string]string{"foo": "bar"}, CustomInt: map[string]int32{"fooI": 1}, CustomBigInt: map[string]int64{"fooII": 12}, InBytes: 12121, InPkts: 12, OutBytes: 13, OutPkts: 1, SrcEthMac: "90:61:ae:fb:c2:19", avroSet: map[string]interface{}{}},
+		&JCHF{CompanyId: 10, SrcAddr: "3.2.2.2", InBytes: 1, OutBytes: 12, InPkts: 12, OutPkts: 1, Protocol: "UDP", SrcAs: 222223, SrcGeo: "CA", DstAddr: "2001:db8::69", SrcEthMac: "90:61:ae:fb:c2:20", Timestamp: 2, CustomStr: map[string]string{"tar": "far"}, EventType: KENTIK_EVENT_TYPE, avroSet: map[string]interface{}{}},
 	}
 
 	InputTestingSynth = []*JCHF{

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -346,6 +346,7 @@ type OutputContext struct {
 	Provider  Provider
 	Type      OutputType
 	CompanyId Cid
+	SenderId  string
 }
 
 type Output struct {
@@ -362,8 +363,8 @@ func NewOutputWithProvider(body []byte, prov Provider, stype OutputType) *Output
 	return &Output{Body: body, Ctx: OutputContext{Provider: prov, Type: stype}}
 }
 
-func NewOutputWithProviderAndCompany(body []byte, prov Provider, cid Cid, stype OutputType) *Output {
-	return &Output{Body: body, Ctx: OutputContext{Provider: prov, Type: stype, CompanyId: cid}}
+func NewOutputWithProviderAndCompanySender(body []byte, prov Provider, cid Cid, stype OutputType, senderid string) *Output {
+	return &Output{Body: body, Ctx: OutputContext{Provider: prov, Type: stype, CompanyId: cid, SenderId: senderid}}
 }
 
 func (o *Output) IsEvent() bool {

--- a/pkg/sinks/kentik/kentik.go
+++ b/pkg/sinks/kentik/kentik.go
@@ -120,8 +120,8 @@ func (s *KentikSink) sendKentik(ctx context.Context, payload []byte, cid int, se
 		return
 	}
 
-	req.Header.Set("X-CH-Auth-Email", s.config.KentikCreds[0].ApiEmail)
-	req.Header.Set("X-CH-Auth-API-Token", s.config.KentikCreds[0].ApiToken)
+	req.Header.Set("X-CH-Auth-Email", s.config.KentikCreds[0].APIEmail)
+	req.Header.Set("X-CH-Auth-API-Token", s.config.KentikCreds[0].APIToken)
 	req.Header.Set("Content-Type", CHF_TYPE)
 	req.Header.Set("Content-Encoding", "gzip")
 

--- a/pkg/util/enrich/enrich.go
+++ b/pkg/util/enrich/enrich.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strconv"
 
@@ -70,11 +71,10 @@ func (e *Enricher) Enrich(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, err
 }
 
 func (e *Enricher) hashSrcIP(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, error) {
-
 	h := sha256.New()
 	for _, msg := range msgs {
 		h.Write([]byte(msg.SrcAddr))
-		msg.SrcAddr = fmt.Sprintf("%x", (h.Sum(nil)))
+		msg.SrcAddr = net.IP(h.Sum(nil)[0:16]).String()
 		msg.CustomStr["src_endpoint"] = msg.SrcAddr + ":" + strconv.Itoa(int(msg.L4SrcPort))
 		h.Reset()
 	}

--- a/pkg/util/enrich/enrich.go
+++ b/pkg/util/enrich/enrich.go
@@ -9,19 +9,25 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
 const (
-	EnrichUrlHashSrc = "hash_src_ip"
+	EnrichUrlHashSrcIP = "hash_src_ip"
+	EnrichUrlHashDstIP = "hash_dst_ip"
+	EnrichUrlHashAllIP = "hash_ip"
 )
 
 type Enricher struct {
 	logger.ContextL
 	url    string
 	client *http.Client
+	doSrc  bool
+	doDst  bool
+	salt   []byte
 }
 
 func NewEnricher(url string, log logger.Underlying) (*Enricher, error) {
@@ -29,15 +35,27 @@ func NewEnricher(url string, log logger.Underlying) (*Enricher, error) {
 		ContextL: logger.NewContextLFromUnderlying(logger.SContext{S: "Enricher"}, log),
 		url:      url,
 		client:   &http.Client{},
+		doSrc:    strings.HasPrefix(url, EnrichUrlHashSrcIP) || strings.HasPrefix(url, EnrichUrlHashAllIP),
+		doDst:    strings.HasPrefix(url, EnrichUrlHashDstIP) || strings.HasPrefix(url, EnrichUrlHashAllIP),
 	}
 
-	e.Infof("Enriching at %s", url)
+	if e.doSrc || e.doDst {
+		var salt string
+		if strings.HasPrefix(url, EnrichUrlHashAllIP) {
+			salt = url[len(EnrichUrlHashAllIP):]
+		} else {
+			salt = url[len(EnrichUrlHashSrcIP):] // same # chars src and dst.
+		}
+		e.salt = []byte(salt)
+	}
+
+	e.Infof("Enriching at %s. Source: %v, Dest: %v, Salt %s", url, e.doSrc, e.doDst, string(e.salt))
 	return &e, nil
 }
 
 func (e *Enricher) Enrich(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, error) {
-	if e.url == EnrichUrlHashSrc {
-		return e.hashSrcIP(ctx, msgs)
+	if e.doSrc || e.doDst {
+		return e.hashIP(ctx, msgs)
 	}
 
 	target, err := json.Marshal(msgs) // Has to be an array here, no idea why.
@@ -70,13 +88,23 @@ func (e *Enricher) Enrich(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, err
 	return msgs, err
 }
 
-func (e *Enricher) hashSrcIP(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, error) {
+func (e *Enricher) hashIP(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, error) {
 	h := sha256.New()
 	for _, msg := range msgs {
-		h.Write([]byte(msg.SrcAddr))
-		msg.SrcAddr = net.IP(h.Sum(nil)[0:16]).String()
-		msg.CustomStr["src_endpoint"] = msg.SrcAddr + ":" + strconv.Itoa(int(msg.L4SrcPort))
-		h.Reset()
+		if e.doSrc {
+			h.Write(e.salt)
+			h.Write([]byte(msg.SrcAddr))
+			msg.SrcAddr = net.IP(h.Sum(nil)[0:16]).String()
+			msg.CustomStr["src_endpoint"] = msg.SrcAddr + ":" + strconv.Itoa(int(msg.L4SrcPort))
+			h.Reset()
+		}
+		if e.doDst {
+			h.Write(e.salt)
+			h.Write([]byte(msg.DstAddr))
+			msg.DstAddr = net.IP(h.Sum(nil)[0:16]).String()
+			msg.CustomStr["dst_endpoint"] = msg.DstAddr + ":" + strconv.Itoa(int(msg.L4DstPort))
+			h.Reset()
+		}
 	}
 
 	return msgs, nil


### PR DESCRIPTION
Two parts here:

1) Strips out any special handling for kflow and makes kentik a normal sink like any other. Also puts together the kflow format so that it can be sent back into kentik.

2) Adds an enricher option which hashes ips. Turn this on with `-enricher hash_dst_ip12345` flag, where this will hash the destination ips and add the salt 12345. Hash src with `hash_dst_ip` and both with `hash_ip`.