### PR TITLE
Fixing a bug where some egress flow is attributed to ingess values

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,9 +8,9 @@ import (
 
 const (
 	// FlowFields are fields for the Flow input
-	FlowFields = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel,CustomInteger1,CustomInteger2,CustomInteger3,CustomInteger4,CustomInteger5,CustomBytes1,CustomBytes2,CustomBytes3,CustomBytes4,CustomBytes5"
+	FlowFields = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,FlowDirection,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel,CustomInteger1,CustomInteger2,CustomInteger3,CustomInteger4,CustomInteger5,CustomBytes1,CustomBytes2,CustomBytes3,CustomBytes4,CustomBytes5"
 	// FlowDefaultFields are the default fields for flow
-	FlowDefaultFields = "TimeReceived,SamplingRate,Bytes,Packets,SrcAddr,DstAddr,Proto,SrcPort,DstPort,InIf,OutIf,SrcVlan,DstVlan,TCPFlags,SrcAS,DstAS,Type,SamplerAddress"
+	FlowDefaultFields = "TimeReceived,SamplingRate,Bytes,Packets,SrcAddr,DstAddr,Proto,SrcPort,DstPort,InIf,OutIf,SrcVlan,DstVlan,TCPFlags,SrcAS,DstAS,Type,SamplerAddress,FlowDirection"
 	// KentikAPITokenEnvVar is the environment variables used to get the Kentik API Token
 	KentikAPITokenEnvVar = "KENTIK_API_TOKEN"
 )

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -157,6 +157,12 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 				// Assume seconds and multiply
 				in.Timestamp = in.Timestamp * 1000
 			}
+		case "FlowDirection":
+			if fmsg.FlowDirection == 1 {
+				in.CustomStr[field] = "egress"
+			} else {
+				in.CustomStr[field] = "ingress"
+			}
 		case "SequenceNum":
 			in.CustomBigInt[field] = int64(fmsg.SequenceNum)
 		case "SamplingRate":
@@ -170,9 +176,17 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 		case "TimeFlowEnd":
 			in.CustomBigInt[field] = int64(fmsg.TimeFlowEnd)
 		case "Bytes":
-			in.InBytes = fmsg.Bytes
+			if fmsg.FlowDirection == 1 {
+				in.OutBytes = fmsg.Bytes
+			} else {
+				in.InBytes = fmsg.Bytes
+			}
 		case "Packets":
-			in.InPkts = fmsg.Packets
+			if fmsg.FlowDirection == 1 {
+				in.OutPkts = fmsg.Packets
+			} else {
+				in.InPkts = fmsg.Packets
+			}
 		case "SrcAddr":
 			in.SrcAddr = net.IP(fmsg.SrcAddr).String()
 		case "DstAddr":


### PR DESCRIPTION
```
background: he originally setup netflow v9 and was only receiving ingress (in_bytes | in_packets); through some digging we found this is by design with pfSense. :facepalm:
now he’s updated to IPFIX and we’ve got a .pcap showing all of the correct template fields, but he’s still only seeing the ingress side of his flows.
details attached here. open to any ideas you may have.
```

This will 1) Set a `FlowDirection` field for netflow.
2) Correctly set `out_bytes` and `out_pkts` for egress flow. 