### PR TITLE
Support or a trap-only value in ktranslate

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -95,7 +95,9 @@ func StartSNMPPolls(ctx context.Context, jchfChan chan []*kt.JCHF, metrics *kt.S
 	}
 
 	// Now, launch a metadata and metrics server for each configured or discovered device.
-	go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, 0, cfg)
+	if conf.Trap != nil && !conf.Trap.TrapOnly { // Unless we are turning off everything but snmp traps.
+		go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, 0, cfg)
+	}
 
 	// Run a trap listener?
 	if conf.Trap != nil && !cfg.FlowOnly {

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -95,7 +95,7 @@ func StartSNMPPolls(ctx context.Context, jchfChan chan []*kt.JCHF, metrics *kt.S
 	}
 
 	// Now, launch a metadata and metrics server for each configured or discovered device.
-	if conf.Trap != nil && !conf.Trap.TrapOnly { // Unless we are turning off everything but snmp traps.
+	if conf.Trap == nil || !conf.Trap.TrapOnly { // Unless we are turning off everything but snmp traps.
 		go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, 0, cfg)
 	}
 
@@ -446,7 +446,8 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 	return &ms, nil
 }
 
-/**
+/*
+*
 Handle the case where we're only doing a ping loop of a device.
 */
 func launchPingOnly(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, connectTimeout time.Duration, retries int, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL) error {
@@ -461,7 +462,8 @@ func launchPingOnly(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.S
 	return nil
 }
 
-/**
+/*
+*
 Handle the case where we're only doing a extention loop of a device.
 */
 func launchExtOnly(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, connectTimeout time.Duration, retries int, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL) error {

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -59,6 +59,7 @@ func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan
 		deviceMap: map[string]*kt.SnmpDeviceConfig{},
 		resolv:    resolv,
 		ctx:       ctx,
+		conf:      conf,
 	}
 
 	// Some quick defaults.
@@ -143,7 +144,11 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 	dst.SrcAddr = addr.IP.String()
 	if dev != nil {
 		dst.DeviceName = dev.DeviceName
-		dst.Provider = dev.Provider
+		if s.conf.Trap.TrapOnly {
+			dst.Provider = kt.ProviderTrapUnknown
+		} else {
+			dst.Provider = dev.Provider
+		}
 		dev.SetUserTags(dst.CustomStr)
 	} else {
 		dst.DeviceName = addr.IP.String()

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -205,6 +205,7 @@ type SnmpTrapConfig struct {
 	Version   string        `yaml:"version"`
 	Transport string        `yaml:"transport"`
 	V3        *V3SNMPConfig `yaml:"v3_config"`
+	TrapOnly  bool          `yaml:"trap_only"`
 }
 
 type KentikMatch struct {


### PR DESCRIPTION
Closes #447 @sskilbred 

Adds an option `trap_only` to the snmp.conf file. For example:

```
trap:
  listen: 127.0.0.1:1620
  community: ""
  version: v2c
  transport: ""
  v3_config: null
  trap_only: true
```

When true, no snmp polling will happen, but all traps will be handled. Additionally, the provider will be `kentik-trap-device`. 
