### PR TITLE
Touch config file vs actually writing it out.

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -320,6 +320,11 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 }
 
 func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfig, snmpFile string, conf *kt.SnmpConfig, isTest bool, log logger.ContextL, pollDuration time.Duration) (*SnmpDiscoDeviceStat, error) {
+	// If testing, just return if a touch works or not.
+	if isTest {
+		return nil, snmp_util.TouchFile(snmpFile)
+	}
+
 	// Now add the new.
 	stats := SnmpDiscoDeviceStat{}
 	if conf.Devices == nil {

--- a/pkg/inputs/snmp/util/file.go
+++ b/pkg/inputs/snmp/util/file.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -163,4 +165,30 @@ func (m *mockS3) DownloadWithContext(ctx aws.Context, w io.WriterAt, in *s3.GetO
 
 func getMockS3Client() s3Full {
 	return sMock
+}
+
+func TouchFile(path string) error {
+	u, err := url.Parse(path)
+	if err != nil {
+		return err
+	}
+
+	// If an external scheme, just return nil.
+	switch u.Scheme {
+	case "http", "https":
+		return nil
+	case "s3":
+		return nil
+	case "s3m":
+		return nil
+	}
+
+	_, err = os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	// Now see if can write.
+	currentTime := time.Now().Local()
+	return os.Chtimes(path, currentTime, currentTime)
 }


### PR DESCRIPTION
This moves from actually writing the snmp config file when checking write permissions to just doing a touch on it. I think its a cleaner approach and fixes a bug where ktranslate crashing inside of a disco will corrupt the config file sometimes. 