### PR TITLE
Allow fixed attributes for snmp

### DIFF
--- a/pkg/inputs/snmp/mibs/profile.go
+++ b/pkg/inputs/snmp/mibs/profile.go
@@ -619,6 +619,9 @@ func (p *Profile) GetMetadata(enabledMibs []string) (map[string]*kt.Mib, map[str
 					mib.Enum[strings.ToLower(k)] = v
 					mib.EnumRev[v] = k
 				}
+				if mib.Table != "" {
+					mib.OtherTables = map[string]bool{mib.Table: true}
+				}
 				if len(t.Column.MatchAttr) > 0 {
 					mib.MatchAttr = map[string]*regexp.Regexp{}
 					for _, restr := range t.Column.MatchAttr {

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -200,12 +199,10 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		switch v.Type {
 		case gosnmp.OctetString:
 			if value, ok := snmp_util.ReadOctetString(v, snmp_util.NO_TRUNCATE); ok {
-				if utf8.ValidString(value) {
-					if res != nil {
-						dst.CustomStr[res.GetName()] = value
-					} else {
-						dst.CustomStr[v.Name] = value
-					}
+				if res != nil {
+					dst.CustomStr[res.GetName()] = value
+				} else {
+					dst.CustomStr[v.Name] = value
 				}
 			}
 		case gosnmp.Counter64, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Uinteger32, gosnmp.Integer:

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -199,10 +200,12 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		switch v.Type {
 		case gosnmp.OctetString:
 			if value, ok := snmp_util.ReadOctetString(v, snmp_util.NO_TRUNCATE); ok {
-				if res != nil {
-					dst.CustomStr[res.GetName()] = value
-				} else {
-					dst.CustomStr[v.Name] = value
+				if utf8.ValidString(value) {
+					if res != nil {
+						dst.CustomStr[res.GetName()] = value
+					} else {
+						dst.CustomStr[v.Name] = value
+					}
 				}
 			}
 		case gosnmp.Counter64, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Uinteger32, gosnmp.Integer:

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -28,7 +28,8 @@ const (
 	CONV_REGEXP    = "regexp"
 	CONV_ONE       = "to_one"
 
-	ConstantOidPrefix = "1.3.6.1.6.3.1135.6169."
+	ConstantOidPrefix       = "1.3.6.1.6.3.1135.6169."
+	ConstantOidMetricPrefix = ".1.3.6.1.6.3.1136.6169."
 )
 
 var (
@@ -134,6 +135,9 @@ func WalkOID(ctx context.Context, device *kt.SnmpDeviceConfig, oid string, serve
 	// If the oid is the constant oid, return a fixed string here.
 	if strings.HasPrefix(oid, ConstantOidPrefix) {
 		return []gosnmp.SnmpPDU{{Value: oid[len(ConstantOidPrefix):], Name: oid}}, nil
+	} else if strings.HasPrefix(oid, ConstantOidMetricPrefix) {
+		val, _ := strconv.Atoi(oid[len(ConstantOidMetricPrefix):])
+		return []gosnmp.SnmpPDU{{Value: val, Name: oid}}, nil
 	}
 
 	// If we are overriding with a test set.

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -27,6 +27,8 @@ const (
 	CONV_ENGINE_ID = "engine_id"
 	CONV_REGEXP    = "regexp"
 	CONV_ONE       = "to_one"
+
+	ConstantOidPrefix = "1.3.6.1.6.3.1135.6169."
 )
 
 var (
@@ -127,6 +129,11 @@ func WalkOID(ctx context.Context, device *kt.SnmpDeviceConfig, oid string, serve
 		pollTry{walk: server.BulkWalkAll, sleep: time.Duration(0)},
 		pollTry{walk: server.WalkAll, sleep: time.Duration(0)},
 		pollTry{walk: server.WalkAll, sleep: SNMP_POLL_SLEEP_TIME},
+	}
+
+	// If the oid is the constant oid, return a fixed string here.
+	if strings.HasPrefix(oid, ConstantOidPrefix) {
+		return []gosnmp.SnmpPDU{{Value: oid[len(ConstantOidPrefix):], Name: oid}}, nil
 	}
 
 	// If we are overriding with a test set.


### PR DESCRIPTION
Closes #423 

Allow a definition like:

```
      - column:
          name: fixedValue
          OID: 1.3.6.1.6.3.1135.6169.this_is_a_test
```

And return a static value of this_is_a_test always. 

Fixed value metrics can be defined as:
```
    symbols:
      - name: fixedValueMetric
        OID: 1.3.6.1.6.3.1136.6169.10
```

This will always provide a value of 10 for fixedValueMetric. 

The two prefixes are `1.3.6.1.6.3.1135.6169.` for metadata and `1.3.6.1.6.3.1136.6169.` for metrics. 
