### PR TITLE
Dropping acl for now to fix flow

### DIFF
--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.2'
+          go-version: '1.19.2'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -59,20 +59,6 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: kentik/ktranslate:staging
-          build-args: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
-          secrets: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-
-      - name: Build and Publish Docker (AWS Lambda)
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          platforms: linux/arm64
-          push: true
-          tags: kentik/ktranslate:stagingarm64
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -35,6 +35,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay.IO
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_LOGIN_TOKEN }}
+
       - name: Install dependencies
         run: sudo apt-get install make libpcap-dev golint
 
@@ -58,7 +65,7 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: kentik/ktranslate:staging
+          tags: kentik/ktranslate:staging, quay.io/kentik/ktranslate:staging
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/pkg/inputs/flow/specials.go
+++ b/pkg/inputs/flow/specials.go
@@ -33,14 +33,6 @@ func loadASA(cfg *ktranslate.FlowInputConfig) EntConfig {
 						Type:        233,
 						Destination: "CustomInteger5",
 					},
-					producer.NetFlowMapField{
-						Type:        33000,
-						Destination: "CustomBytes1",
-					},
-					producer.NetFlowMapField{
-						Type:        33001,
-						Destination: "CustomBytes2",
-					},
 				},
 			},
 			NetFlowV9: producer.NetFlowV9ProducerConfig{
@@ -65,14 +57,6 @@ func loadASA(cfg *ktranslate.FlowInputConfig) EntConfig {
 						Type:        233,
 						Destination: "CustomInteger5",
 					},
-					producer.NetFlowMapField{
-						Type:        33000,
-						Destination: "CustomBytes1",
-					},
-					producer.NetFlowMapField{
-						Type:        33001,
-						Destination: "CustomBytes2",
-					},
 				},
 			},
 		},
@@ -82,8 +66,6 @@ func loadASA(cfg *ktranslate.FlowInputConfig) EntConfig {
 			"CustomInteger3": "in_pkts",
 			"CustomInteger4": "out_pkts",
 			"CustomInteger5": "Firewall Event",
-			"CustomBytes1":   "Ingress ACL",
-			"CustomBytes2":   "Egress ACL",
 		},
 	}
 


### PR DESCRIPTION
There's an edge case where ASA code can send in non utf8 strings which corrupt things. This just drops the offending fields. 

Also fixes the staging build workflow. 