### PR TITLE
Break when finding a valid v3 snmp cred. 

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -229,6 +229,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 				log.Warnf("Cannot get device metadata on %s: %v. Check for correct snmp credentials.", result.Host.String(), err)
 				continue
 			}
+			break // We're good to go here.
 		}
 	}
 


### PR DESCRIPTION
Fixing a bug where we do not break when finding a good v3 cred in a list of them.

This causes good creds to get forgotten in a big list. 