### PR TITLE
Default to ICMP mode for ping

### DIFF
--- a/pkg/inputs/snmp/ping/ping.go
+++ b/pkg/inputs/snmp/ping/ping.go
@@ -29,7 +29,7 @@ func NewPinger(log logger.ContextL, target string, inter time.Duration, pingSec 
 		interval: time.Second * time.Duration(pingSec), // Send 1 ping every this many seconds.
 	}
 
-	if os.Getenv(KENTIK_PING_PRIV) == "true" {
+	if os.Getenv(KENTIK_PING_PRIV) != "false" {
 		log.Infof("Running ping service in privileged mode. Ping Interval: %v", p.interval)
 		p.priv = true
 	} else {


### PR DESCRIPTION
Let's try switching the default ping mode to ICMP and see if this decreases customer complaints. 

Now to turn OFF icmp mode, set `KENTIK_PING_PRIV=false`. 

Closes #467.