### PR TITLE
Allow tag values to be variables, filled in by snmp metadata

### DIFF
--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -259,10 +259,8 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 	p.conf.SetUserTags(cs)
 	for k, v := range cs {
 		if strings.HasPrefix(v, TagValuePrefix) { // See if we can find this value in the MDS instead.
-			search := v[len(TagValuePrefix):]
-			v = "" // 0 tag out here incase of no match.
 			for tag, value := range dst.CustomStr {
-				if tag == search {
+				if tag == v[len(TagValuePrefix):] {
 					v = value
 				}
 			}


### PR DESCRIPTION
Given a tag selection like:

```
      user_tags:
        level: provider
        test: one
        type: nas
        location: "$SysLocation" 
```

This will replace `$SysLocation` in the tag value with whatever is found in snmp Metadata. For example, `"tags.location": "Unknown",`. 

Any tag value with a prefix of `$` will be interpreted as a variable. 
If the variable isn't found, this tag is removed. @thezackm  -- what do you think about this behavior? Or can just keep the `$whatever` value if not found. 

Closes #469