### PR TITLE
Implement mapping interface for starlark

### DIFF
--- a/pkg/util/enrich/enrich_test.go
+++ b/pkg/util/enrich/enrich_test.go
@@ -24,6 +24,7 @@ def main(n):
       print(evt.foo)
       evt.company_id = i
       evt.foo = "aaa"
+      evt["foo-one"] = "aaa"
       i += 1
       # state["count"] += 1 # doesn't work for some reason
 
@@ -52,6 +53,7 @@ def main(n):
 	for i, evt := range kt.InputTestingSnmp {
 		assert.Equal(i, int(evt.CompanyId))
 		assert.Equal("aaa", evt.CustomStr["foo"])
+		assert.Equal("aaa", evt.CustomStr["foo-one"])
 	}
 }
 

--- a/pkg/util/enrich/jchf.go
+++ b/pkg/util/enrich/jchf.go
@@ -118,6 +118,34 @@ func (m *JCHF) SetField(name string, value starlark.Value) error {
 	return nil
 }
 
+// Get implements the starlark.Mapping interface.
+func (m *JCHF) Get(key starlark.Value) (v starlark.Value, found bool, err error) {
+	if k, ok := key.(starlark.String); ok {
+		v, err := m.Attr(k.GoString())
+		if err != nil {
+			return starlark.None, false, err
+		}
+		return v, true, nil
+	}
+
+	return starlark.None, false, errors.New("key must be of type 'str'")
+}
+
+// SetKey implements the starlark.HasSetKey interface to support map update
+// using x[k]=v syntax, like a dictionary.
+func (m *JCHF) SetKey(k, v starlark.Value) error {
+	if m.frozen {
+		return fmt.Errorf("cannot modify frozen metric")
+	}
+
+	key, ok := k.(starlark.String)
+	if !ok {
+		return errors.New("field key must be of type 'str'")
+	}
+
+	return m.SetField(key.GoString(), v)
+}
+
 func setUint64(value starlark.Value) uint64 {
 	switch v := value.(type) {
 	case starlark.Int:


### PR DESCRIPTION
This is implementing `HasSetKey` and `Mapping` from https://pkg.go.dev/go.starlark.net/starlark. 

Allows you to do fun things like `evt["foo-one"] = "aaa"`. Should get around the `-` issue @dpajin-kentik raised today. 
