### PR TITLE
feat: add minimalist config sample for meraki polling

### DIFF
--- a/deployment/docker/meraki-minimum-nr.yml
+++ b/deployment/docker/meraki-minimum-nr.yml
@@ -1,0 +1,18 @@
+# this represents a minimalist configuration for Meraki API polling
+---
+devices:
+  meraki_cloud_controller:
+    device_name: meraki_cloud_controller
+    device_ip: snmp.meraki.com
+    provider: meraki-cloud-controller
+    ext:
+      ext_only: true
+      meraki_config:
+        api_key: ABC123
+        monitor_uplinks: true
+        monitor_devices: true
+        monitor_org_changes: true
+trap: {}
+discovery: {}
+global:
+  poll_time_sec: 60


### PR DESCRIPTION
adding a sample config file to show a minimalist config for polling the Meraki API in a New Relic setup.