### PR TITLE
Optionally monitor config file and exit if changed

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -135,6 +135,7 @@ func main() {
 		}
 
 		cfg = ktCfg
+		cfg.Server.CfgPath = v
 	}
 
 	if err := applyMode(cfg, kt.LookupEnvString("KENTIK_MODE", flag.Arg(0))); err != nil {
@@ -163,7 +164,7 @@ func main() {
 		cat.RollupsSendDuration = time.Duration(dumpRollups) * time.Second
 	}
 
-	kc, err := cat.NewKTranslate(cfg, lc, go_metrics.DefaultRegistry, version.Version.Version, cfg.Sinks, bs.ServiceName, logTee, metricsChan)
+	kc, err := cat.NewKTranslate(cfg, lc, go_metrics.DefaultRegistry, version.Version.Version, cfg.Sinks, bs.ServiceName, logTee, metricsChan, bs.Shutdown)
 	if err != nil {
 		bs.Fail(fmt.Sprintf("Cannot start ktranslate: %v", err))
 	}

--- a/config.go
+++ b/config.go
@@ -474,3 +474,19 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	return cfg, nil
 }
+
+// SaveConfig saves the ktranslate configuration to the specified path
+func (c *Config) SaveConfig(configPath string) error {
+	f, err := os.Open(configPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var cfg *Config
+	if err := yaml.NewEncoder(f).Encode(&cfg); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -129,6 +129,8 @@ type ServerConfig struct {
 	MetaListenAddr  string
 	OllyDataset     string
 	OllyWriteKey    string
+	MonitorConf     bool
+	CfgPath         string
 }
 
 // APIConfig is the config for the API service
@@ -400,6 +402,8 @@ func DefaultConfig() *Config {
 			MetaListenAddr:  "localhost:0",
 			OllyDataset:     "",
 			OllyWriteKey:    "",
+			CfgPath:         "",
+			MonitorConf:     false,
 		},
 		API: &APIConfig{
 			DeviceFile: "",

--- a/config.go
+++ b/config.go
@@ -130,7 +130,7 @@ type ServerConfig struct {
 	OllyDataset     string
 	OllyWriteKey    string
 	MonitorConf     bool
-	CfgPath         string
+	CfgPath         string `yaml:"-"` // We don't want to read this directly because it comes from a flag but saved here for internal use.
 }
 
 // APIConfig is the config for the API service

--- a/config.go
+++ b/config.go
@@ -476,8 +476,8 @@ func LoadConfig(configPath string) (*Config, error) {
 }
 
 // SaveConfig saves the ktranslate configuration to the specified path
-func (c *Config) SaveConfig(configPath string) error {
-	f, err := os.Open(configPath)
+func (c *Config) SaveConfig() error {
+	f, err := os.Open(c.Server.CfgPath)
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -483,8 +483,7 @@ func (c *Config) SaveConfig() error {
 	}
 	defer f.Close()
 
-	var cfg *Config
-	if err := yaml.NewEncoder(f).Encode(&cfg); err != nil {
+	if err := yaml.NewEncoder(f).Encode(c); err != nil {
 		return err
 	}
 

--- a/config.go
+++ b/config.go
@@ -477,7 +477,7 @@ func LoadConfig(configPath string) (*Config, error) {
 
 // SaveConfig saves the ktranslate configuration to the specified path
 func (c *Config) SaveConfig() error {
-	f, err := os.Open(c.Server.CfgPath)
+	f, err := os.Create(c.Server.CfgPath)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -120,7 +120,7 @@ require (
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.74.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -796,6 +798,9 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886 h1:eJv7u3ksNXoLbGSKuv2s/SIO4
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/cat/mon.go
+++ b/pkg/cat/mon.go
@@ -1,0 +1,50 @@
+package cat
+
+import (
+	"github.com/kentik/ktranslate"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func (kc *KTranslate) monitorConf(cfg *ktranslate.ServerConfig, shutdown func(string)) error {
+	kc.log.Infof("Monitoring %s for changes", cfg.CfgPath)
+
+	// Create new watcher.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	// Start listening for events.
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if event.Has(fsnotify.Write) {
+					kc.log.Warnf("Write detected on %s, shutting down", cfg.CfgPath)
+					shutdown("Config file changed")
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				kc.log.Infof("error:", err)
+			}
+		}
+	}()
+
+	// Add a path.
+	err = watcher.Add(cfg.CfgPath)
+	if err != nil {
+		return err
+	}
+
+	// Block forever.
+	<-make(chan struct{})
+
+	return nil
+}


### PR DESCRIPTION
Monitor the config file optionally and shut down if it changes. 

Running this with the docker `restart=always` option will allow the system to pick up config changes automatically. 