### PR TITLE
Force src addr for NR

### DIFF
--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -513,7 +513,7 @@ func (f *InfluxFormat) fromSnmpDeviceMetric(in *kt.JCHF) []InfluxData {
 			continue
 		}
 		if _, ok := in.CustomBigInt[m]; ok {
-			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], false)
+			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], false, true)
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], false) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
@@ -557,7 +557,7 @@ func (f *InfluxFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []InfluxData {
 		}
 		profileName = name.Profile
 		if _, ok := in.CustomBigInt[m]; ok {
-			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], false)
+			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], false, true)
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
@@ -612,7 +612,7 @@ func (f *InfluxFormat) setRates(direction string, in *kt.JCHF, results []InfluxD
 				uptime := in.CustomBigInt["Uptime"]
 				uptimeSpeed := uptime * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
 				if uptimeSpeed > 0 {
-					attrNew := util.CopyAttrForSnmp(attr, utilName, kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false)
+					attrNew := util.CopyAttrForSnmp(attr, utilName, kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], false, true)
 					if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 						getMib(attrNew, ip)
 						if totalBytes > 0 {

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -474,7 +474,7 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 			continue
 		}
 		if _, ok := in.CustomBigInt[m]; ok {
-			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], true)
+			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], true, false)
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], false) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
@@ -520,7 +520,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 		}
 		profileName = name.Profile
 		if _, ok := in.CustomBigInt[m]; ok {
-			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], true)
+			attrNew := util.CopyAttrForSnmp(attr, m, name, f.lastMetadata[in.DeviceName], true, false)
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
@@ -552,7 +552,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
 					if uptimeSpeed > 0 {
-						attrNew := util.CopyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], true)
+						attrNew := util.CopyAttrForSnmp(attr, "IfInUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], true, false)
 						if inBytes, ok := in.CustomBigInt["ifHCInOctets"]; ok {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								ms = append(ms, NRMetric{
@@ -572,7 +572,7 @@ func (f *NRMFormat) fromSnmpInterfaceMetric(in *kt.JCHF) []NRMetric {
 				if ispeed, ok := speed.(int32); ok {
 					uptimeSpeed := in.CustomBigInt["Uptime"] * (int64(ispeed) * 10000) // Convert into bits here, from megabits. Also divide by 100 to convert uptime into seconds, from centi-seconds.
 					if uptimeSpeed > 0 {
-						attrNew := util.CopyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], true)
+						attrNew := util.CopyAttrForSnmp(attr, "IfOutUtilization", kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: profileName, Table: "if"}, f.lastMetadata[in.DeviceName], true, false)
 						if outBytes, ok := in.CustomBigInt["ifHCOutOctets"]; ok {
 							if !util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], true) {
 								ms = append(ms, NRMetric{

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -342,6 +342,7 @@ var keepAcrossTables = map[string]bool{
 	"sysoid_profile": true,
 	kt.IndexVar:      true,
 	"if_Index":       true,
+	"src_addr":       true,
 }
 
 var allowSysAttr = map[string]bool{
@@ -351,7 +352,7 @@ var allowSysAttr = map[string]bool{
 	"AvgRttMs": true,
 }
 
-func CopyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata, gentleCardinality bool) map[string]interface{} {
+func CopyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata, gentleCardinality bool, dropSrcAddr bool) map[string]interface{} {
 	attrNew := map[string]interface{}{
 		"objectIdentifier":     name.Oid,
 		"mib-name":             name.Mib,
@@ -366,7 +367,7 @@ func CopyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.Met
 
 	for k, v := range attr {
 		if !allowSysAttr[metricName] { // Only allow Sys* attributes on specific metrics.
-			if strings.HasPrefix(k, "Sys") || k == "src_addr" {
+			if strings.HasPrefix(k, "Sys") || (dropSrcAddr && k == "src_addr") {
 				continue
 			}
 		}

--- a/pkg/formats/util/util_test.go
+++ b/pkg/formats/util/util_test.go
@@ -349,38 +349,53 @@ func TestCopyAttrforSNMP(t *testing.T) {
 	}
 	name := kt.MetricInfo{Oid: "oid", Mib: "mib"}
 
-	res := CopyAttrForSnmp(input, "test", name, nil, true)
+	res := CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal(len(input)+3, len(res)) // adds in three keys
 	assert.Equal("oid", res["objectIdentifier"])
 
 	for i := 0; i < MAX_ATTR_FOR_SNMP+10; i++ {
 		input[fmt.Sprintf("XXX%d", i)] = i
 	}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal(MAX_ATTR_FOR_SNMP, len(res)) // truncated at MAX_ATTR_FOR_SNMP
 	assert.Equal("oid", res["objectIdentifier"])
 
 	input = map[string]interface{}{kt.StringPrefix + "foo": "one"}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal("one", res["foo"], res)
 
 	input = map[string]interface{}{kt.StringPrefix + "foo": "one"}
 	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "noMatch"}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal(nil, res["foo"], res)
 
 	input = map[string]interface{}{kt.StringPrefix + "foo": "one"}
 	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "foo"}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal("one", res["foo"], res)
 
 	input = map[string]interface{}{"foo": "one"}
 	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "foo"}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal("one", res["foo"], res)
 
 	input = map[string]interface{}{"foo": "one"}
 	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "somethingElse"}
-	res = CopyAttrForSnmp(input, "test", name, nil, true)
+	res = CopyAttrForSnmp(input, "test", name, nil, true, true)
 	assert.Equal(nil, res["foo"], res)
+
+	input = map[string]interface{}{"src_addr": "10.10.1.1"}
+	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "somethingElse"}
+	res = CopyAttrForSnmp(input, "test", name, nil, true, false)
+	assert.Equal("10.10.1.1", res["src_addr"], res)
+
+	input = map[string]interface{}{"src_addr": "10.10.1.1"}
+	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "somethingElse"}
+	res = CopyAttrForSnmp(input, "Uptime", name, nil, true, true)
+	assert.Equal("10.10.1.1", res["src_addr"], res)
+
+	input = map[string]interface{}{"src_addr": "10.10.1.1"}
+	name = kt.MetricInfo{Oid: "oid", Mib: "mib", Table: "somethingElse"}
+	res = CopyAttrForSnmp(input, "myTable", name, nil, true, true)
+	assert.Equal(nil, res["src_addr"], res)
 }

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -203,7 +203,9 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 				if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
 					_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
 				}
-				value = strings.ToValidUTF8(value, "")
+				if !utf8.ValidString(value) { // Print out value as a hex string.
+					value = fmt.Sprintf("%x", v.Value)
+				}
 				if res != nil {
 					dst.CustomStr[res.GetName()] = value
 				} else {
@@ -221,7 +223,9 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 			if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
 				_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
 			}
-			value = strings.ToValidUTF8(value, "")
+			if !utf8.ValidString(value) { // Print out value as a hex string.
+				value = fmt.Sprintf("%x", v.Value)
+			}
 			if res != nil {
 				dst.CustomStr[res.GetName()] = value
 			} else {

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -36,7 +36,7 @@ type SnmpTrap struct {
 	deviceMap map[string]*kt.SnmpDeviceConfig
 }
 
-//Move to util?
+// Move to util?
 type logWrapper struct {
 	print  func(v ...interface{})
 	printf func(format string, v ...interface{})
@@ -203,12 +203,11 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 				if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
 					_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
 				}
-				if utf8.ValidString(value) {
-					if res != nil {
-						dst.CustomStr[res.GetName()] = value
-					} else {
-						dst.CustomStr[v.Name] = value
-					}
+				value = strings.ToValidUTF8(value, "")
+				if res != nil {
+					dst.CustomStr[res.GetName()] = value
+				} else {
+					dst.CustomStr[v.Name] = value
 				}
 			}
 		case gosnmp.Counter64, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Uinteger32, gosnmp.Integer:
@@ -222,12 +221,11 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 			if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
 				_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
 			}
-			if utf8.ValidString(value) {
-				if res != nil {
-					dst.CustomStr[res.GetName()] = value
-				} else {
-					dst.CustomStr[v.Name] = value
-				}
+			value = strings.ToValidUTF8(value, "")
+			if res != nil {
+				dst.CustomStr[res.GetName()] = value
+			} else {
+				dst.CustomStr[v.Name] = value
 			}
 		default:
 			s.log.Infof("trap variable with unknown type (%v) handling, skipping: %+v", v.Type, v)


### PR DESCRIPTION
What do you think about this? Forces `src_addr` if present for all NR metrics. 

Separately, it will try to keep valid utf8 chars in traps and not strip out the whole string. The major problem here is that its probably being sent in some weird encoding scheme but I have no idea what it is. This is probably the best we can do for now. 