### PR TITLE
Fix external device file for SNMP

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -371,6 +371,8 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 				return nil, err
 			}
 			ms.DeviceOrig = devFile.DeviceName[1:]
+			delete(ms.Devices, name) // Remove this one from the list because we don't need the external info any more.
+			delete(deviceSet, name)  // Belt and suspendors in case file_0 is present here too.
 			log.Infof("Loading %d devices from %s", len(deviceSet), devFile.DeviceName[1:])
 			for k, v := range deviceSet {
 				fullDevices[k] = v


### PR DESCRIPTION
Fixing bug where an external devices file will have a bad device included. There's a hack where when unmarshaled the file to load is put into a special device called `file_0`. This device should be removed after the file is processed but it wasn't. Now this gets deleted after its read and things seem to work. 