### PR TITLE
Wip for what a managed config system might look like

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -707,6 +707,8 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.FlowInput.PrometheusListenAddr = val
 			case "nf.mapping":
 				cfg.FlowInput.MappingFile = val
+			case "config_provider":
+				cfg.CfgManager.ConfigImpl = val
 			// configs
 			case "config", "generate-config":
 				// ignore

--- a/config.go
+++ b/config.go
@@ -129,7 +129,6 @@ type ServerConfig struct {
 	MetaListenAddr  string
 	OllyDataset     string
 	OllyWriteKey    string
-	MonitorConf     bool
 	CfgPath         string `yaml:"-"` // We don't want to read this directly because it comes from a flag but saved here for internal use.
 }
 
@@ -201,6 +200,12 @@ type FlowInputConfig struct {
 type KentikCred struct {
 	APIEmail string
 	APIToken string
+}
+
+// ConfigManager is the config for how to manage configs.
+type ConfigManager struct {
+	ConfigImpl  string
+	PollTimeSec int
 }
 
 // Config is the ktranslate configuration
@@ -292,6 +297,8 @@ type Config struct {
 	AWSVPCInput *AWSVPCInputConfig
 	// pkg/inputs/flow
 	FlowInput *FlowInputConfig
+	// pkg/config
+	CfgManager *ConfigManager
 }
 
 // DefaultConfig returns a ktranslate configuration with defaults applied
@@ -403,7 +410,6 @@ func DefaultConfig() *Config {
 			OllyDataset:     "",
 			OllyWriteKey:    "",
 			CfgPath:         "",
-			MonitorConf:     false,
 		},
 		API: &APIConfig{
 			DeviceFile: "",
@@ -455,6 +461,10 @@ func DefaultConfig() *Config {
 			MessageFields:        FlowDefaultFields,
 			PrometheusListenAddr: "",
 			MappingFile:          "",
+		},
+		CfgManager: &ConfigManager{
+			ConfigImpl:  "",
+			PollTimeSec: 1200,
 		},
 	}
 }

--- a/pkg/cat/mon.go
+++ b/pkg/cat/mon.go
@@ -2,49 +2,11 @@ package cat
 
 import (
 	"github.com/kentik/ktranslate"
-
-	"github.com/fsnotify/fsnotify"
 )
 
-func (kc *KTranslate) monitorConf(cfg *ktranslate.ServerConfig, shutdown func(string)) error {
-	kc.log.Infof("Monitoring %s for changes", cfg.CfgPath)
-
-	// Create new watcher.
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return err
-	}
-	defer watcher.Close()
-
-	// Start listening for events.
-	go func() {
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return
-				}
-				if event.Has(fsnotify.Write) {
-					kc.log.Warnf("Write detected on %s, shutting down", cfg.CfgPath)
-					shutdown("Config file changed")
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					return
-				}
-				kc.log.Infof("error:", err)
-			}
-		}
-	}()
-
-	// Add a path.
-	err = watcher.Add(cfg.CfgPath)
-	if err != nil {
-		return err
-	}
-
-	// Block forever.
-	<-make(chan struct{})
-
+// Callback for when theres a config managment service which detects a change.
+func (kc *KTranslate) newConfig(newC *ktranslate.Config) error {
+	kc.log.Warnf("Write detected on %s, shutting down", newC.Server.CfgPath)
+	kc.shutdown("Config file changed")
 	return nil
 }

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kentik/ktranslate/pkg/api"
 	"github.com/kentik/ktranslate/pkg/cat/auth"
+	"github.com/kentik/ktranslate/pkg/config"
 	"github.com/kentik/ktranslate/pkg/filter"
 	"github.com/kentik/ktranslate/pkg/formats"
 	"github.com/kentik/ktranslate/pkg/inputs/flow"
@@ -78,6 +79,8 @@ type KTranslate struct {
 	enricher     *enrich.Enricher
 	logTee       chan string
 	authConfig   *auth.AuthConfig
+	confMgr      config.ConfigManager
+	shutdown     func(string)
 }
 
 type CustomMapper struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ Interface to manage configs.
 
 import (
 	"context"
+	"flag"
 	"fmt"
 
 	"github.com/kentik/ktranslate"
@@ -28,6 +29,14 @@ const (
 	LocalConfig    ConfigProvider = "local"
 	NoConfig       ConfigProvider = ""
 )
+
+var (
+	configProvider string
+)
+
+func init() {
+	flag.StringVar(&configProvider, "config_provider", "", "Implementation of which provider controls the config process. Can be one of (new_relic,local)")
+}
 
 func NewConfig(prov ConfigProvider, log logger.Underlying, config *ktranslate.Config) (ConfigManager, error) {
 	switch prov {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,43 @@
+package config
+
+/**
+Interface to manage configs.
+*/
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/config/local"
+	"github.com/kentik/ktranslate/pkg/config/nr"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+type ConfigManager interface {
+	Run(context.Context, func(*ktranslate.Config) error) // Run takes a context and a callback function to call whenever there is a new update to process
+	DeviceDiscovery(kt.DeviceMap)                        // called whenever there is a new snmp device discovery to parse.
+	Close()                                              // Called on shutdown of ktrans.
+}
+
+type ConfigProvider string
+
+const (
+	NewRelicConfig ConfigProvider = "new_relic"
+	LocalConfig    ConfigProvider = "local"
+	NoConfig       ConfigProvider = ""
+)
+
+func NewConfig(prov ConfigProvider, log logger.Underlying, config *ktranslate.Config) (ConfigManager, error) {
+	switch prov {
+	case NewRelicConfig:
+		return nr.NewConfig(log, config)
+	case LocalConfig:
+		return local.NewConfig(log, config)
+	case NoConfig:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Unknown config provider %v", prov)
+	}
+}

--- a/pkg/config/local/local.go
+++ b/pkg/config/local/local.go
@@ -1,0 +1,76 @@
+package local
+
+import (
+	"context"
+
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type LocalConfig struct {
+	logger.ContextL
+	currentConfig *ktranslate.Config
+	watcher       *fsnotify.Watcher
+}
+
+func NewConfig(log logger.Underlying, cfg *ktranslate.Config) (*LocalConfig, error) {
+	lc := LocalConfig{
+		ContextL:      logger.NewContextLFromUnderlying(logger.SContext{S: "localConfig"}, log),
+		currentConfig: cfg,
+	}
+
+	lc.Infof("Monitoring %s for changes", lc.currentConfig.Server.CfgPath)
+
+	// Create new watcher.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	// Add a path.
+	err = watcher.Add(lc.currentConfig.Server.CfgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	lc.watcher = watcher
+
+	return &lc, nil
+}
+
+func (lc *LocalConfig) Run(ctx context.Context, cb func(*ktranslate.Config) error) {
+	lc.Infof("config checker running")
+	for {
+		select {
+		case event, ok := <-lc.watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Has(fsnotify.Write) {
+				err := cb(lc.currentConfig)
+				if err != nil {
+					lc.Errorf("Cannot update to new config: %v", err)
+				}
+			}
+		case err, ok := <-lc.watcher.Errors:
+			if !ok {
+				return
+			}
+			lc.Infof("error:", err)
+		case <-ctx.Done():
+			lc.Infof("config checker done")
+			return
+		}
+	}
+}
+
+func (lc *LocalConfig) DeviceDiscovery(devices kt.DeviceMap) {
+	// NOOP
+}
+
+func (lc *LocalConfig) Close() {
+	lc.watcher.Close()
+}

--- a/pkg/config/nr/nr.go
+++ b/pkg/config/nr/nr.go
@@ -1,0 +1,64 @@
+package nr
+
+import (
+	"context"
+	"time"
+
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+type NRConfig struct {
+	logger.ContextL
+	currentConfig *ktranslate.Config
+}
+
+func NewConfig(log logger.Underlying, cfg *ktranslate.Config) (*NRConfig, error) {
+	nr := NRConfig{
+		ContextL:      logger.NewContextLFromUnderlying(logger.SContext{S: "nrConfig"}, log),
+		currentConfig: cfg,
+	}
+
+	return &nr, nil
+}
+
+func (nr *NRConfig) Run(ctx context.Context, cb func(*ktranslate.Config) error) {
+	checkTicker := time.NewTicker(time.Second * time.Duration(nr.currentConfig.CfgManager.PollTimeSec))
+	defer checkTicker.Stop()
+
+	nr.Infof("config checker running")
+	for {
+		select {
+		case <-checkTicker.C:
+			// Get config
+			newConfig, newVersion, err := nr.getConfig()
+			if err != nil {
+				nr.Errorf("Cannot load new config: %v", err)
+			}
+
+			if newConfig != nil && newVersion {
+				nr.currentConfig = newConfig
+				err := cb(newConfig)
+				if err != nil {
+					nr.Errorf("Cannot update to new config: %v", err)
+				}
+			}
+		case <-ctx.Done():
+			nr.Infof("config checker done")
+			return
+		}
+	}
+}
+
+func (nr *NRConfig) DeviceDiscovery(devices kt.DeviceMap) {
+
+}
+
+func (nr *NRConfig) Close() {
+
+}
+
+func (nr *NRConfig) getConfig() (*ktranslate.Config, bool, error) {
+	return nil, false, nil
+}


### PR DESCRIPTION
Here's a rough outline for what a managed config system might look like. 

https://github.com/kentik/ktranslate/tree/wip-managed-config/pkg/config/local 
Is an example of something which looks for a config change on a local file and restarts things if it sees this.

https://github.com/kentik/ktranslate/tree/wip-managed-config/pkg/config/nr
is a stub where you can pass data to NR. 

Thoughts here, especially on this interface?

```
type ConfigManager interface {
	Run(context.Context, func(*ktranslate.Config) error) // Run takes a context and a callback function to call whenever there is a new update to process
	DeviceDiscovery(kt.DeviceMap)                        // called whenever there is a new snmp device discovery to parse.
	Close()                                              // Called on shutdown of ktrans.
}
```
