### PR TITLE
Don't overwrite snmp-base.yaml file on package upgrade

### DIFF
--- a/ktranslate-package.yml
+++ b/ktranslate-package.yml
@@ -42,6 +42,7 @@ files:
     file: config/snmp-base.yaml
     mode: "0644"
     user: ktranslate
+    keep: true
 
   "/etc/default/ktranslate.env.sample":
     file: config/ktranslate.env.sample


### PR DESCRIPTION
When I went to update my package manager install of KTranslate, I noticed that the `snmp-base.yaml` file got overwritten. I think this flag should be true to prevent that behavior?