### PR TITLE
Remove namespace attributes for influx

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -425,6 +425,8 @@ func applyFlags(cfg *ktranslate.Config) error {
 			// pkg/formats/influxdb
 			case "influxdb_measurement_prefix":
 				cfg.InfluxDBFormat.MeasurementPrefix = val
+			case "influxdb_namespace_token":
+				cfg.InfluxDBFormat.NamespaceToken = val
 			// pkg/sinks/prom
 			case "prom_listen":
 				cfg.PrometheusSink.ListenAddr = val

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type NetflowFormatConfig struct {
 // InfluxDBFormatConfig is the config format for influxdb
 type InfluxDBFormatConfig struct {
 	MeasurementPrefix string
+	NamespaceToken    string
 }
 
 // PrometheusFormatConfig is the config for the prometheus format
@@ -336,6 +337,7 @@ func DefaultConfig() *Config {
 		},
 		InfluxDBFormat: &InfluxDBFormatConfig{
 			MeasurementPrefix: "",
+			NamespaceToken:    ":",
 		},
 		PrometheusSink: &PrometheusSinkConfig{
 			ListenAddr: ":8082",

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -23,6 +23,10 @@ var (
 	measurementPrefix string
 )
 
+const (
+	NameSpaceTokenSep = "::"
+)
+
 func init() {
 	flag.StringVar(&measurementPrefix, "influxdb_measurement_prefix", "", "Prefix metric names with this")
 
@@ -655,6 +659,13 @@ func getMib(attr map[string]interface{}, ip interface{}) string {
 		if k == "Index" {
 			delete(attr, k)
 			attr["index"] = v
+		}
+
+		// If the attribute has a namespace prefix, drop here.
+		if strings.Contains(k, NameSpaceTokenSep) {
+			pts := strings.SplitN(k, NameSpaceTokenSep, 2)
+			delete(attr, k)
+			attr[pts[1]] = v
 		}
 	}
 	if ip != nil {

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -60,6 +60,19 @@ line2`,
 	assert.Contains(str, "line2")
 }
 
+func TestGetMib(t *testing.T) {
+	assert := assert.New(t)
+
+	input := map[string]interface{}{"Index": "11", "bgp::foo": "22"}
+	mibName := getMib(input, nil)
+
+	assert.Equal("11", input["index"])
+	assert.Equal("22", input["foo"])
+	assert.Equal(nil, input["bgp::foo"])
+	assert.Equal(nil, input["device_ip"])
+	assert.Equal("device", mibName)
+}
+
 const (
 	clean = "the quick red fox jumps over the lazy brown dogs"
 	dirty = `the quick red fox

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -63,6 +63,7 @@ line2`,
 func TestGetMib(t *testing.T) {
 	assert := assert.New(t)
 
+	namespaceTokenSep = "::"
 	input := map[string]interface{}{"Index": "11", "bgp::foo": "22"}
 	mibName := getMib(input, nil)
 


### PR DESCRIPTION
Trims the namespace token off tags for influx. Also a test for this. 

Closes #493