### PR TITLE
Adding a way to check v1,2c, and 3 snmp

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -242,7 +242,7 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 	// Loop over all possibe v2c options here if any are set.
 	if md == nil || md.SysObjectID == "" { // Only check these if v3 hasn't found anything.
 		versions := []bool{conf.Disco.UseV1} // By default, just check v1 or v2c only.
-		if conf.Disco.DoubleCheckV1 {
+		if conf.Disco.CheckAllVersions {
 			versions = []bool{false, true} // But, if we ask for it, first check v2c and then check v1.
 		}
 	outer:

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -243,6 +243,7 @@ type SnmpDiscoConfig struct {
 	ReplaceDevices     bool            `yaml:"replace_devices"`
 	NoDedup            bool            `yaml:"no_dedup_engine_id,omitempty"`
 	CheckAll           bool            `yaml:"check_all_ips,omitempty"`
+	DoubleCheckV1      bool            `yaml:"doublecheck_snmp_v1,omitempty"`
 	Kentik             *KentikDisco    `yaml:"kentik"`
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`
@@ -254,21 +255,21 @@ type ProviderMap struct {
 }
 
 type SnmpGlobalConfig struct {
-	PollTimeSec   int                    `yaml:"poll_time_sec"`
-	DropIfOutside bool                   `yaml:"drop_if_outside_poll"`
-	MibProfileDir string                 `yaml:"mib_profile_dir"`
-	MibDB         string                 `yaml:"mibs_db"`
-	MibsEnabled   []string               `yaml:"mibs_enabled"`
-	TimeoutMS     int                    `yaml:"timeout_ms"`
-	Retries       int                    `yaml:"retries"`
-	GlobalV3      *V3SNMPConfig          `yaml:"global_v3"`
-	RunPing       bool                   `yaml:"response_time"`
-	PingSec       int                    `yaml:"ping_interval_sec,omitempty"`
-	PurgeDevices  int                    `yaml:"purge_devices_after_num"` // Delete any device if its not seen after X discovery attempts. Default is 0, which means things never get purged.
-	NoDeviceHardcodedOids  bool          `yaml:"no_device_hardcoded_oids"`
-	UserTags      map[string]string      `yaml:"user_tags"`
-	MatchAttr     map[string]string      `yaml:"match_attributes"`
-	ProviderMap   map[string]ProviderMap `yaml:"providers"`
+	PollTimeSec           int                    `yaml:"poll_time_sec"`
+	DropIfOutside         bool                   `yaml:"drop_if_outside_poll"`
+	MibProfileDir         string                 `yaml:"mib_profile_dir"`
+	MibDB                 string                 `yaml:"mibs_db"`
+	MibsEnabled           []string               `yaml:"mibs_enabled"`
+	TimeoutMS             int                    `yaml:"timeout_ms"`
+	Retries               int                    `yaml:"retries"`
+	GlobalV3              *V3SNMPConfig          `yaml:"global_v3"`
+	RunPing               bool                   `yaml:"response_time"`
+	PingSec               int                    `yaml:"ping_interval_sec,omitempty"`
+	PurgeDevices          int                    `yaml:"purge_devices_after_num"` // Delete any device if its not seen after X discovery attempts. Default is 0, which means things never get purged.
+	NoDeviceHardcodedOids bool                   `yaml:"no_device_hardcoded_oids"`
+	UserTags              map[string]string      `yaml:"user_tags"`
+	MatchAttr             map[string]string      `yaml:"match_attributes"`
+	ProviderMap           map[string]ProviderMap `yaml:"providers"`
 }
 
 type SnmpConfig struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -243,7 +243,7 @@ type SnmpDiscoConfig struct {
 	ReplaceDevices     bool            `yaml:"replace_devices"`
 	NoDedup            bool            `yaml:"no_dedup_engine_id,omitempty"`
 	CheckAll           bool            `yaml:"check_all_ips,omitempty"`
-	DoubleCheckV1      bool            `yaml:"doublecheck_snmp_v1,omitempty"`
+	CheckAllVersions   bool            `yaml:"check_all_snmp_versions,omitempty"`
 	Kentik             *KentikDisco    `yaml:"kentik"`
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`


### PR DESCRIPTION
Adds this option `doublecheck_snmp_v1: true` to the `discovery` section of the snmp config file. 

When set to true, v3, then v2c and finally v1 configs are checked for all devices. If false, current behavior remains. 

Closes #494 