### PR TITLE
Set basic tags on trap events from unknown sources

### DIFF
--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -126,7 +126,7 @@ func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan
 	// Set up some default tags if the device sending isn't found.
 	baseTags := map[string]string{}
 	if serviceName != "" {
-		baseTags["container_service"] = kt.UserTagPrefix + serviceName
+		baseTags[kt.UserTagPrefix+"container_service"] = serviceName
 	}
 	for k, v := range globalTags {
 		key := k

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -137,8 +137,6 @@ func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan
 	}
 	st.baseTags = baseTags
 
-	st.log.Infof("XXXX %v", st.baseTags)
-
 	return st, nil
 }
 

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -34,6 +35,7 @@ type SnmpTrap struct {
 	resolv    *resolv.Resolver
 	ctx       context.Context
 	deviceMap map[string]*kt.SnmpDeviceConfig
+	baseTags  map[string]string
 }
 
 // Move to util?
@@ -50,7 +52,8 @@ func (l logWrapper) Printf(format string, v ...interface{}) {
 	l.printf(format, v...)
 }
 
-func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, mibdb *mibs.MibDB, log logger.ContextL, resolv *resolv.Resolver) (*SnmpTrap, error) {
+func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, mibdb *mibs.MibDB,
+	log logger.ContextL, resolv *resolv.Resolver, serviceName string, globalTags map[string]string) (*SnmpTrap, error) {
 	st := &SnmpTrap{
 		jchfChan:  jchfChan,
 		log:       log,
@@ -120,6 +123,22 @@ func NewSnmpTrapListener(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan
 		st.deviceMap[device.DeviceIP] = device
 	}
 
+	// Set up some default tags if the device sending isn't found.
+	baseTags := map[string]string{}
+	if serviceName != "" {
+		baseTags["container_service"] = kt.UserTagPrefix + serviceName
+	}
+	for k, v := range globalTags {
+		key := k
+		if !strings.HasPrefix(key, kt.UserTagPrefix) {
+			key = kt.UserTagPrefix + k
+		}
+		baseTags[key] = v
+	}
+	st.baseTags = baseTags
+
+	st.log.Infof("XXXX %v", st.baseTags)
+
 	return st, nil
 }
 
@@ -160,6 +179,9 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 			}
 		}
 		dst.Provider = kt.ProviderTrapUnknown
+		for k, v := range s.baseTags {
+			dst.CustomStr[k] = v
+		}
 	}
 
 	// What trap is this from?


### PR DESCRIPTION
Closes #496 

This sets these global tags and `service_name` for all trap events now. For example:

```
  {
    "eventType": "KSnmpTrap",
    "device_name": "127.0.0.1",
    ".1.3.6.1.4.1.8072.2.3.2.1": 123456,
    "instrumentation.provider": "kentik",
    "tags.container_service": "fooo",
    "provider": "kentik-trap-device",
    "tags.level": "global",
    ".1.3.6.1.2.1.1.3.0": 52736386,
    "instrumentation.name": "netflow-events",
    "TrapOID": ".1.3.6.1.4.1.8072.2.3.0.1",
    "collector.name": "ktranslate",
    "src_addr": "127.0.0.1"
  }
```

When `-service_name fooo` and 

``` 
user_tags:
    level: global
```

Are set. This make sense / work for you all? 