### PR TITLE
Add Ubuntu Kinetic to the package cloud list of repos to build

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,6 +28,10 @@ jobs:
             release: jammy
             pkg: deb
             pkg_name: ubuntu
+          - distro: ubuntu
+            release: kinetic
+            pkg: deb
+            pkg_name: ubuntu
 
           - distro: debian
             release: bullseye

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,6 +30,9 @@ jobs:
           - distro: ubuntu
             release: jammy
             pkg: deb
+          - distro: ubuntu
+            release: kinetic
+            pkg: deb
 
           - distro: debian
             release: bullseye


### PR DESCRIPTION
This will build a release package for Ubuntu Kinetic. In general we've only been supporting LTS releases but its easy enough to add this in since we have @Geczy asking for it. 

Closes #513 

