### PR TITLE
Fixing filter and rollup flags

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kentik/ktranslate"
 	"github.com/kentik/ktranslate/cmd/version"
 	"github.com/kentik/ktranslate/pkg/cat"
+	"github.com/kentik/ktranslate/pkg/filter"
 	"github.com/kentik/ktranslate/pkg/kt"
 
 	"github.com/imdario/mergo"
@@ -542,7 +543,7 @@ func applyFlags(cfg *ktranslate.Config) error {
 				}
 				cfg.Rollup.TopK = v
 			case "rollups":
-				cfg.Rollup.Formats = strings.Split(val, ",")
+				cfg.Rollup.Formats = strings.Split(val, filter.AndToken)
 			// pkg/eggs/kmux
 			case "dir":
 				cfg.KMux.Dir = val
@@ -571,7 +572,7 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.API.DeviceFile = val
 			// pkg/filter
 			case "filters":
-				cfg.Filters = strings.Split(val, ",")
+				cfg.Filters = strings.Split(val, filter.AndToken)
 			// pkg/inputs/syslog
 			case "syslog.udp":
 				v, err := strconv.ParseBool(val)

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -21,15 +21,26 @@ const (
 	Int               = "int"
 	Addr              = "addr"
 
-	OrToken = " or "
+	OrToken  = " or "
+	AndToken = " and "
 )
 
 var (
-	filters string
+	filters FilterFlag
 )
 
+type FilterFlag []string
+
+func (ff *FilterFlag) String() string {
+	return strings.Join(*ff, AndToken)
+}
+func (ff *FilterFlag) Set(val string) error {
+	*ff = append(*ff, strings.TrimSpace(val))
+	return nil
+}
+
 func init() {
-	flag.StringVar(&filters, "filters", "", "Any filters to use. Format: type dimension operator value")
+	flag.Var(&filters, "filters", "Any filters to use. Format: type dimension operator value")
 }
 
 type Operator string

--- a/pkg/rollup/rollup.go
+++ b/pkg/rollup/rollup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kentik/ktranslate"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/filter"
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
@@ -28,13 +29,23 @@ const (
 )
 
 var (
-	rollups string
+	rollups RollupFlag
 	keyJoin string
 	topK    int
 )
 
+type RollupFlag []string
+
+func (ff *RollupFlag) String() string {
+	return strings.Join(*ff, filter.AndToken)
+}
+func (ff *RollupFlag) Set(val string) error {
+	*ff = append(*ff, strings.TrimSpace(val))
+	return nil
+}
+
 func init() {
-	flag.StringVar(&rollups, "rollups", "", "Any rollups to use. Format: type, name, metric, dimension 1, dimension 2, ..., dimension n: sum,bytes,in_bytes,dst_addr")
+	flag.Var(&rollups, "rollups", "Any rollups to use. Format: type, name, metric, dimension 1, dimension 2, ..., dimension n: sum,bytes,in_bytes,dst_addr")
 	flag.StringVar(&keyJoin, "rollup_key_join", "^", "Token to use to join dimension keys together")
 	flag.IntVar(&topK, "rollup_top_k", 10, "Export only these top values")
 }


### PR DESCRIPTION
Some flags in ktrans are expected to be set more than one time. When we added support for a config file this functionality got dropped. This PR restores the ability to set multiple `-filter` and `-rollups` flags. 