### PR TITLE
Merge ping metrics into a single record

### DIFF
--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -363,10 +363,14 @@ var keepAcrossTables = map[string]bool{
 }
 
 var allowSysAttr = map[string]bool{
-	"Uptime":   true,
-	"MinRttMs": true,
-	"MaxRttMs": true,
-	"AvgRttMs": true,
+	"Uptime":        true,
+	"MinRttMs":      true,
+	"MaxRttMs":      true,
+	"AvgRttMs":      true,
+	"StdDevRtt":     true,
+	"PacketsSent":   true,
+	"PacketsRecv":   true,
+	"PacketLossPct": true,
 }
 
 func CopyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata, gentleCardinality bool, dropSrcAddr bool) map[string]interface{} {


### PR DESCRIPTION
Retain src_addr field for all ping metrics so the merging process will include all metrics in a single output record. 

This is one of a number of different features requested in #489.