### PR TITLE
Change profile source for kentik variant

### DIFF
--- a/.github/workflows/publish-kentik.yml
+++ b/.github/workflows/publish-kentik.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - kentik
 
+  workflow_dispatch:
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-kentik.yml
+++ b/.github/workflows/publish-kentik.yml
@@ -65,7 +65,7 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: kentik/ktranslate:kentik, quay.io/kentik/ktranslate:kentik
+          tags: kentik/ktranslate:kentik-${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:kentik, quay.io/kentik/ktranslate:kentik
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/.github/workflows/publish-kentik.yml
+++ b/.github/workflows/publish-kentik.yml
@@ -65,7 +65,7 @@ jobs:
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: kentik/ktranslate:kentik-${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:kentik, quay.io/kentik/ktranslate:kentik
+          tags: kentik/ktranslate:${{ env.KENTIK_KTRANSLATE_VERSION }}, kentik/ktranslate:kentik, quay.io/kentik/ktranslate:kentik
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}

--- a/.github/workflows/publish-kentik.yml
+++ b/.github/workflows/publish-kentik.yml
@@ -69,6 +69,6 @@ jobs:
           build-args: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
             KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
-            KENTIK_SNMP_PROFILE_BRANCH=kentik
+            KENTIK_SNMP_PROFILE_REPO=https://github.com/kentik/collection-profiles
           secrets: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ config/profiles
 cmd/version/generated_version.go
 
 .vscode/
+.idea/
 
 ## local configuration
 config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM alpine:latest as snmp
 RUN apk add -U git
 
 # If there is a branch of snmp-profiles to use, switch over here now.
-RUN if [ -z "${KENTIK_SNMP_PROFILE_BRANCH}" ]; then \
+RUN if [ -z "${KENTIK_SNMP_PROFILE_REPO}" ]; then \
     git clone https://github.com/kentik/snmp-profiles /snmp; \
 else \
     echo "picking repo ${KENTIK_SNMP_PROFILE_REPO} for snmp profiles"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -o /tmp/asn.tar.gz "https://download.maxmind.com/app/geoip_download?edi
 
 # snmp profiles
 FROM alpine:latest as snmp
+ARG KENTIK_SNMP_PROFILE_REPO
 RUN apk add -U git
 
 # If there is a branch of snmp-profiles to use, switch over here now.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN apk add -U git
 RUN if [ -z "${KENTIK_SNMP_PROFILE_BRANCH}" ]; then \
     git clone https://github.com/kentik/snmp-profiles /snmp; \
 else \
-    echo "picking branch ${KENTIK_SNMP_PROFILE_BRANCH} for snmp profiles"; \
-    git clone --branch ${KENTIK_SNMP_PROFILE_BRANCH} https://github.com/kentik/snmp-profiles /snmp; \
+    echo "picking repo ${KENTIK_SNMP_PROFILE_REPO} for snmp profiles"; \
+    git clone ${KENTIK_SNMP_PROFILE_REPO} /snmp; \
 fi
 
 # main image


### PR DESCRIPTION
The kentik variant should use the collection-profiles repo instead of the kentik branch of the snmp-profiles repo.