### PR TITLE
Make computed device metric names configurable

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -28,6 +28,7 @@ type DeviceMetrics struct {
 	conf        *kt.SnmpDeviceConfig
 	gconf       *kt.SnmpGlobalConfig
 	metrics     *kt.SnmpDeviceMetric
+	profile     *mibs.Profile
 	profileName string
 	oids        map[string]*kt.Mib
 	missing     map[string]bool
@@ -56,6 +57,7 @@ func NewDeviceMetrics(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, met
 		log:         log,
 		conf:        conf,
 		metrics:     metrics,
+		profile:     profile,
 		profileName: profile.GetProfileName(conf.InstrumentationName),
 		oids:        oidMap,
 		missing:     map[string]bool{},
@@ -141,8 +143,16 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 		}
 	}
 
+	var mib string
+	for _, m := range dm.profile.Metrics {
+		// FIXME: proper OID allocation
+		if m.Table.Oid == ".1.2.3.1" {
+			mib = m.Table.Name
+		}
+	}
+
 	// Map back into types we know about.
-	metricsFound := map[string]kt.MetricInfo{"Uptime": kt.MetricInfo{Oid: sysUpTime, Profile: dm.profileName}}
+	metricsFound := map[string]kt.MetricInfo{"Uptime": kt.MetricInfo{Oid: sysUpTime, Mib: mib, Profile: dm.profileName}}
 	for _, wrapper := range results {
 		if wrapper.variable.Value == nil { // You can get nil w/out getting an error, though.
 			continue
@@ -326,6 +336,16 @@ func assureDeviceMetrics(m map[string]*deviceMetricRow, index string) *deviceMet
 
 // Return a flow with status of SNMP, reguardless of if the rest of the system is working.
 func (dm *DeviceMetrics) GetStatusFlows() []*kt.JCHF {
+	mib := "computed"
+	oid := "computed"
+
+	for _, m := range dm.profile.Metrics {
+		if m.Table.Oid == ".1.2.3.2" {
+			mib = m.Table.Name
+			oid = m.Table.Oid
+		}
+	}
+
 	dst := kt.NewJCHF()
 	dst.CustomStr = map[string]string{}
 	dst.CustomInt = map[string]int32{}
@@ -335,7 +355,7 @@ func (dm *DeviceMetrics) GetStatusFlows() []*kt.JCHF {
 	dst.DeviceName = dm.conf.DeviceName
 	dst.SrcAddr = dm.conf.DeviceIP
 	dst.Timestamp = time.Now().Unix()
-	dst.CustomMetrics = map[string]kt.MetricInfo{"PollingHealth": kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: dm.profileName}}
+	dst.CustomMetrics = map[string]kt.MetricInfo{"PollingHealth": kt.MetricInfo{Oid: oid, Mib: mib, Profile: dm.profileName}}
 	dm.conf.SetUserTags(dst.CustomStr)
 	if dst.Provider == kt.ProviderDefault { // Add this to trigger a UI element.
 		dst.CustomStr["profile_message"] = kt.DefaultProfileMessage
@@ -361,6 +381,16 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 		return nil, nil
 	}
 
+	mib := "computed"
+	oid := "computed"
+
+	for _, m := range dm.profile.Metrics {
+		if m.Table.Oid == ".1.2.3.3" {
+			mib = m.Table.Name
+			oid = m.Table.Oid
+		}
+	}
+
 	stats := pinger.Statistics()
 	dst := kt.NewJCHF()
 	dst.CustomStr = map[string]string{}
@@ -373,13 +403,13 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	dst.Timestamp = time.Now().Unix()
 	dst.CustomMetrics = map[string]kt.MetricInfo{}
 	dst.CustomBigInt["MinRttMs"] = stats.MinRtt.Microseconds()
-	dst.CustomMetrics["MinRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["MinRttMs"] = kt.MetricInfo{Oid: oid, Mib: mib, Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["MaxRttMs"] = stats.MaxRtt.Microseconds()
-	dst.CustomMetrics["MaxRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["MaxRttMs"] = kt.MetricInfo{Oid: oid, Mib: mib, Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["AvgRttMs"] = stats.AvgRtt.Microseconds()
-	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["AvgRttMs"] = kt.MetricInfo{Oid: oid, Mib: mib, Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["StdDevRtt"] = stats.StdDevRtt.Microseconds()
-	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["StdDevRtt"] = kt.MetricInfo{Oid: oid, Mib: mib, Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 
 	// Calc these directly
 	sent := uint64(stats.PacketsSent)
@@ -396,12 +426,12 @@ func (dm *DeviceMetrics) GetPingStats(ctx context.Context, pinger *ping.Pinger) 
 	}
 
 	dst.CustomBigInt["PacketsSent"] = int64(diffSent)
-	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["PacketsSent"] = kt.MetricInfo{Oid: oid, Mib: mib, Profile: "ping", Type: "ping"}
 	dst.CustomBigInt["PacketsRecv"] = int64(diffRecv)
-	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Profile: "ping", Type: "ping"}
+	dst.CustomMetrics["PacketsRecv"] = kt.MetricInfo{Oid: oid, Mib: mib, Profile: "ping", Type: "ping"}
 	if percnt >= 0.0 {
 		dst.CustomBigInt["PacketLossPct"] = int64(percnt * 1000.)
-		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: "computed", Mib: "computed", Format: kt.FloatMS, Profile: "ping", Type: "ping"}
+		dst.CustomMetrics["PacketLossPct"] = kt.MetricInfo{Oid: oid, Mib: mib, Format: kt.FloatMS, Profile: "ping", Type: "ping"}
 
 		// If percent ~ 100, push rtt down to 0 to avoid bad readings.
 		if math.Abs(percnt-99.) <= 1 {


### PR DESCRIPTION
Add dummy OIDs for the synthetic metrics ktranslate generates for uptime, health status, and ping, then output the table name associated with those OIDs, if one exists in the profile, instead of `computed`.

This is one of the features requested in #489.