### PR TITLE
Allow variable jitter time for snmp polling

### DIFF
--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -270,6 +270,7 @@ type SnmpGlobalConfig struct {
 	UserTags              map[string]string      `yaml:"user_tags"`
 	MatchAttr             map[string]string      `yaml:"match_attributes"`
 	ProviderMap           map[string]ProviderMap `yaml:"providers"`
+	JitterTimeSec         int                    `yaml:"jitter_time_sec"`
 }
 
 type SnmpConfig struct {


### PR DESCRIPTION
Consider adding a configurable `jitter_time_sec` variable which will spread the processing load out across this many seconds. Defaults to 15 which is the current hard coded value. For large number of devices, good to raise this number higher. 