### PR TITLE
Allow kentik/collection-profiles to trigger the publish-kentik workflow

### DIFF
--- a/.github/workflows/publish-kentik.yml
+++ b/.github/workflows/publish-kentik.yml
@@ -1,4 +1,5 @@
 name: Publish Kentik
+run-name: ${{ inputs.message }}
 
 on:
   push:
@@ -6,6 +7,9 @@ on:
       - kentik
 
   workflow_dispatch:
+    inputs:
+      message:
+        type: string
 
 jobs:
   deploy:


### PR DESCRIPTION
This is adding back in 

```
[main 7a48c68] Allow kentik/collection-profiles to trigger the publish-kentik workflow (#531)
 Author: Tim Danner <tdanner@users.noreply.github.com>
 Date: Wed Mar 1 19:56:11 2023 -0600
 1 file changed, 4 insertions(+)
```

which got dropped in yesterday's fire alarm. 