### PR TITLE
Fixing panic when variable tags are the empty string

### DIFF
--- a/pkg/inputs/snmp/metadata/poll.go
+++ b/pkg/inputs/snmp/metadata/poll.go
@@ -262,6 +262,7 @@ func (p *Poller) toFlows(dd *kt.DeviceData) ([]*kt.JCHF, error) {
 			for tag, value := range dst.CustomStr {
 				if tag == v[len(TagValuePrefix):] {
 					v = value
+					break // Once we find a match, break out and don't try comparing to anything else any more.
 				}
 			}
 		}

--- a/pkg/inputs/snmp/metadata/poll_test.go
+++ b/pkg/inputs/snmp/metadata/poll_test.go
@@ -40,3 +40,37 @@ func TestGetDeviceManufacturer(t *testing.T) {
 		}
 	}
 }
+
+func TestToFlows(t *testing.T) {
+	l := lt.NewTestContextL(logger.NilContext, t)
+	conf := &kt.SnmpDeviceConfig{
+		Provider: "foo",
+		UserTags: map[string]string{
+			"foo": "$foo",
+			"aaa": "$SysContact",
+		},
+	}
+	conf.InitUserTags("service")
+
+	p := &Poller{
+		log:  l,
+		conf: conf,
+	}
+
+	input := kt.DeviceData{
+		Manufacturer: "man",
+		DeviceMetricsMetadata: &kt.DeviceMetricsMetadata{
+			SysContact: "ddd",
+			Customs: map[string]string{
+				"foo": "",
+				"bar": "",
+			},
+		},
+	}
+	res, err := p.toFlows(&input)
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, "ddd", res[0].CustomStr["tags.aaa"])
+	assert.Equal(t, "", res[0].CustomStr["tags.foo"]) // Empty string match for tag here.
+}


### PR DESCRIPTION
There's a bug in how this variable mapping is applied. There's this loop here: 

```
            for tag, value := range dst.CustomStr {
                if tag == v[len(TagValuePrefix):] {
                    v = value
                }
            }
```

 the first time through, it will swap v to the value and everything is good. The problem is that the loop isn't exiting and v now is the empty string.

next time though, it will try to take a slice of the empty string and get your stack trace.
Code fix is to add a break statement so that once a correct variable is applied, no more variables will be swapped in.
for now, I'd recommend if possible you remove any of the $SysContact in tags for the offending containers
this should prevent the crash