### PR TITLE
improve netflow format export

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,9 @@ const (
 	FlowDefaultFields = "TimeReceived,SamplingRate,Bytes,Packets,SrcAddr,DstAddr,Proto,SrcPort,DstPort,InIf,OutIf,SrcVlan,DstVlan,TCPFlags,SrcAS,DstAS,Type,SamplerAddress,FlowDirection"
 	// KentikAPITokenEnvVar is the environment variables used to get the Kentik API Token
 	KentikAPITokenEnvVar = "KENTIK_API_TOKEN"
+	// MaxNetflowsPerMessage is the maximum flowsets in a single netflow message
+	// Must be less than ( 65535[nf_max_size] - 16[nf_header_size] - 96(nf_template_flowset_size] ) / 128[nf_data_flowset_size]
+	MaxNetflowsPerMessage = 510
 )
 
 // NetflowFormatConfig is the config format for netflow
@@ -492,6 +495,10 @@ func LoadConfig(configPath string) (*Config, error) {
 	var cfg *Config
 	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
 		return nil, err
+	}
+
+	if cfg.Format == "netflow" && (cfg.MaxFlowsPerMessage <= 0 || cfg.MaxFlowsPerMessage > MaxNetflowsPerMessage) {
+		cfg.MaxFlowsPerMessage = MaxNetflowsPerMessage
 	}
 
 	return cfg, nil

--- a/pkg/formats/netflow/netflow.go
+++ b/pkg/formats/netflow/netflow.go
@@ -58,6 +58,7 @@ const (
 	IPV6_DST_ADDR             = 28
 	SRC_MAC                   = 56
 	DST_MAC                   = 80
+	OBSERVATION_POINT_ID      = 138
 	FLOW_START_SECONDS        = 150
 	FLOW_END_SECONDS          = 151
 )
@@ -92,6 +93,7 @@ var fields = []Field{
 	{OUT_BYTES, 8},
 	{IN_PKTS, 8},
 	{OUT_PKTS, 8},
+	{OBSERVATION_POINT_ID, 8}, // uint64
 	{FLOW_START_SECONDS, 4}, // uint32
 	{FLOW_END_SECONDS, 4},
 }
@@ -434,6 +436,8 @@ func encodeFlow(flow *kt.JCHF) (*bytes.Buffer, error) {
 			value = uint64(flow.InPkts)
 		case OUT_PKTS:
 			value = uint64(flow.OutPkts)
+		case OBSERVATION_POINT_ID:
+			value = uint64(flow.CompanyId&0xffff)<<32 + uint64(flow.DeviceId)
 		case FLOW_START_SECONDS:
 			value = uint32(flow.Timestamp)
 		case FLOW_END_SECONDS: // Assume that each flow is 60 sec long.


### PR DESCRIPTION
- auto-limit flows batch size to avoid reaching network message size limit
- pack CompanyId and DeviceId fields into observationPointId netflow entity