### PR TITLE
Allow named match metrics

### DIFF
--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -166,13 +166,21 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 		case gosnmp.OctetString, gosnmp.BitString:
 			value := string(wrapper.variable.Value.([]byte))
 			if wrapper.mib.Conversion != "" { // Adjust for any hard coded values here.
-				ival, sval, _ := snmp_util.GetFromConv(wrapper.variable, wrapper.mib.Conversion, dm.log)
+				ival, sval, mval := snmp_util.GetFromConv(wrapper.variable, wrapper.mib.Conversion, dm.log)
 				if ival > 0 {
 					dmr.customBigInt[oidName] = ival
 					dmr.customStr[kt.StringPrefix+oidName] = sval
 					continue // we have everything we need, no need to continue processing.
 				} else {
-					value = sval
+					if len(mval) > 0 {
+						for k, v := range mval {
+							dmr.customStr[k] = v
+							continue // we have everything we need, no need to continue processing.
+						}
+					} else {
+						value = sval
+					}
+
 				}
 			}
 			if wrapper.mib.Enum != nil {

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -174,6 +174,7 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 				} else {
 					if len(mval) > 0 {
 						for k, v := range mval {
+							metricsFound[k] = kt.MetricInfo{Oid: wrapper.mib.Oid, Mib: wrapper.mib.Mib, Profile: dm.profileName, Table: wrapper.mib.Table, PollDur: wrapper.mib.PollDur}
 							if s, err := strconv.ParseInt(v, 10, 64); err == nil {
 								dmr.customBigInt[k] = s
 								dmr.customStr[kt.StringPrefix+k] = v

--- a/pkg/inputs/snmp/metrics/device_metrics.go
+++ b/pkg/inputs/snmp/metrics/device_metrics.go
@@ -174,9 +174,16 @@ func (dm *DeviceMetrics) pollFromConfig(ctx context.Context, server *gosnmp.GoSN
 				} else {
 					if len(mval) > 0 {
 						for k, v := range mval {
-							dmr.customStr[k] = v
-							continue // we have everything we need, no need to continue processing.
+							if s, err := strconv.ParseInt(v, 10, 64); err == nil {
+								dmr.customBigInt[k] = s
+								dmr.customStr[kt.StringPrefix+k] = v
+							} else {
+								dm.log.Debugf("unable to set string valued metric as numeric: %s %s", k, v)
+								dmr.customStr[kt.StringPrefix+k] = v // Still save this as a string valued field.
+								dmr.customBigInt[k] = 0
+							}
 						}
+						continue // Once we have set everything here, go on.
 					} else {
 						value = sval
 					}

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -313,7 +313,8 @@ func GetFromConv(pdu gosnmp.SnmpPDU, conv string, log logger.ContextL) (int64, s
 	return 0, string(bv), nil // Default down to here.
 }
 
-/**
+/*
+*
 Some OID's don't store IP as a string, they store it as a hex value that we are going to want to translate.
 I need to take this:
 .1.3.6.1.4.1.9.9.42.1.2.2.1.2.1 = Hex-String: 0A00640A
@@ -353,7 +354,8 @@ func engineID(bv []byte) (int64, string, map[string]string) {
 	return 0, string(buf[:len(buf)-1]), nil
 }
 
-/**
+/*
+*
 Ubiquity and maybe others can be annoying in returning a string version of CPU.
 This lets people parse it out.
 

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -367,7 +367,7 @@ func fromRegexp(bv []byte, reg string) (int64, string, map[string]string) {
 	if r == nil {
 		rn, err := regexp.Compile(reg)
 		if err != nil {
-			return 0, "", nil
+			return 0, err.Error(), nil
 		}
 		reCache[reg] = rn
 		r = rn

--- a/pkg/inputs/snmp/util/util_test.go
+++ b/pkg/inputs/snmp/util/util_test.go
@@ -207,6 +207,14 @@ func TestRegex(t *testing.T) {
 				"version": "13.3R9.13",
 			},
 		},
+		multiRe{
+			input: []byte("[Card-cc1 Intake : 23 C] [Card-cc1 Exhaust : 26 C] [Card-cc1 Board : 23 C] [Card-1 Board : 23 C] [Card-2 Board : 24 C] [Card-3 Board : 23 C] [Card-4 Board : 23 C] [Card-5 Board : 27 C] "),
+			re:    `:.*Intake.*?(?P<Intake>\d+) .*Exhaust.*?(?P<Exhaust>\d+)`,
+			outputs: map[string]string{
+				"Intake":  "23",
+				"Exhaust": "26",
+			},
+		},
 	}
 
 	for _, in := range testStr {


### PR DESCRIPTION
A request came in to support named matches as metrics in addition to metadata. Here it is. Test has example input, which will get turned into something like:

```
 "name": "kentik.snmp.Exhaust",
        "type": "gauge",
        "value": 31,
```