### PR TITLE
Adding support for variables set for snmp trap mibs #547

### DIFF
--- a/pkg/inputs/snmp/mibs/trap.go
+++ b/pkg/inputs/snmp/mibs/trap.go
@@ -2,6 +2,7 @@ package mibs
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
@@ -52,14 +53,42 @@ func (mdb *MibDB) parseTrapsFromYml(fname string, file os.DirEntry, extends map[
 	added := 0
 	for _, trap := range t.Traps {
 		for _, event := range trap.Events {
+			oid := event.Oid
+			kvs := map[string][]int{}
+			pts := strings.Split(oid, ".")
+			newOid := []string{}
+			for i := 0; i < len(pts); i++ {
+				last := pts[i]
+				if len(last) > 2 && last[0:1] == "{" && last[len(last)-1:] == "}" { // Handle this as a variable.
+					set := strings.Split(last[1:len(last)-1], ":")
+					if len(set) == 2 {
+						vlen, err := strconv.Atoi(set[1])
+						if err == nil {
+							kvs[set[0]] = []int{i + 1, vlen}
+						} else if set[1] == "*" { // Wildcard means use all the rest.
+							kvs[set[0]] = []int{i + 1, 0}
+						} else {
+							// Noop?
+						}
+					}
+				} else {
+					newOid = append(newOid, last) // Put this on as a regular key.
+				}
+			}
+			if len(kvs) > 0 {
+				newOid = append(newOid, "*") // End the oid with a wildcard because we're matching on variables.
+			}
+			oid = strings.Join(newOid, ".")
+
 			mib := &kt.Mib{
-				Oid:        event.Oid,
+				Oid:        oid,
 				Name:       event.Name,
 				Enum:       event.Enum,
 				Tag:        event.Tag,
 				Conversion: event.Conversion,
 				Extra:      trap.Name,
 				Mib:        trap.Oid,
+				VarSet:     kvs,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)

--- a/pkg/inputs/snmp/mibs/trap_test.go
+++ b/pkg/inputs/snmp/mibs/trap_test.go
@@ -1,0 +1,79 @@
+package mibs
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	lt "github.com/kentik/ktranslate/pkg/eggs/logger/testing"
+)
+
+func TestLoadTraps(t *testing.T) {
+	l := lt.NewTestContextL(logger.NilContext, t)
+	mdb, err := NewMibDB("", "", false, l)
+	assert.NoError(t, err)
+	defer mdb.Close()
+	content := []byte(`
+traps:
+  # Traps from Visual Data Center (VDC), formerly owned by Optimum Path
+  - trap_oid: 1.3.6.1.4.1.34510.2.1.1.6.1
+    trap_name: vdcAlarms
+    drop_undefined: true
+    events:
+      - name: vdcAlarmId
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.1
+      - name: vdcAlarmDesc
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.2
+      - name: vdcAlarmTime
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.3
+      - name: vdcLevel
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.4
+      - name: vdcDevice
+        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.5
+      - name: vdcMonAttribWild
+        OID: 1.3.6.1.4.1.34510.22.*
+      - name: cbgpPeerLastErrorTxt
+        OID: 1.3.6.1.4.1.9.9.187.1.2.1.1.7.{bgpPeerRemoteAddr:*}
+      - name: chsrpTrapVarBing
+        OID: 1.3.6.1.4.1.9.9.187.1.3.4.5.{ifIndex:1}.{cHsrpGrpTable:1}
+`)
+	// Save test data to local.
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.FailNow()
+	}
+	if _, err := file.Write(content); err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+	fe, _ := file.Stat()
+	err = mdb.parseTrapsFromYml(file.Name(), fs.FileInfoToDirEntry(fe), nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 8, len(mdb.trapMibs))
+	tr, attr, err := mdb.GetForKey(".1.3.6.1.4.1.34510.2.1.1.3.2.1.1")
+	assert.NoError(t, err)
+	assert.Equal(t, "vdcAlarmId", tr.Name)
+	assert.Equal(t, 0, len(attr))
+
+	assert.Equal(t, 8, len(mdb.trapMibs))
+	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.34510.22.1.2.3.4.5.6")
+	assert.NoError(t, err)
+	assert.Equal(t, "vdcMonAttribWild", tr.Name)
+	assert.Equal(t, 0, len(attr))
+
+	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.187.1.2.1.1.7.2.2.2.3")
+	assert.NoError(t, err)
+	assert.Equal(t, "cbgpPeerLastErrorTxt", tr.Name)
+	assert.Equal(t, "2.2.2.3", attr["bgpPeerRemoteAddr"])
+
+	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.187.1.3.4.5.999.666")
+	assert.NoError(t, err)
+	assert.Equal(t, "chsrpTrapVarBing", tr.Name)
+	assert.Equal(t, "999", attr["ifIndex"])
+	assert.Equal(t, "666", attr["cHsrpGrpTable"])
+}

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -207,7 +207,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		}
 
 		// Do we know this guy?
-		res, err := s.mibdb.GetForKey(v.Name)
+		res, vars, err := s.mibdb.GetForKey(v.Name)
 		if err != nil {
 			s.log.Errorf("Cannot look up OID in trap: %v", err)
 		}
@@ -215,6 +215,11 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		// If we don't want undefined vars, pass along here.
 		if res == nil && trap.DropUndefinedVars() {
 			continue
+		}
+
+		// Load any variables defined in the name here.
+		for n, value := range vars {
+			dst.CustomStr[n] = value
 		}
 
 		switch v.Type {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -385,6 +385,7 @@ type Mib struct {
 	AllowDup     bool
 	Condition    *MibCondition
 	Script       Enricher
+	VarSet       map[string][]int
 }
 
 type Enricher interface {


### PR DESCRIPTION
Adds support for variables in snmp trap oids. Allows a profile to look like:

```
traps:
  # Traps from Visual Data Center (VDC), formerly owned by Optimum Path
  - trap_oid: 1.3.6.1.4.1.34510.2.1.1.6.1
    trap_name: vdcAlarms
    drop_undefined: true
    events:
      - name: vdcAlarmId
        OID: 1.3.6.1.4.1.34510.2.1.1.3.2.1.1
      - name: vdcMonAttribWild
        OID: 1.3.6.1.4.1.34510.22.*
      - name: cbgpPeerLastErrorTxt
        OID: 1.3.6.1.4.1.9.9.187.1.2.1.1.7.{bgpPeerRemoteAddr:*}
      - name: chsrpTrapVarBing
        OID: 1.3.6.1.4.1.9.9.187.1.3.4.5.{ifIndex:1}.{cHsrpGrpTable:1}
```

Closes #547 