### PR TITLE
Using snmp engine id as alternative to ip for traps

### DIFF
--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -148,12 +148,15 @@ func (s *SnmpTrap) Listen() {
 }
 
 func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
-	s.log.Infof("got trapdata from %s", addr.IP)
+	s.log.Infof("got trapdata from %s, EngineID %s", addr.IP, packet.ContextEngineID)
 	s.metrics.Traps.Mark(1)
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 
 	dev := s.deviceMap[addr.IP.String()] // See if we know which device this is coming from.
+	if dev == nil {
+		dev = s.deviceMap[packet.ContextEngineID] // If the device is still nil, try looking up via the ContextEngineID.
+	}
 	dst := kt.NewJCHF()
 	dst.CustomStr = make(map[string]string)
 	dst.CustomInt = make(map[string]int32)

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -148,14 +148,25 @@ func (s *SnmpTrap) Listen() {
 }
 
 func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
-	s.log.Infof("got trapdata from %s, EngineID %s", addr.IP, packet.ContextEngineID)
+	engineID := "" // Decode the context engine id if sent here.
+	if packet.Version == gosnmp.Version3 && packet.ContextEngineID != "" {
+		_, eid, _ := snmp_util.EngineID([]byte(packet.ContextEngineID))
+		engineID = eid
+	}
+
+	s.log.Infof("got trapdata from %s, EngineID %s", addr.IP, engineID)
 	s.metrics.Traps.Mark(1)
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 
 	dev := s.deviceMap[addr.IP.String()] // See if we know which device this is coming from.
-	if dev == nil {
-		dev = s.deviceMap[packet.ContextEngineID] // If the device is still nil, try looking up via the ContextEngineID.
+	if dev == nil && engineID != "" {    // If the device is still nil, try looking up via the ContextEngineID.
+		for _, d := range s.deviceMap {
+			if d.EngineID == engineID {
+				dev = d
+				break
+			}
+		}
 	}
 	dst := kt.NewJCHF()
 	dst.CustomStr = make(map[string]string)

--- a/pkg/inputs/snmp/util/util.go
+++ b/pkg/inputs/snmp/util/util.go
@@ -267,7 +267,7 @@ func GetFromConv(pdu gosnmp.SnmpPDU, conv string, log logger.ContextL) (int64, s
 	case CONV_HEXTOIP:
 		return hexToIP(bv)
 	case CONV_ENGINE_ID:
-		return engineID(bv)
+		return EngineID(bv)
 	case CONV_ONE:
 		return toOne(bv)
 	default:
@@ -344,7 +344,7 @@ func hexToIP(bv []byte) (int64, string, map[string]string) {
 	}
 }
 
-func engineID(bv []byte) (int64, string, map[string]string) {
+func EngineID(bv []byte) (int64, string, map[string]string) {
 	buf := make([]byte, 0, 3*len(bv))
 	x := buf[1*len(bv) : 3*len(bv)]
 	hex.Encode(x, bv)


### PR DESCRIPTION
Lets SNMP v3 Context Engine ID be used to look up devices in addition to the sending IP when processing a trap. 

Closes #558 