### PR TITLE
Tweak filters

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -401,7 +401,11 @@ func applyFlags(cfg *ktranslate.Config) error {
 				}
 				cfg.EnableHTTPInput = v
 			case "enricher":
-				cfg.EnricherURL = val
+				if _, err := os.Stat(val); err == nil { // If this is a file on disk, run as a script.
+					cfg.EnricherScript = val
+				} else {
+					cfg.EnricherURL = val
+				}
 			case "ddog_url":
 				cfg.DDogSink.URL = val
 			// pkg/maps/file

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -458,7 +458,7 @@ var (
 )
 
 // Updates asn and geo if set for any of these inputs.
-func (kc *KTranslate) doEnrichments(ctx context.Context, msgs []*kt.JCHF) {
+func (kc *KTranslate) doEnrichments(ctx context.Context, msgs []*kt.JCHF) []*kt.JCHF {
 	for _, msg := range msgs {
 		sip := net.ParseIP(msg.SrcAddr)
 		dip := net.ParseIP(msg.DstAddr)
@@ -536,4 +536,6 @@ func (kc *KTranslate) doEnrichments(ctx context.Context, msgs []*kt.JCHF) {
 			msgs = new
 		}
 	}
+
+	return msgs
 }

--- a/pkg/cat/kentik.go
+++ b/pkg/cat/kentik.go
@@ -278,8 +278,8 @@ func (kc *KTranslate) monitorAlphaChan(ctx context.Context, i int, seri func([]*
 		}
 
 		// Add in any extra things here.
-		if kc.geo != nil || kc.asn != nil {
-			kc.doEnrichments(ctx, msgs)
+		if kc.geo != nil || kc.asn != nil || kc.enricher != nil {
+			msgs = kc.doEnrichments(ctx, msgs)
 		}
 
 		// If we have any rollups defined, send here instead of directly to the output format.

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -393,8 +393,8 @@ func (kc *KTranslate) sendToSinks(ctx context.Context) error {
 
 // This processes data from the non-kentik input sets.
 func (kc *KTranslate) handleInput(ctx context.Context, msgs []*kt.JCHF, serBuf []byte, cb func(error), seri func([]*kt.JCHF, []byte) (*kt.Output, error)) {
-	if kc.geo != nil || kc.asn != nil {
-		kc.doEnrichments(ctx, msgs)
+	if kc.geo != nil || kc.asn != nil || kc.enricher != nil {
+		msgs = kc.doEnrichments(ctx, msgs)
 	}
 
 	// If we are filtering, cut any out here.

--- a/pkg/filter/addr.go
+++ b/pkg/filter/addr.go
@@ -61,6 +61,14 @@ func (f *AddrFilter) addrEquals(chf map[string]interface{}) bool {
 			vv := net.ParseIP(dim[f.dimension[1]])
 			return f.value.Contains(vv)
 		}
+	} else if dd, ok := chf["custom_str"]; ok { // Fall back and try all strings here.
+		switch dim := dd.(type) {
+		case map[string]string:
+			if _, ok := dim[f.dimension[0]]; ok {
+				vv := net.ParseIP(dim[f.dimension[0]])
+				return f.value.Contains(vv)
+			}
+		}
 	}
 	return false
 }

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -3,6 +3,8 @@ package filter
 import (
 	"flag"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/kentik/ktranslate/pkg/kt"
@@ -88,8 +90,18 @@ func (i *FilterDefs) Set(value string) error {
 	inner := FilterDefWrapper{}
 	for _, orSet := range strings.Split(value, OrToken) {
 		pts := strings.Split(orSet, ",")
-		if len(pts) < 4 {
-			return fmt.Errorf("Filter flag is defined by type dimension operator value")
+		if len(pts) < 3 {
+			return fmt.Errorf("Filter flag is defined by <type> dimension operator value")
+		}
+		if len(pts) == 3 {
+			ftype := String
+			// Try to guess the type.
+			if _, err := strconv.Atoi(pts[2]); err == nil {
+				ftype = Int
+			} else if _, _, err := net.ParseCIDR(pts[2]); err == nil {
+				ftype = Addr
+			}
+			pts = append([]string{string(ftype)}, pts...)
 		}
 		ptn := make([]string, len(pts))
 		for i, p := range pts {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -24,12 +24,15 @@ func TestFilter(t *testing.T) {
 		"int,fooII,==,12",
 		"string,foo,==,bar",
 		"string,fooAAAA,==,",
+		"foo,==,bar",
+		"fooII,==,12",
+		"src_addr,==,10.2.2.0/24",
 	}
 	fs, err := GetFilters(l, filters)
 	assert.NoError(err)
 	assert.Equal(len(filters), len(fs))
 
-	results := []bool{true, true, true, false, true, true, true, true, false}
+	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true}
 	for i, fs := range fs {
 		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d -> %v", i, filters[i])
 	}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -27,12 +27,13 @@ func TestFilter(t *testing.T) {
 		"foo,==,bar",
 		"fooII,==,12",
 		"src_addr,==,10.2.2.0/24",
+		"foo,==,no or fooII,==,12",
 	}
 	fs, err := GetFilters(l, filters)
 	assert.NoError(err)
 	assert.Equal(len(filters), len(fs))
 
-	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true}
+	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true, true}
 	for i, fs := range fs {
 		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d -> %v", i, filters[i])
 	}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -21,12 +21,15 @@ func TestFilter(t *testing.T) {
 		"addr,src_addr,%,10.2.3.0/24",
 		"int,custom_bigint.foo,!=,13",
 		"string,src_addr,%,10.2",
+		"int,fooII,==,12",
+		"string,foo,==,bar",
+		"string,fooAAAA,==,",
 	}
 	fs, err := GetFilters(l, filters)
 	assert.NoError(err)
 	assert.Equal(len(filters), len(fs))
 
-	results := []bool{true, true, true, false, true, true}
+	results := []bool{true, true, true, false, true, true, true, true, false}
 	for i, fs := range fs {
 		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d -> %v", i, filters[i])
 	}

--- a/pkg/filter/int.go
+++ b/pkg/filter/int.go
@@ -63,6 +63,13 @@ func (f *IntFilter) intEquals(chf map[string]interface{}) bool {
 		case map[string]int64:
 			return dim[f.dimension[1]] == f.value
 		}
+	} else if dd, ok := chf["custom_bigint"]; ok { // Fall back and try all ints here.
+		switch dim := dd.(type) {
+		case map[string]int64:
+			if _, ok := dim[f.dimension[0]]; ok {
+				return dim[f.dimension[0]] == f.value
+			}
+		}
 	}
 	return false
 }
@@ -81,6 +88,13 @@ func (f *IntFilter) intLessThan(chf map[string]interface{}) bool {
 		case map[string]int64:
 			return dim[f.dimension[1]] < f.value
 		}
+	} else if dd, ok := chf["custom_bigint"]; ok { // Fall back and try all ints here.
+		switch dim := dd.(type) {
+		case map[string]int64:
+			if _, ok := dim[f.dimension[0]]; ok {
+				return dim[f.dimension[0]] < f.value
+			}
+		}
 	}
 	return false
 }
@@ -94,6 +108,13 @@ func (f *IntFilter) intGreaterThan(chf map[string]interface{}) bool {
 			return dim[f.dimension[1]] > int32(f.value)
 		case map[string]int64:
 			return dim[f.dimension[1]] > f.value
+		}
+	} else if dd, ok := chf["custom_bigint"]; ok { // Fall back and try all ints here.
+		switch dim := dd.(type) {
+		case map[string]int64:
+			if _, ok := dim[f.dimension[0]]; ok {
+				return dim[f.dimension[0]] > f.value
+			}
 		}
 	}
 	return false

--- a/pkg/filter/string.go
+++ b/pkg/filter/string.go
@@ -53,6 +53,13 @@ func (f *StringFilter) stringEquals(chf map[string]interface{}) bool {
 		case map[string]string:
 			return dim[f.dimension[1]] == f.value
 		}
+	} else if dd, ok := chf["custom_str"]; ok { // Fall back and try all strings here.
+		switch dim := dd.(type) {
+		case map[string]string:
+			if _, ok := dim[f.dimension[0]]; ok {
+				return dim[f.dimension[0]] == f.value
+			}
+		}
 	}
 	return false
 }
@@ -68,6 +75,13 @@ func (f *StringFilter) stringContains(chf map[string]interface{}) bool {
 			return strings.Contains(dim, f.value)
 		case map[string]string:
 			return strings.Contains(dim[f.dimension[1]], f.value)
+		}
+	} else if dd, ok := chf["custom_str"]; ok { // Fall back and try all strings here.
+		switch dim := dd.(type) {
+		case map[string]string:
+			if _, ok := dim[f.dimension[0]]; ok {
+				return strings.Contains(dim[f.dimension[0]], f.value)
+			}
 		}
 	}
 	return false

--- a/pkg/util/enrich/enrich.go
+++ b/pkg/util/enrich/enrich.go
@@ -202,10 +202,19 @@ func (e *Enricher) runScript(ctx context.Context, msgs []*kt.JCHF) ([]*kt.JCHF, 
 	case starlark.NoneType:
 		return nil, nil
 	case starlark.Int:
-		e.Infof("RC %d", rv)
+		e.Debugf("RC %d", rv)
 	}
 
-	return msgs, nil
+	out := make([]*kt.JCHF, 0, len(msgs))
+	for _, msg := range inputs {
+		switch rv := msg.(type) {
+		case starlark.NoneType: // Its been set to none, so don't pass this value back up.
+		case *JCHF:
+			out = append(out, rv.Unwrap())
+		}
+	}
+
+	return out, nil
 }
 
 func (e *Enricher) sourceProgram(builtins starlark.StringDict) (*starlark.Program, error) {

--- a/pkg/util/enrich/enrich_test.go
+++ b/pkg/util/enrich/enrich_test.go
@@ -149,3 +149,29 @@ def main(n):
 	assert.Equal("fool", out[0].CustomStr["zero"])
 	assert.Equal("barf", out[0].CustomStr["bar"])
 }
+
+func TestRemoveMsg(t *testing.T) {
+	testDataPy := string(`
+def main(n):
+    for i in range(len(n)):
+      if i == 0:
+        n[i] = None
+      else:
+        n[i].company_id = i-1 # Bump everyone up.
+    return len(n)-1
+`)
+
+	assert := assert.New(t)
+	l := lt.NewTestContextL(logger.NilContext, t)
+	e, err := NewEnricher("", testDataPy, "", l.GetLogger().GetUnderlyingLogger())
+	assert.Nil(err)
+	assert.NotNil(e)
+
+	out, err := e.Enrich(context.Background(), kt.InputTestingSnmp)
+	assert.Nil(err)
+	assert.NotNil(out)
+	assert.Equal(len(kt.InputTestingSnmp)-1, len(out))
+	for i, evt := range out {
+		assert.Equal(i, int(evt.CompanyId), "%v", evt)
+	}
+}


### PR DESCRIPTION
Reworking filters to make them more logical. Now you can just say `-filters fooII,==,12` and things will work to filter out all events where fooII doesn't equal 12. 