### PR TITLE
Allow static attributes on traps

### DIFF
--- a/pkg/inputs/snmp/mibs/load.go
+++ b/pkg/inputs/snmp/mibs/load.go
@@ -95,7 +95,7 @@ func (db *MibDB) GetTrap(oid string) *Trap {
 
 func (db *MibDB) GetForKey(oid string) (*kt.Mib, map[string]string, error) {
 	if res, ok := db.trapMibs[oid]; ok {
-		return res, nil, nil
+		return res, res.XAttr, nil
 	}
 
 	// Now walk resursivly up the tree, seeing what profiles are found via a wildcard or variables.
@@ -113,6 +113,12 @@ func (db *MibDB) GetForKey(oid string) (*kt.Mib, map[string]string, error) {
 					attrs[name] = strings.Join(pts[posits[0]:], ".")
 				} else {
 					attrs[name] = strings.Join(pts[posits[0]:posits[0]+posits[1]], ".")
+				}
+			}
+			// Also fill in any const attrs here if they are not already set.
+			for k, v := range t.XAttr {
+				if _, ok := attrs[k]; !ok {
+					attrs[k] = v
 				}
 			}
 			return t, attrs, nil

--- a/pkg/inputs/snmp/mibs/trap.go
+++ b/pkg/inputs/snmp/mibs/trap.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Trap struct {
-	Oid           string `yaml:"trap_oid"`
-	Name          string `yaml:"trap_name"`
-	DropUndefined bool   `yaml:"drop_undefined"`
-	Events        []OID  `yaml:"events"`
+	Oid           string            `yaml:"trap_oid"`
+	Name          string            `yaml:"trap_name"`
+	DropUndefined bool              `yaml:"drop_undefined"`
+	Events        []OID             `yaml:"events"`
+	Attributes    map[string]string `yaml:"attributes"`
 }
 
 type TrapBase struct {
@@ -93,6 +94,7 @@ func (mdb *MibDB) parseTrapsFromYml(fname string, file os.DirEntry, extends map[
 				Extra:      trap.Name,
 				Mib:        trap.Oid,
 				VarSet:     kvs,
+				XAttr:      trap.Attributes,
 			}
 			if len(mib.Enum) > 0 {
 				mib.EnumRev = make(map[int64]string)

--- a/pkg/inputs/snmp/mibs/trap_test.go
+++ b/pkg/inputs/snmp/mibs/trap_test.go
@@ -44,6 +44,9 @@ traps:
         OID: 1.3.6.1.4.1.9.9.666.1.3.4.5.{cHsrpGrpTable:2}.{ifIndex:1}
       - name: chsrpTrapVarYandex
         OID: 1.3.6.1.4.1.9.9.1811.1.3.4.5.{ifIndex:1}.{cHsrpGrpTable:2}
+    attributes:
+      responsible_team: vmware
+      cHsrpGrpTable: 777
 `)
 	// Save test data to local.
 	file, err := ioutil.TempFile("", "")
@@ -62,34 +65,39 @@ traps:
 	tr, attr, err := mdb.GetForKey(".1.3.6.1.4.1.34510.2.1.1.3.2.1.1")
 	assert.NoError(t, err)
 	assert.Equal(t, "vdcAlarmId", tr.Name)
-	assert.Equal(t, 0, len(attr))
+	assert.Equal(t, 2, len(attr))
 
 	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.34510.22.1.2.3.4.5.6")
 	assert.NoError(t, err)
 	assert.Equal(t, "vdcMonAttribWild", tr.Name)
-	assert.Equal(t, 0, len(attr))
+	assert.Equal(t, 2, len(attr))
 
 	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.187.1.2.1.1.7.2.2.2.3")
 	assert.NoError(t, err)
 	assert.Equal(t, "cbgpPeerLastErrorTxt", tr.Name)
 	assert.Equal(t, "2.2.2.3", attr["bgpPeerRemoteAddr"])
 	assert.Equal(t, "", attr["ifIndex"]) // Since this is after a wildcard, assume nothing because there are no valid tokens to consume.
+	assert.Equal(t, "vmware", attr["responsible_team"])
+	assert.Equal(t, "777", attr["cHsrpGrpTable"])
 
 	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.187.1.3.4.5.999.666")
 	assert.NoError(t, err)
 	assert.Equal(t, "chsrpTrapVarBing", tr.Name)
 	assert.Equal(t, "999", attr["ifIndex"])
 	assert.Equal(t, "666", attr["cHsrpGrpTable"])
+	assert.Equal(t, "vmware", attr["responsible_team"])
 
 	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.666.1.3.4.5.66.99.333")
 	assert.NoError(t, err)
 	assert.Equal(t, "chsrpTwoOne", tr.Name)
 	assert.Equal(t, "333", attr["ifIndex"])
 	assert.Equal(t, "66.99", attr["cHsrpGrpTable"])
+	assert.Equal(t, "vmware", attr["responsible_team"])
 
 	tr, attr, err = mdb.GetForKey(".1.3.6.1.4.1.9.9.1811.1.3.4.5.66.99.333")
 	assert.NoError(t, err)
 	assert.Equal(t, "chsrpTrapVarYandex", tr.Name)
 	assert.Equal(t, "66", attr["ifIndex"])
 	assert.Equal(t, "99.333", attr["cHsrpGrpTable"])
+	assert.Equal(t, "vmware", attr["responsible_team"])
 }

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -386,6 +386,7 @@ type Mib struct {
 	Condition    *MibCondition
 	Script       Enricher
 	VarSet       map[string][]int
+	XAttr        map[string]string
 }
 
 type Enricher interface {


### PR DESCRIPTION
Allows adding a value like 

```
    attributes:
      responsible_team: vmware
      cHsrpGrpTable: 777
```

To trap definitions. Then these fields are added to traps caught. If there's a conflict between a variable var name and a constant one, the variable wins. 

Closes #564

