### PR TITLE
Trying to close gap where config file can be racy

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -499,6 +499,15 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 		}
 	}
 
+	// Since disco might have taken a while, we need to re-read the file into memory and update the non device sections of the config to get any new changes.
+	confNew, err := parseConfig(ctx, snmpFile, log)
+	if err != nil {
+		return nil, err
+	}
+	conf.Global = confNew.Global
+	conf.Disco = confNew.Disco
+	conf.Trap = confNew.Trap
+
 	// Save out the config file.
 	t, err := yaml.Marshal(conf)
 	if err != nil {

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -351,6 +351,15 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 	}
 	origCount := len(conf.Devices)
 
+	// Since disco might have taken a while, we need to re-read the file into memory and update the non device sections of the config to get any new changes.
+	confNew, err := parseConfig(ctx, snmpFile, log)
+	if err != nil {
+		return nil, err
+	}
+	conf.Global = confNew.Global
+	conf.Disco = confNew.Disco
+	conf.Trap = confNew.Trap
+
 	for dip, d := range foundDevices {
 		key := d.DeviceName
 		keyAlt := d.DeviceName + "__" + dip
@@ -498,15 +507,6 @@ func addDevices(ctx context.Context, foundDevices map[string]*kt.SnmpDeviceConfi
 			conf.Devices = nil
 		}
 	}
-
-	// Since disco might have taken a while, we need to re-read the file into memory and update the non device sections of the config to get any new changes.
-	confNew, err := parseConfig(ctx, snmpFile, log)
-	if err != nil {
-		return nil, err
-	}
-	conf.Global = confNew.Global
-	conf.Disco = confNew.Disco
-	conf.Trap = confNew.Trap
 
 	// Save out the config file.
 	t, err := yaml.Marshal(conf)

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -607,3 +607,33 @@ func addKentikDevices(apic *api.KentikApi, conf *kt.SnmpConfig) map[string]strin
 
 	return added
 }
+
+// Remove any dangling in memory items which should not be propigated to disk.
+func cleanForSave(cfg *kt.SnmpConfig) {
+	if cfg == nil {
+		return
+	}
+
+	set := func(m map[string]string, p kt.Provider) {
+		for k, v := range m {
+			if nk, ok := matchesPrefix(k, p); ok {
+				delete(m, k)
+				if v != "" {
+					m[nk] = v
+				}
+			} else { // Just delete.
+				delete(m, k)
+			}
+		}
+	}
+
+	if cfg.Global != nil {
+		set(cfg.Global.UserTags, kt.GlobalProvider)
+		set(cfg.Global.MatchAttr, kt.GlobalProvider)
+	}
+
+	for _, device := range cfg.Devices {
+		set(device.UserTags, kt.DeviceProvider)
+		set(device.MatchAttr, kt.DeviceProvider)
+	}
+}

--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -541,36 +541,6 @@ func setDeviceTagsAndMatch(device *kt.SnmpDeviceConfig) {
 	prune(device.MatchAttr)
 }
 
-// Remove any dangling in memory items which should not be propigated to disk.
-func cleanForSave(cfg *kt.SnmpConfig) {
-	if cfg == nil {
-		return
-	}
-
-	set := func(m map[string]string, p kt.Provider) {
-		for k, v := range m {
-			if nk, ok := matchesPrefix(k, p); ok {
-				delete(m, k)
-				if v != "" {
-					m[nk] = v
-				}
-			} else { // Just delete.
-				delete(m, k)
-			}
-		}
-	}
-
-	if cfg.Global != nil {
-		set(cfg.Global.UserTags, kt.GlobalProvider)
-		set(cfg.Global.MatchAttr, kt.GlobalProvider)
-	}
-
-	for _, device := range cfg.Devices {
-		set(device.UserTags, kt.DeviceProvider)
-		set(device.MatchAttr, kt.DeviceProvider)
-	}
-}
-
 // Strip out any tags which shouldn't be there for traps.
 func cleanTagsForCopy(cfg *kt.SnmpConfig) map[string]string {
 	if cfg == nil || cfg.Global == nil {


### PR DESCRIPTION
This fix grabs a new version of the snmp config file into memory before writing out the updated device list after disco. Should help to fix a case where when this config file is updated during disco the changes are lost. 

Closes #570 