### PR TITLE
Allow dynamic tags on all icmp metrics

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -507,6 +507,7 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], false) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
+
 			mtype := name.GetType()
 			if name.Format == kt.FloatMS {
 				ms = append(ms, NRMetric{

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -507,7 +507,6 @@ func (f *NRMFormat) fromSnmpDeviceMetric(in *kt.JCHF) []NRMetric {
 			if util.DropOnFilter(attrNew, f.lastMetadata[in.DeviceName], false) {
 				continue // This Metric isn't in the white list so lets drop it.
 			}
-
 			mtype := name.GetType()
 			if name.Format == kt.FloatMS {
 				ms = append(ms, NRMetric{

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -369,10 +369,14 @@ var keepAcrossTables = map[string]bool{
 }
 
 var allowSysAttr = map[string]bool{
-	"Uptime":   true,
-	"MinRttMs": true,
-	"MaxRttMs": true,
-	"AvgRttMs": true,
+	"Uptime":        true,
+	"MinRttMs":      true,
+	"MaxRttMs":      true,
+	"AvgRttMs":      true,
+	"StdDevRtt":     true,
+	"PacketsSent":   true,
+	"PacketsRecv":   true,
+	"PacketLossPct": true,
 }
 
 func CopyAttrForSnmp(attr map[string]interface{}, metricName string, name kt.MetricInfo, lm *kt.LastMetadata, gentleCardinality bool, dropSrcAddr bool) map[string]interface{} {


### PR DESCRIPTION
I think this will at least make the behavior for ICMP tags consistent across all ICMP metrics. 

Closes #567