### PR TITLE
network clients scale better than app clients for meraki

### DIFF
--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -312,7 +312,7 @@ type client struct {
 
 func (c *MerakiClient) getNetworkClients(dur time.Duration) ([]*kt.JCHF, error) {
 	clientSet := []*client{}
-	durs := float32(3600) // Look back 1 hour in seconds, get all devices using APs in this range.
+	durs := float32(dur.Seconds())
 	for _, org := range c.orgs {
 		for _, network := range org.networks {
 			params := networks.NewGetNetworkClientsParams()
@@ -462,7 +462,7 @@ func (c *MerakiClient) getDeviceClients(dur time.Duration) ([]*kt.JCHF, error) {
 
 	c.log.Infof("Got devices for %d networks", len(networkDevs))
 	clientSet := []*client{}
-	durs := float32(3600) // Look back 1 hour in seconds, get all devices using APs in this range.
+	durs := float32(dur.Seconds())
 	for network, deviceSet := range networkDevs {
 		c.log.Infof("Looking at %d devices for network %s", len(deviceSet), network)
 		for _, device := range deviceSet {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -159,13 +159,14 @@ type EAPIConfig struct {
 }
 
 type MerakiConfig struct {
-	ApiKey            string   `yaml:"api_key"`         // Required.
-	Host              string   `yaml:"host"`            // Optional, defaults to api.meraki.com
-	MonitorUplinks    bool     `yaml:"monitor_uplinks"` // This will be the default if neither is set.
-	MonitorDevices    bool     `yaml:"monitor_devices"`
-	MonitorOrgChanges bool     `yaml:"monitor_org_changes"`
-	Orgs              []string `yaml:"organizations"` // Only monitor orgs in this list, if set.
-	Networks          []string `yaml:"networks"`      // Only monitor networks in this list, if set.
+	ApiKey                string   `yaml:"api_key"`         // Required.
+	Host                  string   `yaml:"host"`            // Optional, defaults to api.meraki.com
+	MonitorUplinks        bool     `yaml:"monitor_uplinks"` // This will be the default if neither is set.
+	MonitorDevices        bool     `yaml:"monitor_devices"`
+	MonitorOrgChanges     bool     `yaml:"monitor_org_changes"`
+	MonitorNetworkClients bool     `yaml:"monitor_clients"`
+	Orgs                  []string `yaml:"organizations"` // Only monitor orgs in this list, if set.
+	Networks              []string `yaml:"networks"`      // Only monitor networks in this list, if set.
 }
 
 // Contain various extensions to snmp which can be used to get data.


### PR DESCRIPTION
I had a hard time getting meraki to scale on the application client api call. This version adds `monitor_clients: true` option to the meraki config. Let me know what you think. 