### PR TITLE
Specifying timeout for meraki now using global settings

### DIFF
--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -81,7 +81,7 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 	}
 
 	// If we are extending the metrics for this device in any way, set it up now.
-	ext, err := extension.NewExtension(jchfChan, conf, metrics, log)
+	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log)
 	if err != nil {
 		log.Errorf("Cannot setup extension for %s -> %s: %v", err, conf.DeviceIP, conf.DeviceName)
 	} else if ext != nil {
@@ -168,7 +168,7 @@ func NewPollerForExtention(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig
 	}
 
 	// If we are extending the metrics for this device in any way, set it up now.
-	ext, err := extension.NewExtension(jchfChan, conf, metrics, log)
+	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log)
 	if err != nil {
 		log.Errorf("Cannot setup extension for %s -> %s: %v", err, conf.DeviceIP, conf.DeviceName)
 	} else if ext != nil {

--- a/pkg/inputs/snmp/x/arista/eapi.go
+++ b/pkg/inputs/snmp/x/arista/eapi.go
@@ -17,16 +17,18 @@ type EAPIClient struct {
 	log      logger.ContextL
 	jchfChan chan []*kt.JCHF
 	conf     *kt.SnmpDeviceConfig
+	gconf    *kt.SnmpGlobalConfig
 	metrics  *kt.SnmpDeviceMetric
 	client   *goeapi.Node
 }
 
-func NewEAPIClient(jchfChan chan []*kt.JCHF, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (*EAPIClient, error) {
+func NewEAPIClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (*EAPIClient, error) {
 	c := EAPIClient{
 		log:      log,
 		jchfChan: jchfChan,
 		conf:     conf,
 		metrics:  metrics,
+		gconf:    gconf,
 	}
 
 	node, err := goeapi.Connect(conf.Ext.EAPIConfig.Transport, conf.DeviceIP, conf.Ext.EAPIConfig.Username, conf.Ext.EAPIConfig.Password, conf.Ext.EAPIConfig.Port)

--- a/pkg/inputs/snmp/x/ext.go
+++ b/pkg/inputs/snmp/x/ext.go
@@ -16,15 +16,15 @@ type Extension interface {
 	GetName() string
 }
 
-func NewExtension(jchfChan chan []*kt.JCHF, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (Extension, error) {
+func NewExtension(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (Extension, error) {
 	if conf.Ext == nil { // No extensions set.
 		return nil, nil
 	}
 
 	if conf.Ext.EAPIConfig != nil {
-		return arista.NewEAPIClient(jchfChan, conf, metrics, log)
+		return arista.NewEAPIClient(jchfChan, gconf, conf, metrics, log)
 	} else if conf.Ext.MerakiConfig != nil {
-		return meraki.NewMerakiClient(jchfChan, conf, metrics, log)
+		return meraki.NewMerakiClient(jchfChan, gconf, conf, metrics, log)
 	}
 
 	return nil, nil


### PR DESCRIPTION
Before we were always using the meraki default timeout value. This uses the global and device level `timeout_ms` values to set. 