### PR TITLE
add the device status call for meraki

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/judwhite/go-svc v1.2.1
 	github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945
-	github.com/kentik/dashboard-api-golang v0.0.0-20230808230432-28477cd77336
+	github.com/kentik/dashboard-api-golang v0.0.0-20230822181606-6c9a280a9428
 	github.com/kentik/go-metrics v0.0.0-20200109025407-4bfd4a9b42c5
 	github.com/kentik/patricia v0.0.0-20210909164817-21603333b70e
 	github.com/liamg/furious v0.0.0-20191231090757-c295c872d6c1

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945 h1:PCi9E7y4j28fqFMjjAVn97jZ90FpbavvbhKa/FGiDZA=
 github.com/kentik/api-schema-public v0.0.0-20220322181339-896729e59945/go.mod h1:3eRiIiOwdOkInkMptcgaG5q4AvDjQd7zvQYGM7KeSzc=
-github.com/kentik/dashboard-api-golang v0.0.0-20230808230432-28477cd77336 h1:vUYrSbtZCOwLXxt1sPJl9bc55kHsgOT6lotHS86w/88=
-github.com/kentik/dashboard-api-golang v0.0.0-20230808230432-28477cd77336/go.mod h1:VfjlG6IobAYBJGX/D6MaYIalPzuXEm1lAUMuVJJenXc=
+github.com/kentik/dashboard-api-golang v0.0.0-20230822181606-6c9a280a9428 h1:SLUYwonkPgme0QUYKpISzG1ZZ8d/qx3/xO2OrMXsgfg=
+github.com/kentik/dashboard-api-golang v0.0.0-20230822181606-6c9a280a9428/go.mod h1:VfjlG6IobAYBJGX/D6MaYIalPzuXEm1lAUMuVJJenXc=
 github.com/kentik/go-metrics v0.0.0-20200109025407-4bfd4a9b42c5 h1:1rZ84eG01A0q93bOxVEY38qvJlfbcFlgKboFERP9TRQ=
 github.com/kentik/go-metrics v0.0.0-20200109025407-4bfd4a9b42c5/go.mod h1:29P02QqC48eCWcb9A4HvtEQypXkw5T9U9DxF1fn/kbs=
 github.com/kentik/patricia v0.0.0-20210909164817-21603333b70e h1:1wAVuGu1c+lsdaOPQN+9xoP9+gaIMJV6H0ehGc+K5iA=

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -169,6 +169,7 @@ type MerakiConfig struct {
 	Orgs                  []string        `yaml:"organizations"` // Only monitor orgs in this list, if set.
 	Networks              []string        `yaml:"networks"`      // Only monitor networks in this list, if set.
 	Prefs                 map[string]bool `yaml:"preferences"`   // Additional fine tuning of what data is returned.
+	ProductTypes          []string        `yaml:"product_types"` // Only monitor these product types, if set.
 }
 
 // Contain various extensions to snmp which can be used to get data.


### PR DESCRIPTION
This adds in https://developer.cisco.com/meraki/api-v1/get-organization-devices-statuses/ to the mix of API calls the meraki adapter understands. To turn on, set 

`monitor_devices: true` AND 
```
preferences:
           device_status_only: true
```

OR just:

```
preferences:
           device_status: true
```

Data looks like

```
      {
        "name": "kentik.meraki.device_status.Status",
        "type": "gauge",
        "value": 1,
        "attributes": {
          "mib-name": "meraki",
          "serial": "Serial",
          "network_id": "L_NETWORK",
          "org_id": "ID",
          "instrumentation.name": "meraki.device_status",
          "mac": "dead::beef",
          "device_name": "name",
          "provider": "meraki-cloud-controller",
          "eventType": "KSnmpDeviceMetric",
          "objectIdentifier": "meraki",
          "network": "Network",
          "last_reported_at": "2023-08-24T03:21:23.327000Z",
          "product_type": "wireless",
          "org_name": "MyOrg",
          "src_addr": "1.1.1.1",
          "status": "online",
          "model": "MR46E",
          "tags": "TAG1,TAG2"
        }
      },
```

The metric has a value of 1 if status is online, 0 otherwise. 

QQ -- the `device_status` is getting complicated. Open to other ideas here on how to manage. Idea being that there are device status (the APs/switches) and the device's clients status (things connected to them). 

Filter by these options in the config file:

```
          networks:
           - "My Site 21"
         product_types:
           - wireless
``` 

Closes #603