### PR TITLE
Adding CustomIP fields for netflow to support ips in custom fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// FlowFields are fields for the Flow input
-	FlowFields = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,FlowDirection,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel,CustomInteger1,CustomInteger2,CustomInteger3,CustomInteger4,CustomInteger5,CustomBytes1,CustomBytes2,CustomBytes3,CustomBytes4,CustomBytes5"
+	FlowFields = "Type,TimeReceived,SequenceNum,SamplingRate,SamplerAddress,TimeFlowStart,TimeFlowEnd,Bytes,Packets,SrcAddr,DstAddr,Etype,Proto,SrcPort,DstPort,InIf,OutIf,SrcMac,DstMac,SrcVlan,DstVlan,VlanId,IngressVrfID,EgressVrfID,IPTos,ForwardingStatus,IPTTL,TCPFlags,IcmpType,IcmpCode,IPv6FlowLabel,FragmentId,FragmentOffset,FlowDirection,BiFlowDirection,SrcAS,DstAS,NextHop,NextHopAS,SrcNet,DstNet,HasMPLS,MPLSCount,MPLS1TTL,MPLS1Label,MPLS2TTL,MPLS2Label,MPLS3TTL,MPLS3Label,MPLSLastTTL,MPLSLastLabel,CustomInteger1,CustomInteger2,CustomInteger3,CustomInteger4,CustomInteger5,CustomBytes1,CustomBytes2,CustomBytes3,CustomBytes4,CustomBytes5,CustomIPv41,CustomIPv42,CustomIP1,CustomIP2"
 	// FlowDefaultFields are the default fields for flow
 	FlowDefaultFields = "TimeReceived,SamplingRate,Bytes,Packets,SrcAddr,DstAddr,Proto,SrcPort,DstPort,InIf,OutIf,SrcVlan,DstVlan,TCPFlags,SrcAS,DstAS,Type,SamplerAddress,FlowDirection"
 	// KentikAPITokenEnvVar is the environment variables used to get the Kentik API Token

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -168,7 +168,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 
 	// start with the basic src and dst.
 	if src.CHF.Ipv4DstAddr() > 0 {
-		addr = int2ip(src.CHF.Ipv4DstAddr())
+		addr = kt.Int2ip(src.CHF.Ipv4DstAddr())
 	} else {
 		ipr, _ := src.CHF.Ipv6DstAddr()
 		addr = net.IP(ipr)
@@ -181,7 +181,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 	}
 
 	if src.CHF.Ipv4SrcAddr() > 0 {
-		addr = int2ip(src.CHF.Ipv4SrcAddr())
+		addr = kt.Int2ip(src.CHF.Ipv4SrcAddr())
 	} else {
 		ipr, _ := src.CHF.Ipv6SrcAddr()
 		addr = net.IP(ipr)
@@ -189,9 +189,9 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 	dst.SrcAddr = addr.String()
 
 	// These are ipv4 addresses.
-	addr = int2ip(src.CHF.SrcRoutePrefix())
+	addr = kt.Int2ip(src.CHF.SrcRoutePrefix())
 	dst.SrcRoutePrefix = addr.String()
-	addr = int2ip(src.CHF.DstRoutePrefix())
+	addr = kt.Int2ip(src.CHF.DstRoutePrefix())
 	dst.DstRoutePrefix = addr.String()
 
 	if kc.resolver != nil {
@@ -200,7 +200,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 
 	// next hops
 	if src.CHF.Ipv4SrcNextHop() > 0 {
-		addr = int2ip(src.CHF.Ipv4SrcNextHop())
+		addr = kt.Int2ip(src.CHF.Ipv4SrcNextHop())
 	} else {
 		ipr, _ := src.CHF.Ipv6SrcNextHop()
 		addr = net.IP(ipr)
@@ -208,7 +208,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 	dst.SrcNextHop = addr.String()
 
 	if src.CHF.Ipv4DstNextHop() > 0 {
-		addr = int2ip(src.CHF.Ipv4DstNextHop())
+		addr = kt.Int2ip(src.CHF.Ipv4DstNextHop())
 	} else {
 		ipr, _ := src.CHF.Ipv6DstNextHop()
 		addr = net.IP(ipr)
@@ -410,12 +410,6 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 	dst.Provider = kc.getProviderType(dst)
 
 	return nil
-}
-
-func int2ip(nn uint32) net.IP {
-	ip := make(net.IP, 4)
-	binary.BigEndian.PutUint32(ip, nn)
-	return ip
 }
 
 var (

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -298,6 +298,22 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes4))
 		case "CustomBytes5":
 			in.CustomStr[t.config.NameMap[field]] = fmt.Sprintf("%s", string(fmsg.CustomBytes5))
+		case "CustomIPv41":
+			in.CustomStr[t.config.NameMap[field]] = kt.Int2ip(uint32(fmsg.CustomInteger1)).String()
+		case "CustomIPv42":
+			in.CustomStr[t.config.NameMap[field]] = kt.Int2ip(uint32(fmsg.CustomInteger2)).String()
+		case "CustomIP1":
+			if len(fmsg.CustomBytes1) == 4 {
+				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes1[0], fmsg.CustomBytes1[1], fmsg.CustomBytes1[2], fmsg.CustomBytes1[3]).String()
+			} else {
+				in.CustomStr[t.config.NameMap[field]] = net.IP(fmsg.CustomBytes1).String()
+			}
+		case "CustomIP2":
+			if len(fmsg.CustomBytes2) == 4 {
+				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes2[0], fmsg.CustomBytes2[1], fmsg.CustomBytes2[2], fmsg.CustomBytes2[3]).String()
+			} else {
+				in.CustomStr[t.config.NameMap[field]] = net.IP(fmsg.CustomBytes2).String()
+			}
 		}
 	}
 

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -304,13 +304,13 @@ func (t *KentikDriver) toJCHF(fmsg *flowmessage.FlowMessage) *kt.JCHF {
 			in.CustomStr[t.config.NameMap[field]] = kt.Int2ip(uint32(fmsg.CustomInteger2)).String()
 		case "CustomIP1":
 			if len(fmsg.CustomBytes1) == 4 {
-				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes1[0], fmsg.CustomBytes1[1], fmsg.CustomBytes1[2], fmsg.CustomBytes1[3]).String()
+				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes1[3], fmsg.CustomBytes1[2], fmsg.CustomBytes1[1], fmsg.CustomBytes1[0]).String()
 			} else {
 				in.CustomStr[t.config.NameMap[field]] = net.IP(fmsg.CustomBytes1).String()
 			}
 		case "CustomIP2":
 			if len(fmsg.CustomBytes2) == 4 {
-				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes2[0], fmsg.CustomBytes2[1], fmsg.CustomBytes2[2], fmsg.CustomBytes2[3]).String()
+				in.CustomStr[t.config.NameMap[field]] = net.IPv4(fmsg.CustomBytes2[3], fmsg.CustomBytes2[2], fmsg.CustomBytes2[1], fmsg.CustomBytes2[0]).String()
 			} else {
 				in.CustomStr[t.config.NameMap[field]] = net.IP(fmsg.CustomBytes2).String()
 			}

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -90,7 +90,7 @@ func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf 
 	params := organizations.NewGetOrganizationsParamsWithTimeout(c.timeout)
 	prod, err := client.Organizations.GetOrganizations(params, c.auth)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Invalid API Key. Cannot get organizations. Check config and try again")
 	}
 
 	// There's some options which are disabled now, we need to check and error.

--- a/pkg/kt/helpers.go
+++ b/pkg/kt/helpers.go
@@ -1,6 +1,8 @@
 package kt
 
 import (
+	"encoding/binary"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -34,4 +36,10 @@ func LookupEnvBool(key string, defaultVal bool) bool {
 func FixupName(name string) string {
 	name = strings.ToLower(strings.ReplaceAll(name, " ", "_"))
 	return name
+}
+
+func Int2ip(nn uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, nn)
+	return ip
 }

--- a/pkg/kt/helpers_test.go
+++ b/pkg/kt/helpers_test.go
@@ -1,0 +1,16 @@
+package kt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInt2ip(t *testing.T) {
+	inputs := []uint64{1057383603, 183819855, 1057412798, 183819855, 183818207, 183819882}
+	outputs := []string{"63.6.100.179", "10.244.222.79", "63.6.214.190", "10.244.222.79", "10.244.215.223", "10.244.222.106"}
+
+	for i, input := range inputs {
+		assert.Equal(t, outputs[i], Int2ip(uint32(input)).String(), "%d", i)
+	}
+}

--- a/pkg/kt/helpers_test.go
+++ b/pkg/kt/helpers_test.go
@@ -1,6 +1,7 @@
 package kt
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,5 +13,16 @@ func TestInt2ip(t *testing.T) {
 
 	for i, input := range inputs {
 		assert.Equal(t, outputs[i], Int2ip(uint32(input)).String(), "%d", i)
+	}
+
+	// Test again as a byte[]
+	for i, input := range inputs {
+		var bytes [4]byte
+		bytes[0] = byte(input & 0xFF)
+		bytes[1] = byte((input >> 8) & 0xFF)
+		bytes[2] = byte((input >> 16) & 0xFF)
+		bytes[3] = byte((input >> 24) & 0xFF)
+
+		assert.Equal(t, outputs[i], net.IPv4(bytes[3], bytes[2], bytes[1], bytes[0]).String(), "%d", i)
 	}
 }


### PR DESCRIPTION
This will produce a string version of IPs in extra netflow fields, vs a number. New fields added are: `CustomIPv41,CustomIPv42,CustomIP1,CustomIP2`. 

Usage could be:

```
{
  "flow_config": {
    "sflow": {
      "mapping": [
        {
          "layer": 0,
          "offset": 368,
          "length": 32,
          "destination": "CustomIPv41"
        },
        {
          "layer": 0,
          "offset": 400,
          "length": 32,
          "destination": "CustomIPv42"
        }
      ]
    }
  },
  "name_map": {
    "CustomIPv41": "IP Foo",
    "CustomIPv42": "IP Bar"
  }
}
```