### PR TITLE
Better way to send into prom

### DIFF
--- a/pkg/formats/prom/init.go
+++ b/pkg/formats/prom/init.go
@@ -1,0 +1,16 @@
+package prom
+
+import (
+	"github.com/json-iterator/go"
+)
+
+// fast JSON encoding
+var json = jsoniter.ConfigFastest
+
+// jsonSorted is fast, but still sorts keys
+var jsonSorted = jsoniter.Config{
+	IndentionStep:          4,
+	EscapeHTML:             false,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: false,
+}.Froze()

--- a/pkg/sinks/prom/prom.go
+++ b/pkg/sinks/prom/prom.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&listen, "prom_listen", ":8082", "Bind to listen for prometheus requests on.")
+	flag.StringVar(&listen, "prom_listen", "127.0.0.1:8083", "Bind to listen for prometheus requests on.")
 	flag.StringVar(&remoteUrl, "prom_remote_write", "", "Pass on remote write to this address.")
 }
 
@@ -91,6 +91,10 @@ func (s *PromSink) Init(ctx context.Context, format formats.Format, compression 
 			return fmt.Errorf("You must set the -prom_remote_write flag to make this work.")
 		}
 
+		if compression != kt.CompressionSnappy {
+			return fmt.Errorf("You used the %s unsupported compression format. Use snappy only.", compression)
+		}
+
 		s.Infof("Sending to remote_write endpoint %s", remoteUrl)
 	default:
 		return fmt.Errorf("Prometheus only supports %s and %s formats, not %s", formats.FORMAT_PROM, formats.FORMAT_PROM_REMOTE, format)
@@ -98,10 +102,6 @@ func (s *PromSink) Init(ctx context.Context, format formats.Format, compression 
 
 	s.remoteUrl = remoteUrl
 	s.compression = compression
-
-	if s.compression != kt.CompressionSnappy {
-		return fmt.Errorf("You used the %s unsupported compression format. Use snappy only.", s.compression)
-	}
 
 	return nil
 }


### PR DESCRIPTION
This makes the prom format a first class synth system (like new relic).  

Run with`-format prometheus -sinks prometheus`. This will set up a prom export on the default of 127.0.0.1:8083, or else set a better one with `-prom_listen` flag. 

I tested with grafana cloud and grafana exporter, working well. All metrics are currently gauges, can look at fine tuning going forward.

<img width="924" alt="image" src="https://github.com/kentik/ktranslate/assets/315460/e8657bf1-ffbe-4383-85fa-ca976d01b11d">
