### PR TITLE
Better error handling if meraki org cannot list networks inside

### DIFF
--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -136,7 +136,8 @@ func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf 
 		netSet := map[string]networkDesc{}
 		numAdded, err := c.getOrgNetworks(netSet, "", lorg, nets, 0)
 		if err != nil {
-			return nil, err
+			c.log.Warnf("Skipping organization %s because it does not have permission to list networks.", org.Name)
+			continue
 		}
 		numNets += numAdded
 


### PR DESCRIPTION
This will skip the organization and try to keep going with other working orgs. 

Log line:

```

2023-12-01T21:38:51.385 ktranslate/ [Warn] KTranslate>acadian_meraki Skipping organization $MY_ORG because it does not have permission to list networks.
```