### PR TITLE
Adding a retry for 429 errors in common meraki apis

### DIFF
--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -166,10 +166,11 @@ type MerakiConfig struct {
 	MonitorOrgChanges     bool            `yaml:"monitor_org_changes"`
 	MonitorNetworkClients bool            `yaml:"monitor_clients"`
 	MonitorVpnStatus      bool            `yaml:"monitor_vpn_status"`
-	Orgs                  []string        `yaml:"organizations"` // Only monitor orgs in this list, if set.
-	Networks              []string        `yaml:"networks"`      // Only monitor networks in this list, if set.
-	Prefs                 map[string]bool `yaml:"preferences"`   // Additional fine tuning of what data is returned.
-	ProductTypes          []string        `yaml:"product_types"` // Only monitor these product types, if set.
+	Orgs                  []string        `yaml:"organizations"`  // Only monitor orgs in this list, if set.
+	Networks              []string        `yaml:"networks"`       // Only monitor networks in this list, if set.
+	Prefs                 map[string]bool `yaml:"preferences"`    // Additional fine tuning of what data is returned.
+	ProductTypes          []string        `yaml:"product_types"`  // Only monitor these product types, if set.
+	MaxAPIRetry           int             `yaml:"max_http_retry"` // retry up to this many times on 429 errors. Default 2.
 }
 
 // Contain various extensions to snmp which can be used to get data.


### PR DESCRIPTION
See if we hit a 429 code and retry for up to 5 times before giving up. 