### PR TITLE
Adding a drop_undefined conf option to drop undefined traps

### DIFF
--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -227,7 +227,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		}
 
 		// If we don't want undefined vars, pass along here.
-		if res == nil && trap.DropUndefinedVars() {
+		if res == nil && (s.conf.Trap.DropUndefined || trap.DropUndefinedVars()) {
 			continue
 		}
 

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -216,12 +216,13 @@ type SnmpDeviceConfig struct {
 }
 
 type SnmpTrapConfig struct {
-	Listen    string        `yaml:"listen"`
-	Community string        `yaml:"community"`
-	Version   string        `yaml:"version"`
-	Transport string        `yaml:"transport"`
-	V3        *V3SNMPConfig `yaml:"v3_config"`
-	TrapOnly  bool          `yaml:"trap_only"`
+	Listen        string        `yaml:"listen"`
+	Community     string        `yaml:"community"`
+	Version       string        `yaml:"version"`
+	Transport     string        `yaml:"transport"`
+	V3            *V3SNMPConfig `yaml:"v3_config"`
+	TrapOnly      bool          `yaml:"trap_only"`
+	DropUndefined bool          `yaml:"drop_undefined"`
 }
 
 type KentikMatch struct {


### PR DESCRIPTION
Closes #654

Adds the option `drop_undefined` to the trap config yaml to drop all undefined variables.

```trap:
    listen: 127.0.0.1:1620
    community: ""
    version: v3
    drop_undefined: true
    trap_only: false```