### PR TITLE
Adding a regex to drop some invalid prom labels

### DIFF
--- a/pkg/formats/prom/prom.go
+++ b/pkg/formats/prom/prom.go
@@ -3,6 +3,7 @@ package prom
 import (
 	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ import (
 var (
 	doCollectorStats bool
 	seenNeeded       int
+	invalidTag       = regexp.MustCompile(`^\d+$`)
 )
 
 func init() {
@@ -40,6 +42,9 @@ func (d *PromData) AddTagLabels(vecTags tagVec) {
 	}
 	next := len(vecTags[d.Name])
 	for k, _ := range d.Tags {
+		if invalidTag.MatchString(k) {
+			continue
+		}
 		if _, ok := vecTags[d.Name][k]; !ok {
 			vecTags[d.Name][k] = next
 			next++


### PR DESCRIPTION
<img width="889" alt="image" src="https://github.com/kentik/ktranslate/assets/315460/b35550c4-6d73-4ef8-b145-630e2e6278e6">

Drops these kinda labels. Closes https://github.com/kentik/ui-app/issues/20892