### PR TITLE
Masking out file operations also

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"strings"
 	"time"
 
@@ -147,6 +146,7 @@ func initSnmp(ctx context.Context, snmpFile string, log logger.ContextL) (*kt.Sn
 	return conf, connectTimeout, retries, nil
 }
 
+<<<<<<< HEAD
 func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, confMgr config.ConfigManager, logchan chan string) {
 	ctxSnmp, cancel := context.WithCancel(ctx)
 	err := runSnmpPolling(ctxSnmp, snmpFile, jchfChan, metrics, registry, apic, log, restartCount, cfg, logchan)
@@ -177,6 +177,9 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 }
 
 func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, logchan chan string) error {
+=======
+func runSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig) error {
+>>>>>>> d44d2a0 (Masking out file operations also)
 	// Parse again to make sure nothing's changed.
 	conf, connectTimeout, retries, err := initSnmp(ctx, snmpFile, log)
 	if err != nil || conf == nil || conf.Global == nil {

--- a/pkg/inputs/snmp/snmp_unix.go
+++ b/pkg/inputs/snmp/snmp_unix.go
@@ -1,0 +1,47 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package snmp
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	go_metrics "github.com/kentik/go-metrics"
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/api"
+	"github.com/kentik/ktranslate/pkg/config"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, confMgr config.ConfigManager) {
+	ctxSnmp, cancel := context.WithCancel(ctx)
+	err := runSnmpPolling(ctxSnmp, snmpFile, jchfChan, metrics, registry, apic, log, restartCount, cfg)
+	if err != nil {
+		log.Errorf("There was an error when polling for SNMP devices: %v.", err)
+	}
+
+	// We only want to run a disco on start when restartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
+	runOnStart := cfg.DiscoveryOnStart
+	if restartCount > 0 {
+		runOnStart = false
+	}
+
+	// Now, wait for sigusr2 to re-do or if there's a discovery with new devices.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR2, kt.SIGUSR2)
+	if v := cfg.DiscoveryIntervalMinutes; v > 0 || runOnStart { // If we are re-running snmp discovery every interval AND/OR running on start, start the ticker here.
+		go RunDiscoOnTimer(ctxSnmp, c, log, v, runOnStart, cfg, apic, confMgr)
+	}
+
+	// Block here
+	_ = <-c
+
+	// If we got this signal, redo the snmp system.
+	cancel()
+
+	go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, restartCount+1, cfg, confMgr) // Track how many times through here we've been.
+}

--- a/pkg/inputs/snmp/snmp_windows.go
+++ b/pkg/inputs/snmp/snmp_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+// +build windows
+
+package snmp
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	go_metrics "github.com/kentik/go-metrics"
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/api"
+	"github.com/kentik/ktranslate/pkg/config"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, confMgr config.ConfigManager) {
+	ctxSnmp, cancel := context.WithCancel(ctx)
+	err := runSnmpPolling(ctxSnmp, snmpFile, jchfChan, metrics, registry, apic, log, restartCount, cfg)
+	if err != nil {
+		log.Errorf("There was an error when polling for SNMP devices: %v.", err)
+	}
+
+	// We only want to run a disco on start when restartCount is 0. Otherwise you end up doing 2 discos if a new device is found on start.
+	runOnStart := cfg.DiscoveryOnStart
+	if restartCount > 0 {
+		runOnStart = false
+	}
+
+	// Now, wait for sigusr2 to re-do or if there's a discovery with new devices.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, kt.SIGUSR2)
+	if v := cfg.DiscoveryIntervalMinutes; v > 0 || runOnStart { // If we are re-running snmp discovery every interval AND/OR running on start, start the ticker here.
+		go RunDiscoOnTimer(ctxSnmp, c, log, v, runOnStart, cfg, apic, confMgr)
+	}
+
+	// Block here
+	_ = <-c
+
+	// If we got this signal, redo the snmp system.
+	cancel()
+
+	go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, restartCount+1, cfg, confMgr) // Track how many times through here we've been.
+}

--- a/pkg/inputs/snmp/snmp_windows.go
+++ b/pkg/inputs/snmp/snmp_windows.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"syscall"
 
 	go_metrics "github.com/kentik/go-metrics"
 	"github.com/kentik/ktranslate"

--- a/pkg/inputs/snmp/snmp_windows.go
+++ b/pkg/inputs/snmp/snmp_windows.go
@@ -16,9 +16,10 @@ import (
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
-func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, confMgr config.ConfigManager) {
+func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, apic *api.KentikApi, log logger.ContextL, restartCount int, cfg *ktranslate.SNMPInputConfig, confMgr config.ConfigManager, logchan chan string) {
+	c := make(chan os.Signal, 1)
 	ctxSnmp, cancel := context.WithCancel(ctx)
-	err := runSnmpPolling(ctxSnmp, snmpFile, jchfChan, metrics, registry, apic, log, restartCount, cfg)
+	err := runSnmpPolling(ctxSnmp, snmpFile, jchfChan, metrics, registry, apic, log, restartCount, cfg, logchan, c)
 	if err != nil {
 		log.Errorf("There was an error when polling for SNMP devices: %v.", err)
 	}
@@ -30,7 +31,6 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 	}
 
 	// Now, wait for sigusr2 to re-do or if there's a discovery with new devices.
-	c := make(chan os.Signal, 1)
 	signal.Notify(c, kt.SIGUSR2)
 	if v := cfg.DiscoveryIntervalMinutes; v > 0 || runOnStart { // If we are re-running snmp discovery every interval AND/OR running on start, start the ticker here.
 		go RunDiscoOnTimer(ctxSnmp, c, log, v, runOnStart, cfg, apic, confMgr)
@@ -42,5 +42,5 @@ func wrapSnmpPolling(ctx context.Context, snmpFile string, jchfChan chan []*kt.J
 	// If we got this signal, redo the snmp system.
 	cancel()
 
-	go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, restartCount+1, cfg, confMgr) // Track how many times through here we've been.
+	go wrapSnmpPolling(ctx, snmpFile, jchfChan, metrics, registry, apic, log, restartCount+1, cfg, confMgr, logchan) // Track how many times through here we've been.
 }

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -280,6 +280,7 @@ type SnmpGlobalConfig struct {
 	ProviderMap           map[string]ProviderMap `yaml:"providers"`
 	JitterTimeSec         int                    `yaml:"jitter_time_sec"`
 	FastPoll              bool                   `yaml:"fast_poll"`
+	WatchProfileChanges   bool                   `yaml:"watch_profile_changes"`
 }
 
 type SnmpConfig struct {

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -78,7 +78,6 @@ const (
 
 	SendBatchDuration     = 1 * time.Second
 	DefaultProfileMessage = "Missing matched profile. See overview page for details."
-	SIGUSR1               = syscall.Signal(0xa) // Because windows doesn't have this.
 	SIGUSR2               = syscall.Signal(0xc) // Because windows doesn't have this.
 
 	PluginSyslog   = "ktranslate-syslog"

--- a/pkg/sinks/file/file_unix.go
+++ b/pkg/sinks/file/file_unix.go
@@ -1,0 +1,74 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package file
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// Listen for signals to print or not.
+func (s *FileSink) loopAndListen(ctx context.Context) {
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, syscall.SIGUSR1)
+	dumpTick := time.NewTicker(time.Duration(s.config.FlushIntervalSeconds) * time.Second)
+	s.Infof("Writing file at %s %v ...", s.location, s.doWrite)
+	defer dumpTick.Stop()
+
+	for {
+		select {
+		case sig := <-sigCh:
+			switch sig {
+			case syscall.SIGUSR1: // Toggles print. Note -- doesn't work in windows.
+				s.doWrite = !s.doWrite
+				s.Infof("Writing file at %s %v ...", s.location, s.doWrite)
+				if s.doWrite {
+					s.mux.Lock()
+					name := s.getName()
+					f, err := os.Create(name)
+					if err != nil {
+						s.Errorf("There was an error when creating the %s file: %v.", name, err)
+					} else {
+						s.fd = f
+					}
+					s.mux.Unlock()
+				}
+			}
+
+		case _ = <-dumpTick.C:
+			if !s.doWrite {
+				continue
+			}
+
+			s.mux.Lock()
+			oldName := s.fd.Name()
+			if s.fd != nil {
+				s.fd.Sync()
+				s.fd.Close()
+			}
+			if s.written == 0 {
+				os.Remove(oldName)
+			}
+
+			s.written = 0
+			name := s.getName()
+			f, err := os.Create(name)
+			if err != nil {
+				s.Errorf("There was an error when creating the %s file: %v.", name, err)
+				s.fd = nil
+			} else {
+				s.fd = f
+			}
+			s.mux.Unlock()
+			s.Debugf("New file: %s", name)
+
+		case <-ctx.Done():
+			s.Infof("fileSink Done")
+			return
+		}
+	}
+}

--- a/pkg/sinks/file/file_windows.go
+++ b/pkg/sinks/file/file_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+// +build windows
+
+package file
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"time"
+)
+
+// Listen for signals to print or not.
+func (s *FileSink) loopAndListen(ctx context.Context) {
+	dumpTick := time.NewTicker(time.Duration(s.config.FlushIntervalSeconds) * time.Second)
+	s.Infof("Writing file at %s %v ...", s.location, s.doWrite)
+	defer dumpTick.Stop()
+
+	for {
+		select {
+		case _ = <-dumpTick.C:
+			if !s.doWrite {
+				continue
+			}
+
+			s.mux.Lock()
+			oldName := s.fd.Name()
+			if s.fd != nil {
+				s.fd.Sync()
+				s.fd.Close()
+			}
+			if s.written == 0 {
+				os.Remove(oldName)
+			}
+
+			s.written = 0
+			name := s.getName()
+			f, err := os.Create(name)
+			if err != nil {
+				s.Errorf("There was an error when creating the %s file: %v.", name, err)
+				s.fd = nil
+			} else {
+				s.fd = f
+			}
+			s.mux.Unlock()
+			s.Debugf("New file: %s", name)
+
+		case <-ctx.Done():
+			s.Infof("fileSink Done")
+			return
+		}
+	}
+}

--- a/pkg/sinks/file/file_windows.go
+++ b/pkg/sinks/file/file_windows.go
@@ -6,7 +6,6 @@ package file
 import (
 	"context"
 	"os"
-	"os/signal"
 	"time"
 )
 


### PR DESCRIPTION
Closes #659

Fixes a bug where the `USR2` signal wasn't getting properly picked up. 

This allows linux and macos version of ktrans to dynamically reload the snmp config with a `kill -s USR2 60161` for example. 