### PR TITLE
Fixing a crash on rollups

### DIFF
--- a/pkg/rollup/stats.go
+++ b/pkg/rollup/stats.go
@@ -43,6 +43,7 @@ func newStatsRollup(log logger.Underlying, rd RollupDef, cfg *ktranslate.RollupC
 	r := &StatsRollup{
 		ContextL: logger.NewContextLFromUnderlying(logger.SContext{S: "sumRollup"}, log),
 		state:    map[string][]float64{},
+		config:   cfg,
 	}
 
 	r.keyJoin = cfg.JoinKey


### PR DESCRIPTION
Fixing a crash on rollups:

```
anic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x103f21a48]

goroutine 98 [running]:
github.com/kentik/ktranslate/pkg/rollup.(*StatsRollup).exportSum(0x14000676000, 0x14000ec0000, 0x0?, 0x102c1c334?, 0x140004939e0?, 0x0?, 0x0?)
	/Users/pye/src/ktranslate/pkg/rollup/stats.go:305 +0x428
created by github.com/kentik/ktranslate/pkg/rollup.(*StatsRollup).sumKvs in goroutine 30
	/Users/pye/src/ktranslate/pkg/rollup/stats.go:271 +0x168
zsh: exit 2     ./bin/ktranslate -nf.source=auto -rollup_interval 30 -filters  -rollups 
```

I guess no one ever used this code brach /shrug