### PR TITLE
Fixing path of secret so that it actually works for gcp

### DIFF
--- a/pkg/kt/gcp.go
+++ b/pkg/kt/gcp.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	gSMClient *secretmanager.Client
+	gSMClient  *secretmanager.Client
+	gcpProject = ""
 )
 
 const (
@@ -34,7 +35,17 @@ func loadViaGCPSecrets(key string) string {
 		gSMClient = client
 	}
 
+	// We need this project explicitly set for us also.
+	if gcpProject == "" {
+		gcpProject = LookupEnvString("GOOGLE_CLOUD_PROJECT", "")
+		if gcpProject == "" {
+			log.Printf("Missing env var GOOGLE_CLOUD_PROJECT")
+			return fmt.Sprintf("Missing env var GOOGLE_CLOUD_PROJECT")
+		}
+	}
+
 	// Build the request.
+	key = fmt.Sprintf("projects/%s/secrets/%s/versions/latest", gcpProject, key)
 	req := &secretmanagerpb.AccessSecretVersionRequest{
 		Name: key,
 	}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -528,6 +528,11 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 type V3SNMP V3SNMPConfig // Need a 2nd type alias to avoid stack overflow on parsing.
 
+func (a *V3SNMPConfig) String() string {
+	return fmt.Sprintf("UserName: %s, AuthenticationProtocol: %s, AuthenticationPassphrase: %s PrivacyProtocol: %s PrivacyPassphrase: %s ContextEngineID: %s ContextName: %s",
+		a.UserName, a.AuthenticationProtocol, a.AuthenticationPassphrase, a.PrivacyProtocol, a.PrivacyPassphrase, a.ContextEngineID, a.ContextName)
+}
+
 // Make sure that things serialize back to how they were.
 func (a *V3SNMPConfig) MarshalYAML() (interface{}, error) {
 	if a.origStr != "" {


### PR DESCRIPTION
Now this should actually work. Needed the explicit path to the secret. This info is hidden inside of a comment in the source code here only:

https://pkg.go.dev/cloud.google.com/go/secretmanager/apiv1/secretmanagerpb#AccessSecretVersionRequest