### PR TITLE
Add meraki logs

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -685,7 +685,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 		}
 		assureInput()
 		kc.metrics.SnmpDeviceData = kt.NewSnmpMetricSet(kc.registry)
-		err := snmp.StartSNMPPolls(ctx, kc.inputChan, kc.metrics.SnmpDeviceData, kc.registry, kc.apic, kc.log, kc.config.SNMPInput, kc.resolver, kc.confMgr)
+		err := snmp.StartSNMPPolls(ctx, kc.inputChan, kc.metrics.SnmpDeviceData, kc.registry, kc.apic, kc.log, kc.config.SNMPInput, kc.resolver, kc.confMgr, kc.logTee)
 		if err != nil {
 			return err
 		}

--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -34,7 +34,7 @@ type Poller struct {
 	pingSec          int
 }
 
-func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL) *Poller {
+func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL, logchan chan string) *Poller {
 	// Default poll rate is 5 min. This is what a lot of SNMP billing is on.
 	counterTimeSec := 5 * 60
 	if conf != nil && conf.PollTimeSec > 0 {
@@ -84,7 +84,7 @@ func NewPoller(server *gosnmp.GoSNMP, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpD
 	}
 
 	// If we are extending the metrics for this device in any way, set it up now.
-	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log)
+	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log, logchan)
 	if err != nil {
 		log.Errorf("Cannot setup extension for %s -> %s: %v", err, conf.DeviceIP, conf.DeviceName)
 	} else if ext != nil {
@@ -144,7 +144,7 @@ func NewPollerForPing(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jch
 	return &poller
 }
 
-func NewPollerForExtention(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL) *Poller {
+func NewPollerForExtention(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL, logchan chan string) *Poller {
 	// Default poll rate is 5 min. This is what a lot of SNMP billing is on.
 	counterTimeSec := 5 * 60
 	if conf != nil && conf.PollTimeSec > 0 {
@@ -174,7 +174,7 @@ func NewPollerForExtention(gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig
 	}
 
 	// If we are extending the metrics for this device in any way, set it up now.
-	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log)
+	ext, err := extension.NewExtension(jchfChan, gconf, conf, metrics, log, logchan)
 	if err != nil {
 		log.Errorf("Cannot setup extension for %s -> %s: %v", err, conf.DeviceIP, conf.DeviceName)
 	} else if ext != nil {

--- a/pkg/inputs/snmp/pollOnce.go
+++ b/pkg/inputs/snmp/pollOnce.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
-func pollOnce(ctx context.Context, tdevice string, conf *kt.SnmpConfig, connectTimeout time.Duration, retries int, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, log logger.ContextL) error {
+func pollOnce(ctx context.Context, tdevice string, conf *kt.SnmpConfig, connectTimeout time.Duration, retries int, jchfChan chan []*kt.JCHF, metrics *kt.SnmpMetricSet, registry go_metrics.Registry, log logger.ContextL, logchan chan string) error {
 	device := conf.Devices[tdevice]
 	if device == nil {
 		for _, dev := range conf.Devices {
@@ -50,7 +50,7 @@ func pollOnce(ctx context.Context, tdevice string, conf *kt.SnmpConfig, connectT
 
 	nm := kt.NewSnmpDeviceMetric(registry, device.DeviceName)
 	metadataPoller := metadata.NewPoller(metadataServer, conf.Global, device, jchfChan, nm, profile, log)
-	metricPoller := snmp_metrics.NewPoller(metricsServer, conf.Global, device, jchfChan, nm, profile, log)
+	metricPoller := snmp_metrics.NewPoller(metricsServer, conf.Global, device, jchfChan, nm, profile, log, logchan)
 
 	metadataPoller.StartLoop(ctx)
 	// Give a little time to get this done.

--- a/pkg/inputs/snmp/x/ext.go
+++ b/pkg/inputs/snmp/x/ext.go
@@ -16,7 +16,7 @@ type Extension interface {
 	GetName() string
 }
 
-func NewExtension(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (Extension, error) {
+func NewExtension(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL, logchan chan string) (Extension, error) {
 	if conf.Ext == nil { // No extensions set.
 		return nil, nil
 	}
@@ -24,7 +24,7 @@ func NewExtension(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt
 	if conf.Ext.EAPIConfig != nil {
 		return arista.NewEAPIClient(jchfChan, gconf, conf, metrics, log)
 	} else if conf.Ext.MerakiConfig != nil {
-		return meraki.NewMerakiClient(jchfChan, gconf, conf, metrics, log)
+		return meraki.NewMerakiClient(jchfChan, gconf, conf, metrics, log, logchan)
 	}
 
 	return nil, nil

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -387,6 +387,7 @@ func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) erro
 				emap["network"] = network.Name
 				emap["orgName"] = network.org.Name
 				emap["orgId"] = network.org.ID
+				emap["eventType"] = kt.KENTIK_EVENT_EXT
 				b, err := json.Marshal(emap)
 				if err != nil {
 					return err
@@ -453,9 +454,10 @@ func (c *MerakiClient) getNetworkEventsWrapper(ctx context.Context) {
 
 type eventWrapper struct {
 	networks.GetNetworkEventsOKBodyEventsItems0
-	Network string `json:"network"`
-	OrgName string `json:"orgName"`
-	OrgId   string `json:"orgId"`
+	Network   string `json:"network"`
+	OrgName   string `json:"orgName"`
+	OrgId     string `json:"orgId"`
+	EventType string `json:"eventType"`
 }
 
 func (c *MerakiClient) getNetworkEvents(lastPageEndAt string) (error, string) {
@@ -487,7 +489,7 @@ func (c *MerakiClient) getNetworkEvents(lastPageEndAt string) (error, string) {
 
 		results := prod.GetPayload()
 		for _, event := range results.Events {
-			ew := eventWrapper{*event, network.Name, network.org.Name, network.org.ID}
+			ew := eventWrapper{*event, network.Name, network.org.Name, network.org.ID, kt.KENTIK_EVENT_EXT}
 			b, err := json.Marshal(ew)
 			if err != nil {
 				return err, nextToken

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -61,7 +61,6 @@ const (
 	DEFAULT_TIMEOUT_RETRY = 2
 )
 
-<<<<<<< HEAD
 var (
 	DeviceStatusEnum = map[string]int64{
 		"online":   1,
@@ -71,20 +70,8 @@ var (
 	}
 )
 
-<<<<<<< HEAD
-func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (*MerakiClient, error) {
-=======
-func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL, logchan chan string) (*MerakiClient, error) {
->>>>>>> 8f8f622 (wip: Adding in meraki logs for events)
-	c := MerakiClient{
-=======
-<<<<<<< HEAD
-	c `  := MerakiClient{
-=======
 func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL, logchan chan string) (*MerakiClient, error) {
 	c := MerakiClient{
->>>>>>> 81472d3 (wip: Adding in meraki logs for events)
->>>>>>> eb50ab8 (wip: Adding in meraki logs for events)
 		log:      log,
 		jchfChan: jchfChan,
 		conf:     conf,
@@ -364,7 +351,6 @@ func (c *MerakiClient) Run(ctx context.Context, dur time.Duration) {
 	}
 }
 
-<<<<<<< HEAD
 func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) error {
 	startTime := time.Now().Add(-1 * dur)
 	startTimeStr := fmt.Sprintf("%v", startTime.Unix())
@@ -401,57 +387,11 @@ func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) erro
 				b, err := json.Marshal(emap)
 				if err != nil {
 					return err
-=======
-func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) ([]*kt.JCHF, error) {
-	startTime := time.Now().Add(-1 * dur)
-	startTimeStr := fmt.Sprintf("%v", startTime.Unix())
-
-	res := []*kt.JCHF{}
-	for _, org := range c.orgs {
-		for _, network := range org.networks {
-			params := appliance.NewGetNetworkApplianceSecurityEventsParamsWithTimeout(c.timeout)
-			params.SetNetworkID(network.ID)
-			params.SetT0(&startTimeStr)
-
-			prod, err := c.client.Appliance.GetNetworkApplianceSecurityEvents(params, c.auth)
-			if err != nil {
-				return nil, err
-			}
-
-			_ = prod.GetPayload()
-		}
-
-	}
-
-	return res, nil
-}
-
-func (c *MerakiClient) getNetworkEvents(dur time.Duration) ([]*kt.JCHF, error) {
-	res := []*kt.JCHF{}
-	for _, org := range c.orgs {
-		for _, network := range org.networks {
-			for _, pt := range c.conf.Ext.MerakiConfig.ProductTypes {
-				params := networks.NewGetNetworkEventsParamsWithTimeout(c.timeout)
-				params.SetNetworkID(network.ID)
-				lpt := pt
-				params.SetProductType(&lpt)
-
-				prod, err := c.client.Networks.GetNetworkEvents(params, c.auth)
-				if err != nil {
-					return nil, err
-				}
-
-				results := prod.GetPayload()
-				b, err := json.Marshal(results)
-				if err != nil {
-					return nil, err
->>>>>>> 81472d3 (wip: Adding in meraki logs for events)
 				}
 				c.logchan <- string(b)
 			}
 		}
 
-<<<<<<< HEAD
 		nextLink := getNextLink(prod.Link)
 		if nextLink != "" {
 			return getNetworkEvents(nextLink, network, timeouts)
@@ -588,11 +528,6 @@ func (c *MerakiClient) getNetworkEvents(lastPageEndAt string) (error, string) {
 
 	c.log.Infof("Done with network events download to %s", nextPageEndAt)
 	return nil, nextPageEndAt
-=======
-	}
-
-	return res, nil
->>>>>>> 81472d3 (wip: Adding in meraki logs for events)
 }
 
 type orgLog struct {

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -71,11 +71,20 @@ var (
 	}
 )
 
+<<<<<<< HEAD
 func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL) (*MerakiClient, error) {
 =======
 func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL, logchan chan string) (*MerakiClient, error) {
 >>>>>>> 8f8f622 (wip: Adding in meraki logs for events)
 	c := MerakiClient{
+=======
+<<<<<<< HEAD
+	c `  := MerakiClient{
+=======
+func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf *kt.SnmpDeviceConfig, metrics *kt.SnmpDeviceMetric, log logger.ContextL, logchan chan string) (*MerakiClient, error) {
+	c := MerakiClient{
+>>>>>>> 81472d3 (wip: Adding in meraki logs for events)
+>>>>>>> eb50ab8 (wip: Adding in meraki logs for events)
 		log:      log,
 		jchfChan: jchfChan,
 		conf:     conf,
@@ -355,6 +364,7 @@ func (c *MerakiClient) Run(ctx context.Context, dur time.Duration) {
 	}
 }
 
+<<<<<<< HEAD
 func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) error {
 	startTime := time.Now().Add(-1 * dur)
 	startTimeStr := fmt.Sprintf("%v", startTime.Unix())
@@ -391,11 +401,57 @@ func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) erro
 				b, err := json.Marshal(emap)
 				if err != nil {
 					return err
+=======
+func (c *MerakiClient) getNetworkApplianceSecurityEvents(dur time.Duration) ([]*kt.JCHF, error) {
+	startTime := time.Now().Add(-1 * dur)
+	startTimeStr := fmt.Sprintf("%v", startTime.Unix())
+
+	res := []*kt.JCHF{}
+	for _, org := range c.orgs {
+		for _, network := range org.networks {
+			params := appliance.NewGetNetworkApplianceSecurityEventsParamsWithTimeout(c.timeout)
+			params.SetNetworkID(network.ID)
+			params.SetT0(&startTimeStr)
+
+			prod, err := c.client.Appliance.GetNetworkApplianceSecurityEvents(params, c.auth)
+			if err != nil {
+				return nil, err
+			}
+
+			_ = prod.GetPayload()
+		}
+
+	}
+
+	return res, nil
+}
+
+func (c *MerakiClient) getNetworkEvents(dur time.Duration) ([]*kt.JCHF, error) {
+	res := []*kt.JCHF{}
+	for _, org := range c.orgs {
+		for _, network := range org.networks {
+			for _, pt := range c.conf.Ext.MerakiConfig.ProductTypes {
+				params := networks.NewGetNetworkEventsParamsWithTimeout(c.timeout)
+				params.SetNetworkID(network.ID)
+				lpt := pt
+				params.SetProductType(&lpt)
+
+				prod, err := c.client.Networks.GetNetworkEvents(params, c.auth)
+				if err != nil {
+					return nil, err
+				}
+
+				results := prod.GetPayload()
+				b, err := json.Marshal(results)
+				if err != nil {
+					return nil, err
+>>>>>>> 81472d3 (wip: Adding in meraki logs for events)
 				}
 				c.logchan <- string(b)
 			}
 		}
 
+<<<<<<< HEAD
 		nextLink := getNextLink(prod.Link)
 		if nextLink != "" {
 			return getNetworkEvents(nextLink, network, timeouts)
@@ -532,6 +588,11 @@ func (c *MerakiClient) getNetworkEvents(lastPageEndAt string) (error, string) {
 
 	c.log.Infof("Done with network events download to %s", nextPageEndAt)
 	return nil, nextPageEndAt
+=======
+	}
+
+	return res, nil
+>>>>>>> 81472d3 (wip: Adding in meraki logs for events)
 }
 
 type orgLog struct {


### PR DESCRIPTION
Adding in https://developer.cisco.com/meraki/api/get-network-appliance-security-events/ and https://developer.cisco.com/meraki/api/get-network-events/ to meraki. 

Enable with

```
         preferences:
                log_network_security_events: true
                log_network_events: true
```

log_network_events doesn't seem to have a start time component so it only is called at startup. log_network_security_events is polled each duration. 

Since these are network level calls, be careful about adding lots of networks to the list because of usage limits. 

What do you think?
