### PR TITLE
Allow sending upstream netflow to multiple servers

### DIFF
--- a/pkg/sinks/net/net.go
+++ b/pkg/sinks/net/net.go
@@ -65,7 +65,7 @@ func (s *NetSink) Init(ctx context.Context, format formats.Format, compression k
 		case "unix":
 			serverAddr, err = net.ResolveUnixAddr(s.config.Protocol, endpoint)
 		default:
-			err = fmt.Errorf("Invalid protocol: %s. Supported: udp|tcp|unix", endpoint)
+			err = fmt.Errorf("Invalid protocol: %s. Supported: udp|tcp|unix", s.config.Protocol)
 
 		}
 		if err != nil {


### PR DESCRIPTION
Now you can use ktranslate like samplicator. Tested with:

```
Process 1:
ktranslate -nf.source=auto -format netflow -sinks net -net_server 127.0.0.1:9090,127.0.0.1:9091 -max_flows_per_message=1

Process 2:
ktranslate -nf.source auto -nf.port 9090 -listen off 

Process 3:
ktranslate -nf.source auto -nf.port 9091 -listen off 
```

Process 2 and 3 get the same flows. Use a comma split `-net_server` to specify multiple destinations. 

`-max_flows_per_message=1` is needed when sending udp packets because otherwise it is dumb and tries to cram too much into 1 udp packet. 