### PR TITLE
Bumping dockerfile build go version to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build ktranslate
-FROM golang:1.20-alpine as build
+FROM golang:1.21-alpine as build
 RUN apk add -U libpcap-dev alpine-sdk bash libcap
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
This fixes this build error:

```
 > [linux/amd64 build 5/5] RUN make:
0.070 go generate ./cmd/version
0.073 go: errors parsing go.mod:
0.073 /src/go.mod:5: unknown directive: toolchain
0.074 make: *** [Makefile:3: all] Error 1
```

Also brings up to date the go version to 1.21 for production builds. 