### PR TITLE
resettig ping stats across runs now

### DIFF
--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -320,6 +320,10 @@ func (p *Poller) StartPingOnlyLoop(ctx context.Context) {
 					continue
 				}
 
+				// Reset so that we don't keep avg/min/max across checks.
+				p.pinger.Reset(slowTick)
+				p.deviceMetrics.ResetPingStats()
+
 				// Send data on.
 				p.jchfChan <- flows
 

--- a/pkg/inputs/snmp/ping/ping.go
+++ b/pkg/inputs/snmp/ping/ping.go
@@ -57,7 +57,7 @@ func (p *Pinger) Reset(inter time.Duration) error {
 	}
 	pinger.SetPrivileged(p.priv)
 	pinger.OnFinish = func(stats *ping.Statistics) {
-		p.log.Infof("Ping run %d finished.", p.num)
+		p.log.Debugf("Ping run %d finished.", p.num)
 		p.num++
 	}
 


### PR DESCRIPTION
Closes #657

We now will compute a new Max/Min/Avg for each ping run, resetting the stats after each call. 

Putting this up on staging to test. 