### PR TITLE
More mm shenanigans

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,27 @@ on:
 name: Upload Release
 
 jobs:
+  get_mm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install MM DBs
+        run: |
+          YOUR_ACCOUNT_ID=${{ secrets.MM_ACCOUNT_ID }} MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+
+      - name: 'Upload MM Geo DB'
+        uses: actions/upload-artifact@v4
+        with:
+          name: GeoLite2-Country.mmdb
+          path: config/GeoLite2-Country.mmdb
+          retention-days: 1
+
+      - name: 'Upload MM ASN DB'
+        uses: actions/upload-artifact@v4
+        with:
+          name: GeoLite2-ASN.mmdb
+          path: config/GeoLite2-ASN.mmdb
+          retention-days: 1
+
   build:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -114,9 +135,15 @@ jobs:
       - name: Run Test
         run: make test
 
-      - name: Install MM DBs
-        run: |
-          YOUR_ACCOUNT_ID=${{ secrets.MM_ACCOUNT_ID }} MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+      - name: Get MM Geo
+        uses: actions/download-artifact@v4
+        with:
+          name: GeoLite2-Country.mmdb
+
+      - name: Get MM Asn
+        uses: actions/download-artifact@v4
+        with:
+          name: GeoLite2-ASN.mmdb
 
       - name: Create package
         id: package

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,6 +7,27 @@ on:
       - make-rpm
 
 jobs:
+  get_mm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install MM DBs
+        run: |
+          YOUR_ACCOUNT_ID=${{ secrets.MM_ACCOUNT_ID }} MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+
+      - name: 'Upload MM Geo DB'
+        uses: actions/upload-artifact@v4
+        with:
+          name: GeoLite2-Country.mmdb
+          path: config/GeoLite2-Country.mmdb
+          retention-days: 1
+
+      - name: 'Upload MM ASN DB'
+        uses: actions/upload-artifact@v4
+        with:
+          name: GeoLite2-ASN.mmdb
+          path: config/GeoLite2-ASN.mmdb
+          retention-days: 1
+
   build:
     runs-on: ubuntu-latest
     # There's several of these lists of releases that we're building
@@ -102,9 +123,15 @@ jobs:
       - name: Run Test
         run: make test
 
-      - name: Install MM DBs
-        run: |
-          YOUR_ACCOUNT_ID=${{ secrets.MM_ACCOUNT_ID }} MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }} ./bin/get_mm.sh
+      - name: Get MM Geo
+        uses: actions/download-artifact@v4
+        with:
+          name: GeoLite2-Country.mmdb
+
+      - name: Get MM Asn
+        uses: actions/download-artifact@v4
+        with:
+          name: GeoLite2-ASN.mmdb
 
       - name: Create package
         id: package

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,14 @@ RUN make
 # maxmind dbs
 FROM alpine:latest as maxmind
 ARG MAXMIND_LICENSE_KEY
+ARG YOUR_ACCOUNT_ID
 RUN apk add -U curl tar
 ENV GEOLITE2_COUNTRY_FILE=GeoLite2-Country.mmdb
 ENV GEOLITE2_ASN_FILE=GeoLite2-ASN.mmdb
 RUN if [ -z "${MAXMIND_LICENSE_KEY}" ]; then echo "MAXMIND_LICENSE_KEY" not set; exit 1; fi
-RUN curl -o /tmp/country.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" && \
+RUN curl -L -o /tmp/country.tar.gz -u ${YOUR_ACCOUNT_ID}:${MAXMIND_LICENSE_KEY} "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz" && \
 	tar zxf /tmp/country.tar.gz --strip-components 1 -C /
-RUN curl -o /tmp/asn.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" && \
+RUN curl -L -o /tmp/asn.tar.gz -u ${YOUR_ACCOUNT_ID}:${MAXMIND_LICENSE_KEY} "https://download.maxmind.com/geoip/databases/GeoLite2-ASN/download?suffix=tar.gz" && \
 	tar zxf /tmp/asn.tar.gz --strip-components 1 -C /
 
 # snmp profiles


### PR DESCRIPTION
MM is starting to enforce a limit of 30 downloads/day. This fix pulls the download out of the per distro loop of builds and does it once before the build and then caches the results. Hopefully will be enough to keep us under the limit. 