### PR TITLE
Adding in a retry for org networks. Also removing lambda push.

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -89,21 +89,6 @@ jobs:
           secrets: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
 
-      - name: Build and Publish Docker (AWS Lambda)
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          platforms: linux/arm64
-          push: true
-          tags: kentik/ktranslate:v2arm64
-          build-args: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-            YOUR_ACCOUNT_ID=${{ secrets.MM_ACCOUNT_ID }}
-            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
-          secrets: |
-            MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
-
       - name: Build and Publish Docker (Kentik EU)
         uses: docker/build-push-action@v2
         with:

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -207,7 +207,7 @@ func (c *MerakiClient) getOrgNetworks(netSet map[string]networkDesc, nextToken s
 	}
 	prod, err := c.client.Organizations.GetOrganizationNetworks(params, c.auth)
 	if err != nil {
-		if c.conf.Ext.MerakiConfig.Prefs["retry_org_networks"] && retries >= MaxRetriesGetOrgNetworks {
+		if !c.conf.Ext.MerakiConfig.Prefs["retry_org_networks"] || retries >= MaxRetriesGetOrgNetworks {
 			return numNets, err
 		}
 		retries += 1

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -60,7 +60,7 @@ const (
 	MAX_TIMEOUT_RETRY        = 10 // Don't retry a call more than this many times.
 	MAX_TIMEOUT_SEC          = 5  // Sleep this many sec each 429.
 	DEFAULT_TIMEOUT_RETRY    = 2
-	MaxRetriesGetOrgNetworks = 2
+	MaxRetriesGetOrgNetworks = 3
 )
 
 var (

--- a/pkg/inputs/snmp/x/meraki/meraki.go
+++ b/pkg/inputs/snmp/x/meraki/meraki.go
@@ -53,13 +53,14 @@ type networkDesc struct {
 }
 
 const (
-	ControllerKey         = "meraki_controller_name"
-	MerakiApiKey          = "KENTIK_MERAKI_API_KEY"
-	DeviceCacheDuration   = time.Duration(24) * time.Hour
-	UplinkBWCacheDuration = time.Duration(24) * time.Hour
-	MAX_TIMEOUT_RETRY     = 10 // Don't retry a call more than this many times.
-	MAX_TIMEOUT_SEC       = 5  // Sleep this many sec each 429.
-	DEFAULT_TIMEOUT_RETRY = 2
+	ControllerKey            = "meraki_controller_name"
+	MerakiApiKey             = "KENTIK_MERAKI_API_KEY"
+	DeviceCacheDuration      = time.Duration(24) * time.Hour
+	UplinkBWCacheDuration    = time.Duration(24) * time.Hour
+	MAX_TIMEOUT_RETRY        = 10 // Don't retry a call more than this many times.
+	MAX_TIMEOUT_SEC          = 5  // Sleep this many sec each 429.
+	DEFAULT_TIMEOUT_RETRY    = 2
+	MaxRetriesGetOrgNetworks = 2
 )
 
 var (
@@ -156,7 +157,7 @@ func NewMerakiClient(jchfChan chan []*kt.JCHF, gconf *kt.SnmpGlobalConfig, conf 
 
 		// Now list the networks for this org.
 		netSet := map[string]networkDesc{}
-		numAdded, err := c.getOrgNetworks(netSet, "", lorg, nets, 0)
+		numAdded, err := c.getOrgNetworks(netSet, "", lorg, nets, 0, 0)
 		if err != nil {
 			c.log.Warnf("Skipping organization %s because it does not have permission to list networks.", org.Name)
 			continue
@@ -195,7 +196,7 @@ func getNextLink(linkSet string) string {
 }
 
 func (c *MerakiClient) getOrgNetworks(netSet map[string]networkDesc, nextToken string,
-	org *organizations.GetOrganizationsOKBodyItems0, nets []*regexp.Regexp, numNets int) (int, error) {
+	org *organizations.GetOrganizationsOKBodyItems0, nets []*regexp.Regexp, numNets int, retries int) (int, error) {
 
 	perPageLimit := int64(100) // Seems like a good default.
 	params := organizations.NewGetOrganizationNetworksParamsWithTimeout(c.timeout)
@@ -206,7 +207,11 @@ func (c *MerakiClient) getOrgNetworks(netSet map[string]networkDesc, nextToken s
 	}
 	prod, err := c.client.Organizations.GetOrganizationNetworks(params, c.auth)
 	if err != nil {
-		return 0, err
+		if c.conf.Ext.MerakiConfig.Prefs["retry_org_networks"] && retries >= MaxRetriesGetOrgNetworks {
+			return numNets, err
+		}
+		retries += 1
+		return c.getOrgNetworks(netSet, nextToken, org, nets, numNets, retries)
 	}
 
 	b, err := json.Marshal(prod.GetPayload())
@@ -241,7 +246,7 @@ func (c *MerakiClient) getOrgNetworks(netSet map[string]networkDesc, nextToken s
 	// Recursion!
 	nextLink := getNextLink(prod.Link)
 	if nextLink != "" {
-		return c.getOrgNetworks(netSet, nextLink, org, nets, numNets)
+		return c.getOrgNetworks(netSet, nextLink, org, nets, numNets, retries)
 	} else {
 		return numNets, nil
 	}


### PR DESCRIPTION
When 

```yaml
preferences:
           retry_org_networks: true
```
is set, ktrans will retry to get all of the networks in an organization 2 times for the Meraki API. 

Q? is this enough? Should it be a variable? 

Also removing support for building the AWS lambda specific docker image. 