### PR TITLE
Let traps have a regex conversion

### DIFF
--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -245,15 +245,23 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 		case gosnmp.OctetString:
 			if value, ok := snmp_util.ReadOctetString(v, snmp_util.NO_TRUNCATE); ok {
 				if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
-					_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
-				}
-				if !utf8.ValidString(value) { // Print out value as a hex string.
-					value = fmt.Sprintf("%x", v.Value)
-				}
-				if res != nil {
-					dst.CustomStr[res.GetName()] = value
-				} else {
-					dst.CustomStr[v.Name] = value
+					_, sval, mval := snmp_util.GetFromConv(v, res.Conversion, s.log)
+					if len(mval) > 0 { // List the regex matches.
+						for k, v := range mval {
+							dst.CustomStr[k] = v
+						}
+					} else {
+						dst.CustomStr[res.GetName()] = sval
+					}
+				} else { // No conversion.
+					if !utf8.ValidString(value) { // Print out value as a hex string.
+						value = fmt.Sprintf("%x", v.Value)
+					}
+					if res != nil {
+						dst.CustomStr[res.GetName()] = value
+					} else {
+						dst.CustomStr[v.Name] = value
+					}
 				}
 			}
 		case gosnmp.Counter64, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Uinteger32, gosnmp.Integer:

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -248,7 +248,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 					_, sval, mval := snmp_util.GetFromConv(v, res.Conversion, s.log)
 					if len(mval) > 0 { // List the regex matches.
 						for k, v := range mval {
-							dst.CustomStr[k] = v
+							dst.CustomStr[res.GetName()+"."+k] = v
 						}
 					} else {
 						dst.CustomStr[res.GetName()] = sval

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -248,7 +248,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 					_, sval, mval := snmp_util.GetFromConv(v, res.Conversion, s.log)
 					if len(mval) > 0 { // List the regex matches.
 						for k, v := range mval {
-							dst.CustomStr[res.GetName()+"."+k] = v
+							dst.CustomStr[k] = v
 						}
 					} else {
 						dst.CustomStr[res.GetName()] = sval

--- a/pkg/inputs/snmp/util/util_test.go
+++ b/pkg/inputs/snmp/util/util_test.go
@@ -232,6 +232,13 @@ func TestRegex(t *testing.T) {
 				"Exhaust": "26",
 			},
 		},
+		multiRe{
+			input: []byte("There is an issue with: 992-227-332 . The cpu is too high"),
+			re:    `:\:\s(?P<hostid>[0-9]+-[0-9]+-[0-9]+)\s`,
+			outputs: map[string]string{
+				"hostid": "992-227-332",
+			},
+		},
 	}
 
 	for _, in := range testStr {


### PR DESCRIPTION
Closes #700 

(wow, number 700)!

What do you think about this? It uses the existing regex part of snmp profiles so just needed an update to the trap handler. Given an input of 

```
snmptrap -c public -v 2c 127.0.0.1:1620 "" 1.3.6.1.4.1.41263.999 1.3.6.1.4.1.41263.999.3 s "There is an issue with: 992-227-332 . The cpu is too high"
```

Result is `"Problem with.hostid":"992-227-332",` and fully:
```json
[{"src_addr":"127.0.0.1","eventType":"KSnmpTrap","TrapOID":".1.3.6.1.4.1.41263.999","instrumentation.provider":"kentik","instrumentation.name":"netflow-events","collector.name":"ktranslate","TrapName":"ntxAlert","Problem with.hostid":"992-227-332","device_name":"127.0.0.1","provider":"kentik-trap-device"}]
```

The trap.yaml file is extended with:

```yaml
  - trap_oid: 1.3.6.1.4.1.41263.999
    trap_name: ntxAlert
    drop_undefined: false
    events:
      - name: ntxAlertCreationTime
        OID: 1.3.6.1.4.1.41263.999.1
      - name: ntxAlertDisplayMsg
        OID: 1.3.6.1.4.1.41263.999.2
      - name: ntxAlertTitle
        OID: 1.3.6.1.4.1.41263.999.3
        conversion: "regexp:\\:\\s(?P<hostid>[0-9]+-[0-9]+-[0-9]+)\\s"
        tag: "Problem with"
```

`conversion` sets up a capturing regex while the `tag` supplies the key part of the key-value pair. 

This relies on [named captures](https://github.com/StefanSchroeder/Golang-Regex-Tutorial/blob/master/01-chapter2.markdown#named-matches) to set the key part of the map. 






