### PR TITLE
adding a guard so that a nil device is not crashing

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -469,7 +469,11 @@ func parseConfig(ctx context.Context, file string, log logger.ContextL) (*kt.Snm
 	}
 
 	// Correctly format all the user tags needed here:
-	for _, device := range ms.Devices {
+	for dname, device := range ms.Devices {
+		if device == nil {
+			log.Errorf("Device %s is nil. Skipping.", dname)
+			continue
+		}
 		setDeviceTagsAndMatch(device) // Tweak any per provider tags and match attributes here now that we have the actual provider.
 		device.InitUserTags(ServiceName)
 	}


### PR DESCRIPTION
Closes https://github.com/kentik/ui-app/issues/23262
Closes #723 

Fix a crash with a guard and log an error to user to fix. 