### PR TITLE
Bug with filters not reseting kentik flow. 

### DIFF
--- a/pkg/cat/kentik.go
+++ b/pkg/cat/kentik.go
@@ -364,6 +364,7 @@ func (kc *KTranslate) monitorAlphaChan(ctx context.Context, i int, seri func([]*
 						sendBytesOn()
 					}
 				} else {
+					jflow.Reset()
 					kc.jchfChans[i] <- jflow // Toss this guy, he doesn't meet out filter.
 				}
 


### PR DESCRIPTION
Fixing a bug where filters which remove a lot of traffic will eventually block any new data. So filters will work for a bit and then eventually no new data will get past the filters. Fixed with a one liner but several weeks to track down. 