### PR TITLE
Allowing AND in a filter

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -122,8 +122,10 @@ func (i *FilterDefs) Set(value string) error {
 func GetFilters(log logger.Underlying, filters []string) ([]FilterWrapper, error) {
 	ff := FilterDefs{}
 	for _, f := range filters {
-		if err := ff.Set(f); err != nil {
-			return nil, err
+		for _, andSet := range strings.Split(f, AndToken) {
+			if err := ff.Set(andSet); err != nil {
+				return nil, err
+			}
 		}
 	}
 	filterSet := make([]FilterWrapper, 0)
@@ -153,6 +155,7 @@ func GetFilters(log logger.Underlying, filters []string) ([]FilterWrapper, error
 				return nil, fmt.Errorf("Invalid type: %s. Valid Types: %s|%s|%s", fd.FType, String, Int, Addr)
 			}
 		}
+		log.Infof("Filter: ", "Added %s", fSet.String())
 		filterSet = append(filterSet, orSet)
 	}
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -28,13 +28,14 @@ func TestFilter(t *testing.T) {
 		"fooII,==,12",
 		"src_addr,==,10.2.2.0/24",
 		"foo,==,no or fooII,==,12",
+		"foo,==,bar and fooII,==,12",
 	}
 	fs, err := GetFilters(l, filters)
 	assert.NoError(err)
-	assert.Equal(len(filters), len(fs))
+	assert.Equal(len(filters)+1, len(fs)) // There's an extra and in here.
 
-	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true, true}
+	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true, true, true, true}
 	for i, fs := range fs {
-		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d -> %v", i, filters[i])
+		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d", i)
 	}
 }


### PR DESCRIPTION
This PR allows you to explicitly AND filters like 

```
 -filters "string,custom_str.dst_network_bndry,==,external AND custom_str.src_subscriber_id != 0" \
```