### PR TITLE
Adding a test for upper case OR and AND in filters

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -23,8 +23,10 @@ const (
 	Int               = "int"
 	Addr              = "addr"
 
-	OrToken  = " or "
-	AndToken = " and "
+	OrToken      = " or "
+	AndToken     = " and "
+	AndUpperCase = " AND "
+	OrUpperCase  = " OR "
 )
 
 var (
@@ -88,7 +90,7 @@ func (ff *FilterDefs) String() string {
 
 func (i *FilterDefs) Set(value string) error {
 	inner := FilterDefWrapper{}
-	for _, orSet := range strings.Split(value, OrToken) {
+	for _, orSet := range strings.Split(strings.Replace(value, OrUpperCase, OrToken, 1), OrToken) {
 		pts := strings.Split(orSet, ",")
 		if len(pts) < 3 {
 			return fmt.Errorf("Filter flag is defined by <type> dimension operator value")
@@ -122,7 +124,7 @@ func (i *FilterDefs) Set(value string) error {
 func GetFilters(log logger.Underlying, filters []string) ([]FilterWrapper, error) {
 	ff := FilterDefs{}
 	for _, f := range filters {
-		for _, andSet := range strings.Split(f, AndToken) {
+		for _, andSet := range strings.Split(strings.Replace(f, AndUpperCase, AndToken, 1), AndToken) {
 			if err := ff.Set(andSet); err != nil {
 				return nil, err
 			}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -29,12 +29,14 @@ func TestFilter(t *testing.T) {
 		"src_addr,==,10.2.2.0/24",
 		"foo,==,no or fooII,==,12",
 		"foo,==,bar and fooII,==,12",
+		"foo,==,no OR fooII,==,12",
+		"foo,==,bar AND fooII,==,12",
 	}
 	fs, err := GetFilters(l, filters)
 	assert.NoError(err)
-	assert.Equal(len(filters)+1, len(fs)) // There's an extra and in here.
+	assert.Equal(len(filters)+2, len(fs)) // There's an extra and in here.
 
-	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true, true, true, true}
+	results := []bool{true, true, true, false, true, true, true, true, false, true, true, true, true, true, true, true, true, true}
 	for i, fs := range fs {
 		assert.Equal(results[i], fs.Filter(kt.InputTesting[0]), "%d", i)
 	}


### PR DESCRIPTION
This fixes a bug @kentik-rbarnes found where `and` works for filters now but `AND` doesn't.  Also some more tests on this. 