### PR TITLE
Fixing interface api

### DIFF
--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -130,22 +130,22 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.CustomStr["SamplerAddress"] = d.SendingIps[0].String()
 		}
 		if i, ok := d.Interfaces[dst.InputPort]; ok {
-			dst.InputIntDesc = i.InterfaceDescription
-			dst.InputIntAlias = i.SnmpAlias
+			dst.InputIntDesc = i.Description
+			dst.InputIntAlias = i.Alias
 			dst.InputInterfaceCapacity = i.SnmpSpeedMbps
-			dst.InputInterfaceIP = i.InterfaceIP
+			dst.InputInterfaceIP = i.Address
 			dst.CustomStr["input_provider"] = i.Provider
-			dst.CustomStr["input_site_title"] = i.SiteTitle
-			dst.CustomStr["input_site_country"] = i.SiteCountry
+			dst.CustomStr["input_network_boundary"] = i.NetworkBoundary
+			dst.CustomStr["input_connectivity_type"] = i.ConnectivityType
 		}
 		if i, ok := d.Interfaces[dst.OutputPort]; ok {
-			dst.OutputIntDesc = i.InterfaceDescription
-			dst.OutputIntAlias = i.SnmpAlias
+			dst.OutputIntDesc = i.Description
+			dst.OutputIntAlias = i.Alias
 			dst.OutputInterfaceCapacity = i.SnmpSpeedMbps
-			dst.OutputInterfaceIP = i.InterfaceIP
+			dst.OutputInterfaceIP = i.Address
 			dst.CustomStr["output_provider"] = i.Provider
-			dst.CustomStr["output_site_title"] = i.SiteTitle
-			dst.CustomStr["output_site_country"] = i.SiteCountry
+			dst.CustomStr["output_network_boundary"] = i.NetworkBoundary
+			dst.CustomStr["output_connectivity_type"] = i.ConnectivityType
 		}
 	}
 

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -69,26 +69,23 @@ type InterfaceCapacityBPS = uint64
 // It corresponds to a row in mn_interface, joined with information
 // from mn_device and mn_site.
 type Interface struct {
-	ID int64 `json:"id"`
+	DeviceID    DeviceID `json:"device_id,string"`
+	Address     string   `json:"interface_ip"`
+	Netmask     string   `json:"interface_ip_netmask"`
+	Description string   `json:"interface_description"`
 
-	DeviceID   DeviceID `json:"device_id,string"`
-	DeviceName string   `json:"device_name"`
-	DeviceType string   `json:"device_type"`
-	SiteID     int      `json:"site_id"`
+	NetworkBoundary  string `json:"network_boundary"`
+	ConnectivityType string `json:"connectivity_type"`
+	Provider         string `json:"provider"`
 
-	SnmpID               IfaceID `json:"snmp_id,string"`
-	SnmpSpeedMbps        int64   `json:"snmp_speed,string"` // unit? TODO: switch to uint64, rename to SnmpSpeedMbps
-	SnmpType             int     `json:"snmp_type"`
-	SnmpAlias            string  `json:"snmp_alias"`
-	InterfaceIP          string  `json:"interface_ip"`
-	InterfaceDescription string  `json:"interface_description"`
-	Provider             string  `json:"provider"`
-	VrfID                int64   `json:"vrf_id"`
-	Netmask              string  `json:"interface_ip_netmask"`
-	Addrs                []Addr  `json:"secondary_ips"`
+	SnmpID        IfaceID `json:"snmp_id,string"`
+	Alias         string  `json:"snmp_alias"`
+	Type          uint64  `json:"snmp_type"`
+	SnmpSpeedMbps int64   `json:"snmp_speed,string"` // unit? TODO: switch to uint64, rename to SnmpSpeedMbps
+	SnmpType      int     `json:"snmp_type"`
 
-	SiteTitle   string `json:"site_title"`
-	SiteCountry string `json:"site_country"`
+	Addrs     []Addr            `json:"secondary_ips"`
+	ExtraInfo map[string]string `json:"extra_info"`
 }
 
 type Addr struct {


### PR DESCRIPTION
The way the kentik API works for interfaces moved. This updates the API code to correctly take in the needed data. 

Now we can correctly see data like `"input_provider":"MICROSOFT`