### PR TITLE
Allowing rollups to keep undefined terms if needed

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -592,6 +592,13 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.Rollup.TopK = v
 			case "rollups":
 				cfg.Rollup.Formats = strings.Split(val, filter.AndToken)
+			case "rollup_keep_undefined":
+				v, err := strconv.ParseBool(val)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				cfg.Rollup.KeepUndefined = v
 			// pkg/eggs/kmux
 			case "dir":
 				cfg.KMux.Dir = val

--- a/config.go
+++ b/config.go
@@ -138,9 +138,10 @@ type DDogSinkConfig struct {
 
 // RollupConfig is the config for rollups
 type RollupConfig struct {
-	JoinKey string
-	TopK    int
-	Formats []string
+	JoinKey       string
+	TopK          int
+	Formats       []string
+	KeepUndefined bool
 }
 
 // KMuxConfig is the config for the mux server
@@ -451,9 +452,10 @@ func DefaultConfig() *Config {
 			RelayURL: "",
 		},
 		Rollup: &RollupConfig{
-			JoinKey: "^",
-			TopK:    10,
-			Formats: []string{},
+			JoinKey:       "^",
+			TopK:          10,
+			Formats:       []string{},
+			KeepUndefined: false,
 		},
 		KMux: &KMuxConfig{
 			Dir: ".",


### PR DESCRIPTION
Adds in a new flag `-rollup_keep_undefined` which will not remove undefined rollup values but instead replace them with the string `undefined`. This is a customer request. 