### PR TITLE
Fixing bug where the primary dim might be not the first one

### DIFF
--- a/pkg/rollup/rollup.go
+++ b/pkg/rollup/rollup.go
@@ -265,6 +265,13 @@ func (r *rollupBase) getKey(mapr map[string]interface{}) string {
 		next++
 	}
 
+	// The primary dimension is always first now.
+	if r.primaryDim > 0 {
+		tmp := keyPts[0]
+		keyPts[0] = keyPts[r.primaryDim]
+		keyPts[r.primaryDim] = tmp
+	}
+
 	return strings.Join(keyPts, r.keyJoin)
 }
 

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -3,6 +3,7 @@ package rollup
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kentik/ktranslate"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
@@ -120,15 +121,15 @@ func TestRollup(t *testing.T) {
 
 		for _, ri := range rd {
 			ri.Add(inputs[i])
+			time.Sleep(50 * time.Millisecond)
 			res := ri.Export()
+			time.Sleep(50 * time.Millisecond)
 
-			if len(res) > 0 { // Sometimes there's a timing bug which gives us 0.
-				assert.Equal(outputs[i]["metric"].(int), int(res[0].Metric), res)
-				assert.Equal(roll.TopK, len(res), i)
-				dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
-				for j, dim := range dims {
-					assert.Equal(outputs[i]["dimensions"].([]string)[j], dim, res)
-				}
+			assert.Equal(outputs[i]["metric"].(int), int(res[0].Metric), res)
+			assert.Equal(roll.TopK, len(res), i)
+			dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
+			for j, dim := range dims {
+				assert.Equal(outputs[i]["dimensions"].([]string)[j], dim, res)
 			}
 		}
 	}

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -1,0 +1,135 @@
+package rollup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kentik/ktranslate"
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	lt "github.com/kentik/ktranslate/pkg/eggs/logger/testing"
+	"github.com/kentik/ktranslate/pkg/kt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRollup(t *testing.T) {
+	l := lt.NewTestContextL(logger.NilContext, t).GetLogger().GetUnderlyingLogger()
+	assert := assert.New(t)
+	// filters are type,dimension,operator,value
+	rolls := []ktranslate.RollupConfig{
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          2,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,foo"},
+			KeepUndefined: false,
+		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          1,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,foo,bar"},
+			KeepUndefined: false,
+		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          1,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,custom_str.foo,bar"},
+			KeepUndefined: false,
+		},
+	}
+
+	inputs := [][]map[string]interface{}{
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"foo":         "aaa",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(20),
+				"foo":         "aaa",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(20),
+				"foo":         "bbb",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(2),
+				"foo":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"foo":         "bbb",
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(34),
+				"foo":         "bbb",
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"custom_str":  map[string]string{"foo": "ddd"},
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(55),
+				"custom_str":  map[string]string{"foo": "ddd"},
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
+	}
+
+	outputs := []map[string]interface{}{
+		map[string]interface{}{
+			"metric":     30,
+			"dimensions": []string{"aaa"},
+		},
+		map[string]interface{}{
+			"metric":     44,
+			"dimensions": []string{"bbb", "ccc"},
+		},
+		map[string]interface{}{
+			"metric":     65,
+			"dimensions": []string{"ddd", "ccc"},
+		},
+	}
+
+	for i, roll := range rolls {
+		rd, err := GetRollups(l, &roll)
+		assert.NoError(err)
+		assert.Equal(len(roll.Formats), len(rd))
+
+		for _, ri := range rd {
+			ri.Add(inputs[i])
+			res := ri.Export()
+
+			if len(res) > 0 {
+				assert.Equal(outputs[i]["metric"].(int), int(res[0].Metric), res)
+			}
+			assert.Equal(roll.TopK, len(res), i)
+			dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
+			for j, dim := range dims {
+				assert.Equal(outputs[i]["dimensions"].([]string)[j], dim, res)
+			}
+		}
+	}
+}

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -122,13 +122,13 @@ func TestRollup(t *testing.T) {
 			ri.Add(inputs[i])
 			res := ri.Export()
 
-			if len(res) > 0 {
+			if len(res) > 0 { // Sometimes there's a timing bug which gives us 0.
 				assert.Equal(outputs[i]["metric"].(int), int(res[0].Metric), res)
-			}
-			assert.Equal(roll.TopK, len(res), i)
-			dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
-			for j, dim := range dims {
-				assert.Equal(outputs[i]["dimensions"].([]string)[j], dim, res)
+				assert.Equal(roll.TopK, len(res), i)
+				dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
+				for j, dim := range dims {
+					assert.Equal(outputs[i]["dimensions"].([]string)[j], dim, res)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Adds a few tests for rollups. Also fixing a bug where for a definition like 

```
-rollups s_sum,sum_bytes_in,in_bytes,custom_str.output_provider,device_name,output_int_desc,output_int_alias
```

You get a result like

```
"dimension": "device_name^outout_int_desc^output_int_alias^output_provider",
```

@kentik-rbarnes this fixes the bug you raised. 