### PR TITLE
Adding device_site to the flow export

### DIFF
--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -129,6 +129,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 		if len(d.SendingIps) > 0 {
 			dst.CustomStr["SamplerAddress"] = d.SendingIps[0].String()
 		}
+		dst.CustomStr["device_site"] = d.Site.SiteName
 		if i, ok := d.Interfaces[dst.InputPort]; ok {
 			dst.InputIntDesc = i.Description
 			dst.InputIntAlias = i.Alias


### PR DESCRIPTION
This adds in a line for `device_site` into the kflow export. 