### PR TITLE
Refactor to how rollups work with dims

### DIFF
--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -36,6 +36,12 @@ func TestRollup(t *testing.T) {
 			Formats:       []string{"sum,sum_bytes_in,in_bytes,custom_str.foo,bar"},
 			KeepUndefined: false,
 		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          1,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,ccc,custom_str.foo,bar"},
+			KeepUndefined: false,
+		},
 	}
 
 	inputs := [][]map[string]interface{}{
@@ -97,6 +103,24 @@ func TestRollup(t *testing.T) {
 				"provider":    kt.Provider("pp"),
 			},
 		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"custom_str":  map[string]string{"foo": "ddd"},
+				"bar":         "ccc",
+				"ccc":         "fff",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(65),
+				"custom_str":  map[string]string{"foo": "ddd"},
+				"bar":         "ccc",
+				"ccc":         "fff",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
 	}
 
 	outputs := []map[string]interface{}{
@@ -111,6 +135,10 @@ func TestRollup(t *testing.T) {
 		map[string]interface{}{
 			"metric":     65,
 			"dimensions": []string{"ddd", "ccc"},
+		},
+		map[string]interface{}{
+			"metric":     75,
+			"dimensions": []string{"fff", "ddd", "ccc"},
 		},
 	}
 

--- a/pkg/rollup/stats.go
+++ b/pkg/rollup/stats.go
@@ -228,7 +228,7 @@ func (r *StatsRollup) Export() []Rollup {
 		if err != nil {
 			r.Errorf("Error calculating: %v", err)
 		} else {
-			keys[next] = Rollup{Name: r.name, EventType: r.eventType, Dimension: k, Metric: value, KeyJoin: r.keyJoin, dims: combo(r.dims, r.multiDims), Interval: r.dtime.Sub(ot)}
+			keys[next] = Rollup{Name: r.name, EventType: r.eventType, Dimension: k, Metric: value, KeyJoin: r.keyJoin, dims: combo(r.multiDims), Interval: r.dtime.Sub(ot)}
 			next++
 		}
 	}
@@ -297,7 +297,7 @@ func (r *StatsRollup) exportSum(sum map[string]uint64, count map[string]uint64, 
 	for k, v := range sum {
 		keys = append(keys, Rollup{
 			Name: r.name, EventType: r.eventType, Dimension: k,
-			Metric: float64(v), KeyJoin: r.keyJoin, dims: combo(r.dims, r.multiDims), Interval: r.dtime.Sub(ot),
+			Metric: float64(v), KeyJoin: r.keyJoin, dims: combo(r.multiDims), Interval: r.dtime.Sub(ot),
 			Count: count[k], Min: min[k], Max: max[k], Provider: prov[k],
 		})
 		total += v

--- a/pkg/rollup/unique.go
+++ b/pkg/rollup/unique.go
@@ -159,7 +159,7 @@ func (r *UniqueRollup) exportUnique(uniques map[string]gohll.HLL, count map[stri
 	for k, v := range uniques {
 		keys = append(keys, Rollup{
 			Name: r.name, EventType: r.eventType, Dimension: k,
-			Metric: float64(v.EstimateCardinality()), KeyJoin: r.keyJoin, dims: combo(r.dims, r.multiDims), Interval: r.dtime.Sub(ot),
+			Metric: float64(v.EstimateCardinality()), KeyJoin: r.keyJoin, dims: combo(r.multiDims), Interval: r.dtime.Sub(ot),
 			Count: count[k], Provider: prov[k],
 		})
 		totalc += count[k]


### PR DESCRIPTION
This refactors how rollup dimensions work. Previously, multiple and single dimensions were treated separately. This lead to some bugs around how to keep the correct ordering. Now they are all the same and ordering comes for free. 