### PR TITLE
Adding in ult exit data when present

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -72,7 +72,7 @@ func init() {
 	flag.IntVar(&threads, "threads", 1, "Number of threads to run for processing")
 	flag.IntVar(&threadsInput, "input_threads", 1, "Number of threads to run for input processing")
 	flag.IntVar(&maxThreads, "max_threads", 1, "Dynamically grow threads up to this number")
-	flag.StringVar(&format, "format", "flat_json", "Format to convert kflow to: (json|flat_json|avro|netflow|influx|carbon|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow|ddog)")
+	flag.StringVar(&format, "format", "flat_json", "Format to convert kflow to: (json|flat_json|avro|netflow|influx|carbon|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow|ddog|otel|snmp|parquet)")
 	flag.StringVar(&formatRollup, "format_rollup", "", "Format to convert rollups to: (json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow|parquet)")
 	flag.StringVar(&formatMetric, "format_metric", "", "Format to convert metrics to: (json|avro|netflow|influx|prometheus|new_relic|new_relic_metric|splunk|elasticsearch|kflow|parquet)")
 	flag.StringVar(&compression, "compression", "none", "compression algo to use (none|gzip|snappy|deflate|null)")

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -387,6 +387,18 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 		}
 	}
 
+	// Check if there is ultimate exit data and pull this in also.
+	if udid, ok := dst.CustomInt["ult_exit_device_id"]; ok {
+		if d := kc.apic.GetDevice(dst.CompanyId, kt.DeviceID(udid)); d != nil {
+			if ui, ok := dst.CustomInt["ult_exit_port"]; ok {
+				if i, ok := d.Interfaces[kt.IfaceID(ui)]; ok {
+					dst.CustomStr["ult_exit_port_alias"] = i.Alias
+					dst.CustomStr["ult_exit_port_description"] = i.Description
+				}
+			}
+		}
+	}
+
 	// Do we need to remap any of the custom strings?
 	for k, v := range dst.CustomStr {
 		switch dst.CustomStr[UDR_TYPE] { // Kick out any cross contaminated tags.

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -265,6 +265,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 				dst.CustomInt[name] = int32(v)
 				if d := kc.apic.GetDevice(dst.CompanyId, kt.DeviceID(v)); d != nil {
 					dst.CustomStr["ult_exit_device"] = d.Name
+					dst.CustomStr["ult_device_site"] = d.Site.SiteName
 				}
 			default:
 				if tk, tv, ok := kc.tagMap.LookupTagValue(dst.CompanyId, v, name); ok {
@@ -387,13 +388,14 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 		}
 	}
 
-	// Check if there is ultimate exit data and pull this in also.
+	// Check if there is ultimate exit data interface and pull this in also.
 	if udid, ok := dst.CustomInt["ult_exit_device_id"]; ok {
 		if d := kc.apic.GetDevice(dst.CompanyId, kt.DeviceID(udid)); d != nil {
 			if ui, ok := dst.CustomInt["ult_exit_port"]; ok {
 				if i, ok := d.Interfaces[kt.IfaceID(ui)]; ok {
 					dst.CustomStr["ult_exit_port_alias"] = i.Alias
 					dst.CustomStr["ult_exit_port_description"] = i.Description
+					dst.CustomStr["ult_exit_port_provider"] = i.Provider
 				}
 			}
 		}


### PR DESCRIPTION
This will add in `ult_exit_port_alias` and `ult_exit_port_description` when Ultimate Exit data is present for a given device. 

Closes #759 