### PR TITLE
Add no_use_bulkwalkall as an option for discovered devices

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -216,14 +216,15 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 		for _, config := range v3configs { // Now loop over all the possible configs.
 			testConfig := config // Capture this as a local var.
 			device = kt.SnmpDeviceConfig{
-				DeviceName: result.Name,
-				DeviceIP:   result.Host.String(),
-				Community:  "", // Run using v3 here.
-				UseV1:      conf.Disco.UseV1,
-				V3:         testConfig,
-				Debug:      conf.Disco.Debug,
-				Port:       uint16(conf.Disco.Ports[0]),
-				Checked:    time.Now(),
+				DeviceName:       result.Name,
+				DeviceIP:         result.Host.String(),
+				Community:        "", // Run using v3 here.
+				UseV1:            conf.Disco.UseV1,
+				V3:               testConfig,
+				Debug:            conf.Disco.Debug,
+				Port:             uint16(conf.Disco.Ports[0]),
+				Checked:          time.Now(),
+				NoUseBulkWalkAll: conf.Disco.NoUseBulkWalkAll,
 			}
 			serv, err := snmp_util.InitSNMP(&device, timeout, conf.Global.Retries, posit, log)
 			if err != nil {
@@ -249,13 +250,14 @@ func doubleCheckHost(result scan.Result, timeout time.Duration, ctl chan bool, m
 		for _, usev1 := range versions {
 			for _, community := range conf.Disco.DefaultCommunities {
 				device = kt.SnmpDeviceConfig{
-					DeviceName: result.Name,
-					DeviceIP:   result.Host.String(),
-					Community:  community,
-					UseV1:      usev1,
-					Debug:      conf.Disco.Debug,
-					Port:       uint16(conf.Disco.Ports[0]),
-					Checked:    time.Now(),
+					DeviceName:       result.Name,
+					DeviceIP:         result.Host.String(),
+					Community:        community,
+					UseV1:            usev1,
+					Debug:            conf.Disco.Debug,
+					Port:             uint16(conf.Disco.Ports[0]),
+					Checked:          time.Now(),
+					NoUseBulkWalkAll: conf.Disco.NoUseBulkWalkAll,
 				}
 				serv, err := snmp_util.InitSNMP(&device, timeout, conf.Global.Retries, posit, log)
 				if err != nil {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -257,6 +257,7 @@ type SnmpDiscoConfig struct {
 	Kentik             *KentikDisco    `yaml:"kentik"`
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`
+	NoUseBulkWalkAll   bool            `yaml:"no_use_bulkwalkall"`
 }
 
 type ProviderMap struct {


### PR DESCRIPTION
Adding a config value to snmp disco to set the no_use_bulkwalkall value for all discovered devices.

Closes #764 

When there's a disco config like this

```yaml
discovery:
    cidrs:
        - 1.2.3.4/28
    ignore_list: []
    debug: false
    ports:
        - 161
    default_communities: []
    use_snmp_v1: false
    default_v3: aws.sm.my-secret-snmp-creds
    add_devices: true
    add_mibs: true
    threads: 4
    replace_devices: true
    check_all_ips: true
    kentik: null
    no_use_bulkwalkall: true
```

All discovered devices will have `no_use_bulkwalkall` set to true. 

NOTE: if you later on change `no_use_bulkwalkall` to false in the disco section the discovered devices will continue to have it set to true. 