### PR TITLE
Allow logs to be send to http and otel sinks.

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -556,6 +556,8 @@ func applyFlags(cfg *ktranslate.Config) error {
 			// pkg/sinks/http
 			case "http_url":
 				cfg.HTTPSink.Target = val
+			case "http_log_url":
+				cfg.HTTPSink.TargetLogs = val
 			case "http_insecure":
 				v, err := strconv.ParseBool(val)
 				if err != nil {

--- a/config.go
+++ b/config.go
@@ -115,6 +115,7 @@ type GCloudPubSubSinkConfig struct {
 // HTTPSinkConfig is the config for the HTTP sink
 type HTTPSinkConfig struct {
 	Target             string
+	TargetLogs         string
 	Headers            []string
 	InsecureSkipVerify bool
 	TimeoutInSeconds   int
@@ -440,6 +441,7 @@ func DefaultConfig() *Config {
 		},
 		HTTPSink: &HTTPSinkConfig{
 			Target:             "http://localhost:8086/write?db=kentik",
+			TargetLogs:         "http://localhost:8088/services/collector/event",
 			Headers:            []string{},
 			InsecureSkipVerify: false,
 			TimeoutInSeconds:   30,

--- a/pkg/cat/logs.go
+++ b/pkg/cat/logs.go
@@ -1,0 +1,24 @@
+package cat
+
+import (
+	"context"
+)
+
+func (kc *KTranslate) splitLogsForSinks(ctx context.Context) {
+	if kc.logTee == nil || len(kc.logTeeSinks) == 0 {
+		return
+	}
+	kc.log.Infof("splitLogsForSinks running with %d splits", len(kc.logTeeSinks))
+
+	for {
+		select {
+		case log := <-kc.logTee:
+			for _, c := range kc.logTeeSinks {
+				c <- log
+			}
+		case <-ctx.Done():
+			kc.log.Infof("splitLogsForSinks Done")
+			return
+		}
+	}
+}

--- a/pkg/cat/types.go
+++ b/pkg/cat/types.go
@@ -78,6 +78,7 @@ type KTranslate struct {
 	http         *http.KentikHttpListener
 	enricher     *enrich.Enricher
 	logTee       chan string
+	logTeeSinks  []chan string
 	authConfig   *auth.AuthConfig
 	confMgr      config.ConfigManager
 	shutdown     func(string)

--- a/pkg/formats/otel/log_handler.go
+++ b/pkg/formats/otel/log_handler.go
@@ -111,7 +111,7 @@ func (ol *OtelLogger) watchForClose(ctx context.Context, loggerProvider *sdk.Log
 		select {
 		case <-ctx.Done():
 			// gracefully shutdown logger to flush accumulated signals before program finish
-			ol.log.Infof("Done with Trap Logger.")
+			ol.log.Infof("Done with Log Logger.")
 			loggerProvider.Shutdown(ctx)
 			return
 		}

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -70,6 +70,7 @@ const (
 	ProviderHttpDevice         Provider = "kentik-http"
 	ProviderMerakiCloud        Provider = "meraki-cloud-controller"
 	ProviderKflow              Provider = "kentik-kflow"
+	ProviderLogs               Provider = "kentik-logs"
 )
 
 const (

--- a/pkg/sinks/http/http.go
+++ b/pkg/sinks/http/http.go
@@ -158,8 +158,9 @@ func (s *HttpSink) Close() {}
 
 func (s *HttpSink) HttpInfo() map[string]float64 {
 	return map[string]float64{
-		"DeliveryErr": s.metrics.DeliveryErr.Rate1(),
-		"DeliveryWin": s.metrics.DeliveryWin.Rate1(),
+		"DeliveryErr":  s.metrics.DeliveryErr.Rate1(),
+		"DeliveryWin":  s.metrics.DeliveryWin.Rate1(),
+		"DeliveryLogs": s.metrics.DeliveryLogs.Rate1(),
 	}
 }
 

--- a/pkg/sinks/otel/otel.go
+++ b/pkg/sinks/otel/otel.go
@@ -1,0 +1,88 @@
+package otel
+
+import (
+	"context"
+	"log/slog"
+
+	jsoniter "github.com/json-iterator/go"
+	go_metrics "github.com/kentik/go-metrics"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/formats"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+/**
+This is a stub sink because otel format handles most of the outputs.
+
+Just here to allow logs and syslog values from the logTee to go outbound.
+*/
+
+var json = jsoniter.ConfigFastest
+
+const (
+	HttpHostname = "ktranslate"
+)
+
+type OtelSink struct {
+	logger.ContextL
+
+	registry go_metrics.Registry
+	metrics  *OtelMetric
+	logTee   chan string
+}
+
+type OtelMetric struct {
+	DeliveryLogs go_metrics.Meter
+}
+
+func NewSink(log logger.Underlying, registry go_metrics.Registry, logTee chan string) (*OtelSink, error) {
+	nr := OtelSink{
+		ContextL: logger.NewContextLFromUnderlying(logger.SContext{S: "otelSink"}, log),
+		registry: registry,
+		metrics: &OtelMetric{
+			DeliveryLogs: go_metrics.GetOrRegisterMeter("delivery_logs_otel", registry),
+		},
+		logTee: logTee,
+	}
+
+	return &nr, nil
+}
+
+func (s *OtelSink) Init(ctx context.Context, format formats.Format, compression kt.Compression, fmtr formats.Formatter) error {
+
+	// Send logs on if this is set.
+	if s.logTee != nil {
+		go s.watchLogs(ctx)
+	}
+
+	s.Infof("Exporting logs via otel")
+	return nil
+}
+
+func (s *OtelSink) Send(ctx context.Context, payload *kt.Output) {
+	// Noop here because we don't expect to send anything from otel format.
+}
+
+func (s *OtelSink) Close() {}
+
+func (s *OtelSink) HttpInfo() map[string]float64 {
+	return map[string]float64{
+		"DeliveryLogs": s.metrics.DeliveryLogs.Rate1(),
+	}
+}
+
+// Forwards any logs recieved to the NR log API.
+func (s *OtelSink) watchLogs(ctx context.Context) {
+	s.Infof("Receiving logs...")
+	for {
+		select {
+		case log := <-s.logTee:
+			slog.LogAttrs(ctx, slog.LevelInfo, log)
+			s.metrics.DeliveryLogs.Mark(1)
+		case <-ctx.Done():
+			s.Infof("Logs received")
+			return
+		}
+	}
+}

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kentik/ktranslate/pkg/sinks/net"
 	"github.com/kentik/ktranslate/pkg/sinks/nr"
 	"github.com/kentik/ktranslate/pkg/sinks/nrmulti"
+	"github.com/kentik/ktranslate/pkg/sinks/otel"
 	"github.com/kentik/ktranslate/pkg/sinks/prom"
 	"github.com/kentik/ktranslate/pkg/sinks/s3"
 	"github.com/kentik/ktranslate/pkg/sinks/stdout"
@@ -55,6 +56,7 @@ const (
 	GCPPubSub          = "gcppubsub"
 	NewRelicMulti      = "new_relic_multi"
 	DDogSink           = "ddog"
+	OtelSink           = "otel"
 )
 
 func NewSink(sink Sink, log logger.Underlying, registry go_metrics.Registry, tooBig chan int, logTee chan string, config *ktranslate.Config) (SinkImpl, error) {
@@ -85,6 +87,8 @@ func NewSink(sink Sink, log logger.Underlying, registry go_metrics.Registry, too
 		return gcppubsub.NewSink(log, registry, config.GCloudPubSubSink)
 	case NewRelicMulti:
 		return nrmulti.NewSink(log, registry, tooBig, logTee, config.NewRelicSink, config.NewRelicMultiSink)
+	case OtelSink:
+		return otel.NewSink(log, registry, logTee)
 	}
 	return nil, fmt.Errorf("Unknown sink %v", sink)
 }

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -74,7 +74,7 @@ func NewSink(sink Sink, log logger.Underlying, registry go_metrics.Registry, too
 	case NetSink:
 		return net.NewSink(log, registry, config.NetSink)
 	case HttpSink, SplunkSink:
-		return http.NewSink(log, registry, string(sink), config.HTTPSink)
+		return http.NewSink(log, registry, string(sink), config.HTTPSink, logTee)
 	case PromSink:
 		return prom.NewSink(log, registry, config.PrometheusSink)
 	case S3Sink:


### PR DESCRIPTION
Allows the http sink to send logs, including syslog out. An example for splunk would be:

```
./bin/ktranslate -syslog.source 0.0.0.0:5143 -http_insecure -sinks http,stdout -http_header "Authorization: Splunk xxx-xx-xx-xxx-XXXXX" -http_url https://xxx.splunkcloud.com:8088/services/collector/event -http_log_url https://xxx.splunkcloud.com:8088/services/collector/event
```

Tested and working with splunk cloud. Also tested and working with otel/grafana. 

