### PR TITLE
Allow dimensions to be joined together in rollups.

### DIFF
--- a/pkg/rollup/rollup.go
+++ b/pkg/rollup/rollup.go
@@ -178,7 +178,7 @@ type rollupBase struct {
 	metrics      []string
 	multiMetrics [][]string
 	multiDims    [][]string
-	splitDims    map[string][]string
+	splitDims    map[int]splitDim
 	keyJoin      string
 	topK         int
 	eventType    string
@@ -190,34 +190,43 @@ type rollupBase struct {
 	hasFilters   bool
 }
 
+type splitDim struct {
+	lhs  []string
+	join string
+	rhs  []string
+}
+
 func (r *rollupBase) init(rd RollupDef) error {
 	r.metrics = make([]string, 0)
 	r.multiMetrics = make([][]string, 0)
 	r.multiDims = make([][]string, 0)
-	r.splitDims = map[string][]string{}
+	r.splitDims = map[int]splitDim{}
 	r.dtime = time.Now()
 	r.name = rd.Name
 	r.eventType = strings.ReplaceAll(fmt.Sprintf(KENTIK_EVENT_TYPE, strings.Join(rd.Metrics, "_"), strings.Join(rd.Dimensions, ":")), ".", "_")
 	r.sample = rd.Sample
 
-	for _, d := range rd.Dimensions {
+	for i, d := range rd.Dimensions {
 		if strings.Contains(d, DimJoinToken) {
 			joins := strings.SplitN(d, DimJoinToken, 3)
 			if len(joins) == 3 {
-				lht := joins[0]
-				token := joins[1]
-				rhs := joins[2]
-				r.splitDims[d] = joins
+				lhs := strings.Split(joins[0], ".")
+				join := joins[1]
+				rhs := strings.Split(joins[2], ".")
+				r.splitDims[i] = splitDim{lhs: lhs, join: join, rhs: rhs}
+				r.multiDims = append(r.multiDims, []string{d})
+			} else {
+				return fmt.Errorf("Invalid dimension grouping: %s", d)
 			}
-		}
-
-		pts := strings.Split(d, ".")
-		r.multiDims = append(r.multiDims, pts)
-		switch len(pts) {
-		case 1: // noop
-		case 2: // noop
-		default:
-			return fmt.Errorf("Invalid dimension: %s", d)
+		} else {
+			pts := strings.Split(d, ".")
+			r.multiDims = append(r.multiDims, pts)
+			switch len(pts) {
+			case 1: // noop
+			case 2: // noop
+			default:
+				return fmt.Errorf("Invalid dimension: %s", d)
+			}
 		}
 	}
 
@@ -238,42 +247,53 @@ func (r *rollupBase) init(rd RollupDef) error {
 
 func (r *rollupBase) getKey(mapr map[string]interface{}) string {
 	keyPts := make([]string, len(r.multiDims))
-	for i, d := range r.multiDims {
+
+	setKey := func(d []string) string {
+		key := ""
 		if len(d) == 1 {
 			if dd, ok := mapr[d[0]]; ok {
 				switch v := dd.(type) {
 				case string:
-					keyPts[i] = v
+					key = v
 				case int64:
-					keyPts[i] = strconv.Itoa(int(v))
+					key = strconv.Itoa(int(v))
 				default:
 					// Skip?
 				}
-			}
-			if keepUndefined && keyPts[i] == "" {
-				keyPts[i] = UndefinedKey
 			}
 		} else {
 			if d1, ok := mapr[d[0]]; ok {
 				switch dd := d1.(type) {
 				case map[string]string:
-					keyPts[i] = dd[d[1]]
-					if keyPts[i] == "" {
+					key = dd[d[1]]
+					if key == "" {
 						if strings.HasPrefix(d[1], "source_") {
-							keyPts[i] = dd["dest_"+d[1][7:]]
+							key = dd["dest_"+d[1][7:]]
 						} else if strings.HasPrefix(d[1], "dest_") {
-							keyPts[i] = dd["source_"+d[1][5:]]
+							key = dd["source_"+d[1][5:]]
 						}
 					}
 				case map[string]int32:
-					keyPts[i] = strconv.Itoa(int(dd[d[1]]))
+					key = strconv.Itoa(int(dd[d[1]]))
 				case map[string]int64:
-					keyPts[i] = strconv.Itoa(int(dd[d[1]]))
+					key = strconv.Itoa(int(dd[d[1]]))
 				}
 			}
-			if keepUndefined && keyPts[i] == "" {
-				keyPts[i] = UndefinedKey
-			}
+		}
+		if keepUndefined && key == "" {
+			key = UndefinedKey
+		}
+		return key
+	}
+
+	for i, d := range r.multiDims {
+		if md, ok := r.splitDims[i]; !ok {
+			keyPts[i] = setKey(d) // There's no join so just go here.
+		} else {
+			// We're doing a join so have to get a few keys at once.
+			lhs := setKey(md.lhs)
+			rhs := setKey(md.rhs)
+			keyPts[i] = lhs + md.join + rhs
 		}
 	}
 

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -42,6 +42,12 @@ func TestRollup(t *testing.T) {
 			Formats:       []string{"sum,sum_bytes_in,in_bytes,ccc,custom_str.foo,bar"},
 			KeepUndefined: false,
 		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          1,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,aaa$$---$$bbb,ccc"},
+			KeepUndefined: true,
+		},
 	}
 
 	inputs := [][]map[string]interface{}{
@@ -121,6 +127,24 @@ func TestRollup(t *testing.T) {
 				"provider":    kt.Provider("pp"),
 			},
 		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(30),
+				"aaa":         "aaa",
+				"bbb":         "bbb",
+				"ccc":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"custom_str":  map[string]string{"foo": "ddd"},
+				"aaa":         "aaa",
+				"bbb":         "bbb",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
 	}
 
 	outputs := []map[string]interface{}{
@@ -139,6 +163,10 @@ func TestRollup(t *testing.T) {
 		map[string]interface{}{
 			"metric":     75,
 			"dimensions": []string{"fff", "ddd", "ccc"},
+		},
+		map[string]interface{}{
+			"metric":     30,
+			"dimensions": []string{"aaa--bbb", "ccc"},
 		},
 	}
 

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -48,6 +48,12 @@ func TestRollup(t *testing.T) {
 			Formats:       []string{"sum,sum_bytes_in,in_bytes,aaa$$---$$bbb,ccc"},
 			KeepUndefined: true,
 		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          1,
+			Formats:       []string{"sum,sum_bytes_in,in_bytes,ccc,custom_str.aaa$$---$$custom_str.bbb"},
+			KeepUndefined: true,
+		},
 	}
 
 	inputs := [][]map[string]interface{}{
@@ -145,6 +151,22 @@ func TestRollup(t *testing.T) {
 				"provider":    kt.Provider("pp"),
 			},
 		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(30),
+				"custom_str":  map[string]string{"aaa": "aaa", "bbb": "bbb"},
+				"ccc":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"custom_str":  map[string]string{"aaa": "aaa", "bbb": "bbb"},
+				"ccc":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
 	}
 
 	outputs := []map[string]interface{}{
@@ -166,7 +188,11 @@ func TestRollup(t *testing.T) {
 		},
 		map[string]interface{}{
 			"metric":     30,
-			"dimensions": []string{"aaa--bbb", "ccc"},
+			"dimensions": []string{"aaa---bbb", "ccc"},
+		},
+		map[string]interface{}{
+			"metric":     40,
+			"dimensions": []string{"ccc", "aaa---bbb"},
 		},
 	}
 


### PR DESCRIPTION
We have a customer request to allow rollups to merge 2 dimensions into one. For example, given the definition here:

```
sum,sum_bytes_in,in_bytes,aaa$$---$$bbb,ccc
```

dimensions aaa and bbb would be merged together into aaa---bbb. The `$$` token is used to wrap the inner join token, which in the above example is `---`. 

@kentik-rbarnes , your thoughts too? 

NOTE: this version only supports grouping 2 dimensions into 1. Is this OK or do we need to be able to merge N dimensions into 1? 