### PR TITLE
No buffer mode for parquet files which can not be appended to

### DIFF
--- a/pkg/formats/parquet/parquet.go
+++ b/pkg/formats/parquet/parquet.go
@@ -98,7 +98,7 @@ func (f *ParquetFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 	}
 	fw.Close()
 
-	return kt.NewOutput(fw.Bytes()), nil
+	return kt.NewOutputNoBuffer(fw.Bytes()), nil
 }
 
 func (f *ParquetFormat) From(raw *kt.Output) ([]map[string]interface{}, error) {
@@ -194,7 +194,7 @@ func (f *ParquetFormat) Rollup(rolls []rollup.Rollup) (*kt.Output, error) {
 	}
 	fw.Close()
 
-	return kt.NewOutput(fw.Bytes()), nil
+	return kt.NewOutputNoBuffer(fw.Bytes()), nil
 }
 
 func (f *ParquetFormat) toParquetMetricRollup(in []rollup.Rollup, ts int64) []ParquetMetric {

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -353,9 +353,10 @@ type OutputContext struct {
 }
 
 type Output struct {
-	Body []byte
-	Ctx  OutputContext
-	CB   func(error) // Called when this is sent to a sink.
+	Body     []byte
+	Ctx      OutputContext
+	CB       func(error) // Called when this is sent to a sink.
+	NoBuffer bool        // If true, write out right away.
 }
 
 func NewOutput(body []byte) *Output {
@@ -368,6 +369,10 @@ func NewOutputWithProvider(body []byte, prov Provider, stype OutputType) *Output
 
 func NewOutputWithProviderAndCompanySender(body []byte, prov Provider, cid Cid, stype OutputType, senderid string) *Output {
 	return &Output{Body: body, Ctx: OutputContext{Provider: prov, Type: stype, CompanyId: cid, SenderId: senderid}}
+}
+
+func NewOutputNoBuffer(body []byte) *Output {
+	return &Output{Body: body, NoBuffer: true}
 }
 
 func (o *Output) IsEvent() bool {

--- a/pkg/sinks/file/file.go
+++ b/pkg/sinks/file/file.go
@@ -89,7 +89,7 @@ func (s *FileSink) Init(ctx context.Context, format formats.Format, compression 
 
 func (s *FileSink) Send(ctx context.Context, payload *kt.Output) {
 	// In the un-buffered case, write this out right away.
-	if payload.NoBuffer {
+	if payload.NoBuffer && len(payload.Body) > 0 {
 		go s.writeFileNow(ctx, payload.Body)
 		return
 	}

--- a/pkg/sinks/gcloud/gcloud.go
+++ b/pkg/sinks/gcloud/gcloud.go
@@ -116,6 +116,12 @@ func (s *GCloudSink) Init(ctx context.Context, format formats.Format, compressio
 }
 
 func (s *GCloudSink) Send(ctx context.Context, payload *kt.Output) {
+	// In the un-buffered case, write this out right away.
+	if payload.NoBuffer && len(payload.Body) > 0 {
+		go s.send(ctx, payload.Body)
+		return
+	}
+
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.buf.Write(payload.Body)

--- a/pkg/sinks/s3/s3.go
+++ b/pkg/sinks/s3/s3.go
@@ -165,6 +165,13 @@ func (s *S3Sink) Init(ctx context.Context, format formats.Format, compression kt
 }
 
 func (s *S3Sink) Send(ctx context.Context, payload *kt.Output) {
+	// In the un-buffered case, write this out right away.
+	if payload.NoBuffer {
+		go s.send(ctx, payload.Body)
+		return
+	}
+
+	// Else queue up for more efficient sending.
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.buf.Write(payload.Body)

--- a/pkg/sinks/s3/s3.go
+++ b/pkg/sinks/s3/s3.go
@@ -166,7 +166,7 @@ func (s *S3Sink) Init(ctx context.Context, format formats.Format, compression kt
 
 func (s *S3Sink) Send(ctx context.Context, payload *kt.Output) {
 	// In the un-buffered case, write this out right away.
-	if payload.NoBuffer {
+	if payload.NoBuffer && len(payload.Body) > 0 {
 		go s.send(ctx, payload.Body)
 		return
 	}


### PR DESCRIPTION
Fixes a bug where parquet files will get corrupted because you can't just append one to another.

Adds a new type of data option which forces sinks to flush the data right away instead of buffering. 

@kentik-rbarnes this is the fix you're waiting on. 