### PR TITLE
fixing a case where some oid values do not get matched in disco

### DIFF
--- a/pkg/inputs/snmp/metadata/device_metadata.go
+++ b/pkg/inputs/snmp/metadata/device_metadata.go
@@ -164,10 +164,17 @@ func (dm *DeviceMetadata) poll(ctx context.Context, server *gosnmp.GoSNMP) (*kt.
 		case SNMP_sysDescr:
 			md.SysDescr = string(value.([]byte))
 		case SNMP_sysObjectID:
-			if s, ok := value.(string); ok {
-				md.SysObjectID = s
-			} else if s, ok := value.([]byte); ok {
-				md.SysObjectID = string(s)
+			switch sd := value.(type) {
+			case string:
+				md.SysObjectID = sd
+			case []byte:
+				md.SysObjectID = string(sd)
+			default:
+				if wrapper.variable.Type == gosnmp.ObjectIdentifier {
+					md.SysObjectID = string(sd.(string))
+				} else {
+					dm.log.Warnf("Unknown type for sysoid: %v %T", value, value)
+				}
 			}
 		case SNMP_sysContact:
 			md.SysContact = string(value.([]byte))
@@ -319,10 +326,17 @@ func GetBasicDeviceMetadata(log logger.ContextL, server *gosnmp.GoSNMP) (*kt.Dev
 		case SNMP_sysDescr:
 			md.SysDescr = string(value.([]byte))
 		case SNMP_sysObjectID:
-			if s, ok := value.(string); ok {
-				md.SysObjectID = s
-			} else if s, ok := value.([]byte); ok {
-				md.SysObjectID = string(s)
+			switch sd := value.(type) {
+			case string:
+				md.SysObjectID = sd
+			case []byte:
+				md.SysObjectID = string(sd)
+			default:
+				if pdu.Type == gosnmp.ObjectIdentifier {
+					md.SysObjectID = string(sd.(string))
+				} else {
+					log.Warnf("Unknown type for sysoid: %v %T", value, value)
+				}
 			}
 		case SNMP_sysContact:
 			md.SysContact = string(value.([]byte))


### PR DESCRIPTION
For an oid like `SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.119.1.84.16.1` disco wasn't matching correctly. This should parse it as a string. 

Causes the disco to add the device but not pull in the correct profile. 