### PR TITLE
Fixing the -- option for snmp disco

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -54,8 +54,11 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 	}
 
 	if v := cfg.OutputFile; v != "" { // If we want to write somewhere else, swap the output file in here.
+		err := initOutputFile(ctx, log, v, conf, snmpFile)
+		if err != nil {
+			return nil, err
+		}
 		snmpFile = v
-		log.Infof("Writing snmp config file to %s.", v)
 	}
 
 	if conf.Disco.AddDevices { // Verify that the output is writeable before diving into discoing.

--- a/pkg/inputs/snmp/output.go
+++ b/pkg/inputs/snmp/output.go
@@ -1,0 +1,22 @@
+package snmp
+
+import (
+	"context"
+	"os"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+var (
+	snmpConfPerms os.FileMode = 0664
+)
+
+func initOutputFile(ctx context.Context, log logger.ContextL, outputFile string, conf *kt.SnmpConfig, origSnmpFile string) error {
+	log.Infof("Writing snmp config file to %s.", outputFile)
+	data, err := os.ReadFile(origSnmpFile)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputFile, data, snmpConfPerms)
+}


### PR DESCRIPTION
closes #772 

This fixes all of the reported failures in the `--snmp_out_file` flag being used. Depends on a valid snmp.yaml file being provided as input but I think this is reasonable. 