### PR TITLE
Adding a first ping so that its not 2x the period to get first pings

### DIFF
--- a/pkg/inputs/snmp/metrics/poll.go
+++ b/pkg/inputs/snmp/metrics/poll.go
@@ -293,6 +293,19 @@ func (p *Poller) StartPingOnlyLoop(ctx context.Context) {
 	go func() {
 		seenGoodPacketLoss := true
 		runningFast := false
+
+		// Run one ping first.
+		go func() {
+			flows, _, err := p.deviceMetrics.GetPingStats(ctx, p.pinger)
+			if err != nil {
+				p.log.Warnf("There was an error when getting ping stats: %v.", err)
+			}
+
+			// Send data on.
+			p.jchfChan <- flows
+		}()
+
+		// And now wait for the normal ticker to go.
 		for {
 			select {
 			case _ = <-counterCheck.C:


### PR DESCRIPTION
Right now its 2x the ping period to get first results back. This ads an extra ping when things start so its only 1x to get first results into the system. 