### PR TITLE
Now adding in service_name value when flow is seen from unkown

### DIFF
--- a/pkg/cat/auth/auth.go
+++ b/pkg/cat/auth/auth.go
@@ -81,6 +81,15 @@ func NewServer(auth *AuthConfig, snmpFile string, log logger.ContextL, serviceNa
 				s.devicesByID[strconv.Itoa(int(nd.ID))] = nd
 				nextID += 100
 			}
+
+			// Now add a blank missing device device.
+			nd := &kt.Device{
+				ID:         nextID,
+				Name:       kt.MissingDeviceName,
+				SendingIps: []net.IP{net.ParseIP(kt.MissingDeviceIP)},
+			}
+			nd.InitUserTags(serviceName, map[string]string{})
+			s.devicesByID[strconv.Itoa(int(nd.ID))] = nd
 		}
 	}
 

--- a/pkg/inputs/flow/format.go
+++ b/pkg/inputs/flow/format.go
@@ -218,6 +218,9 @@ func (t *KentikDriver) toJCHF(fmsg *pp.ProtoProducerMessage) *kt.JCHF {
 				in.DeviceName = dm
 			}
 		}
+		if mdev, ok := t.devices[kt.MissingDeviceIP]; ok {
+			mdev.SetUserTags(in.CustomStr)
+		}
 	}
 
 	if _, ok := t.metrics[in.DeviceName]; !ok {

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -91,6 +91,9 @@ const (
 	GaugeMetric    = "gauge"
 	CountMetric    = "count"
 	FromGCP        = "gcppubsub"
+
+	MissingDeviceName = "KT_MISSING_DEVICE"
+	MissingDeviceIP   = "1.1.1.255"
 )
 
 type IntId uint64


### PR DESCRIPTION
When processing netflow, ktrans will drop the service_name tag unless the flow is from a known device. This adds in a "missing device" device so there's always a service_name value set. 