### PR TITLE
Allow netbox to be a source of truth in discovering devices.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/liamg/furious v0.0.0-20191231090757-c295c872d6c1
 	github.com/linkedin/goavro/v2 v2.10.1
 	github.com/montanaflynn/stats v0.7.0
+	github.com/netbox-community/go-netbox/v4 v4.2.2-3
 	github.com/netsampler/goflow2/v2 v2.1.3
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -717,6 +717,8 @@ github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a h1:AfneHvfmYgUIcgdUrrDFklLdEzQAvG9AKRTe1x1mx/0=
 github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a/go.mod h1:jZxafo9CAqaKFQE4zitrg5QNlA6CXUsjwXPlIppF3tk=
 github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/netbox-community/go-netbox/v4 v4.2.2-3 h1:NrAkuI41ExiYa6p1o7F0NvxcS2qxsVJfymR5hAZglDs=
+github.com/netbox-community/go-netbox/v4 v4.2.2-3/go.mod h1:X7jbSuzejM0U5uy/ajXidRFEAshl6eKqrcinhMy4aAI=
 github.com/netsampler/goflow2/v2 v2.1.3 h1:glfeG2hIzFlAmEz236nZIAWi848AB+p1pJnuQqiyLkI=
 github.com/netsampler/goflow2/v2 v2.1.3/go.mod h1:94ZaxfHuUwG6KviCxMWuZIvz0UGu657StE/g83hlS8A=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -94,7 +94,7 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
 	if conf.Disco.NetboxAPIHost != "" {
-		log.Infof("Discovering devices from Netbox with tag %s", conf.Disco.NetboxTag)
+		log.Infof("Discovering devices from Netbox with tag [%s] and site [%s]", conf.Disco.NetboxTag, conf.Disco.NetboxSite)
 		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
 		if err != nil {
 			return nil, err

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -93,8 +93,8 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 	}
 
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
-	if conf.Disco.NetboxAPIHost != "" {
-		log.Infof("Discovering devices from Netbox with tag [%s] and site [%s]", conf.Disco.NetboxTag, conf.Disco.NetboxSite)
+	if conf.Disco.Netbox != nil && conf.Disco.Netbox.NetboxAPIHost != "" {
+		log.Infof("Discovering devices from Netbox with tag [%s] and site [%s]", conf.Disco.Netbox.NetboxTag, conf.Disco.Netbox.NetboxSite)
 		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
 		if err != nil {
 			return nil, err

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -87,6 +87,14 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 	}
 	defer mdb.Close()
 
+	if conf.Disco.NetboxAPIHost != "" {
+		err = getDevicesFromNetbox(ctx, conf, log)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
 	ignoreMap := map[string]bool{}
 	for _, ip := range conf.Disco.IgnoreList {
 		ignoreMap[ip] = true

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -1,0 +1,32 @@
+package snmp
+
+/**
+Use netbox API to pull down list of devices to target. Get all devices matching a given tag.
+*/
+import (
+	"context"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/kt"
+
+	"github.com/netbox-community/go-netbox/v4"
+)
+
+func getDevicesFromNetbox(ctx context.Context, conf *kt.SnmpConfig, log logger.ContextL) error {
+	c := netbox.NewAPIClientFor(conf.Disco.NetboxAPIHost, conf.Disco.NetboxAPIToken)
+
+	res, _, err := c.DcimAPI.
+		DcimDevicesList(ctx).
+		Status([]string{"active"}).
+		Limit(10).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	log.Infof("%v", res.Results)
+
+	return nil
+
+}

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -23,7 +23,7 @@ import (
 
 func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[string]*kt.SnmpDeviceConfig,
 	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool) error {
-	c := netbox.NewAPIClientFor(conf.Disco.NetboxAPIHost, conf.Disco.NetboxAPIToken.String())
+	c := netbox.NewAPIClientFor(conf.Disco.Netbox.NetboxAPIHost, conf.Disco.Netbox.NetboxAPIToken.String())
 
 	var getDeviceList func(offset int32, results *[]scan.Result) error
 	getDeviceList = func(offset int32, results *[]scan.Result) error {
@@ -41,17 +41,17 @@ func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[s
 		for _, res := range res.Results {
 			keep := true // Default to add all.
 
-			if conf.Disco.NetboxTag != "" {
+			if conf.Disco.Netbox.NetboxTag != "" {
 				keep = false // If we are filtering with tags, only allow those tags which match though.
 				for _, tag := range res.Tags {
-					if tag.Display == conf.Disco.NetboxTag {
+					if tag.Display == conf.Disco.Netbox.NetboxTag {
 						keep = true
 						continue
 					}
 				}
 			}
-			if conf.Disco.NetboxSite != "" { // Furthermore, if we filter with site, only the selected site.
-				if res.Site.GetDisplay() != conf.Disco.NetboxSite {
+			if conf.Disco.Netbox.NetboxSite != "" { // Furthermore, if we filter with site, only the selected site.
+				if res.Site.GetDisplay() != conf.Disco.Netbox.NetboxSite {
 					keep = false
 				}
 			}

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -5,28 +5,73 @@ Use netbox API to pull down list of devices to target. Get all devices matching 
 */
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
 
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	"github.com/kentik/ktranslate/pkg/inputs/snmp/mibs"
 	"github.com/kentik/ktranslate/pkg/kt"
 
+	"github.com/liamg/furious/scan"
 	"github.com/netbox-community/go-netbox/v4"
 )
 
-func getDevicesFromNetbox(ctx context.Context, conf *kt.SnmpConfig, log logger.ContextL) error {
+func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[string]*kt.SnmpDeviceConfig,
+	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool) error {
 	c := netbox.NewAPIClientFor(conf.Disco.NetboxAPIHost, conf.Disco.NetboxAPIToken)
 
+	limit := int32(0) // This implies we see all. Do we need to implement paging?
 	res, _, err := c.DcimAPI.
 		DcimDevicesList(ctx).
-		Status([]string{"active"}).
-		Limit(10).
+		Status([]string{"active"}). // Only look at active devices.
+		Limit(limit).
 		Execute()
 
 	if err != nil {
 		return err
 	}
 
-	log.Infof("%v", res.Results)
+	timeout := time.Millisecond * time.Duration(conf.Global.TimeoutMS)
+	stb := time.Now()
+	results := make([]scan.Result, 0)
+	for _, res := range res.Results {
+		hasTag := false
+		for _, tag := range res.Tags {
+			if tag.Display == conf.Disco.NetboxTag {
+				hasTag = true
+				continue
+			}
+		}
+
+		if hasTag && res.PrimaryIp.IsSet() {
+			addr := res.PrimaryIp.Get().GetAddress()
+			ipv, err := netip.ParsePrefix(addr)
+			if err != nil {
+				log.Infof("Skipping %s with bad PrimaryIP: %v", res.Display, addr)
+			} else {
+				results = append(results, scan.Result{Name: res.Display, Manufacturer: res.DeviceType.GetDisplay(), Host: net.ParseIP(ipv.Addr().String())})
+			}
+		}
+
+	}
+
+	var wg sync.WaitGroup
+	var mux sync.RWMutex
+	st := time.Now()
+	log.Infof("Starting to check %d ips from netbox", len(results))
+	for i, result := range results {
+		if ignoreMap[result.Host.String()] { // If we have marked this ip as to be ignored, don't do anything more with it.
+			continue
+		}
+		wg.Add(1)
+		posit := fmt.Sprintf("%d/%d)", i+1, len(results))
+		go doubleCheckHost(result, timeout, ctl, &mux, &wg, foundDevices, mdb, conf, posit, kentikDevices, log)
+	}
+	wg.Wait()
+	log.Infof("Checked %d ips in %v (from start: %v)", len(results), time.Now().Sub(st), time.Now().Sub(stb))
 
 	return nil
-
 }

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -260,6 +260,7 @@ type SnmpDiscoConfig struct {
 	NoUseBulkWalkAll   bool            `yaml:"no_use_bulkwalkall"`
 	NetboxAPIHost      string          `yaml:"netbox_host"`
 	NetboxAPIToken     string          `yaml:"netbox_token"`
+	NetboxTag          string          `yaml:"netbox_tag"`
 }
 
 type ProviderMap struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -271,6 +271,7 @@ type NetboxConfig struct {
 	NetboxAPIToken *SecureToken `yaml:"token"`
 	NetboxTag      string       `yaml:"tag"`
 	NetboxSite     string       `yaml:"site"`
+	NetboxIP       string       `yaml:"ip_to_pick"` // One of primary or oob. Default to primary.
 }
 
 type ProviderMap struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -263,10 +263,14 @@ type SnmpDiscoConfig struct {
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`
 	NoUseBulkWalkAll   bool            `yaml:"no_use_bulkwalkall"`
-	NetboxAPIHost      string          `yaml:"netbox_host"`
-	NetboxAPIToken     *SecureToken    `yaml:"netbox_token"`
-	NetboxTag          string          `yaml:"netbox_tag"`
-	NetboxSite         string          `yaml:"netbox_site"`
+	Netbox             *NetboxConfig   `yaml:"netbox"`
+}
+
+type NetboxConfig struct {
+	NetboxAPIHost  string       `yaml:"host"`
+	NetboxAPIToken *SecureToken `yaml:"token"`
+	NetboxTag      string       `yaml:"tag"`
+	NetboxSite     string       `yaml:"site"`
 }
 
 type ProviderMap struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -258,6 +258,8 @@ type SnmpDiscoConfig struct {
 	CidrOrig           string          `yaml:"-"`
 	IgnoreOrig         string          `yaml:"-"`
 	NoUseBulkWalkAll   bool            `yaml:"no_use_bulkwalkall"`
+	NetboxAPIHost      string          `yaml:"netbox_host"`
+	NetboxAPIToken     string          `yaml:"netbox_token"`
 }
 
 type ProviderMap struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -173,6 +173,11 @@ type MerakiConfig struct {
 	MaxAPIRetry           int             `yaml:"max_http_retry"` // retry up to this many times on 429 errors. Default 2.
 }
 
+type SecureToken struct {
+	origStr string
+	Token   string
+}
+
 // Contain various extensions to snmp which can be used to get data.
 type ExtensionSet struct {
 	ExtOnly      bool          `yaml:"ext_only"`
@@ -259,8 +264,9 @@ type SnmpDiscoConfig struct {
 	IgnoreOrig         string          `yaml:"-"`
 	NoUseBulkWalkAll   bool            `yaml:"no_use_bulkwalkall"`
 	NetboxAPIHost      string          `yaml:"netbox_host"`
-	NetboxAPIToken     string          `yaml:"netbox_token"`
+	NetboxAPIToken     *SecureToken    `yaml:"netbox_token"`
 	NetboxTag          string          `yaml:"netbox_tag"`
+	NetboxSite         string          `yaml:"netbox_site"`
 }
 
 type ProviderMap struct {
@@ -565,6 +571,41 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*a = multi
 	}
 	return nil
+}
+
+func (a *SecureToken) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var orig = ""
+	err := unmarshal(&orig)
+	if err != nil {
+		return err
+	}
+	new := orig
+
+	if strings.HasPrefix(orig, "${") {
+		new = os.Getenv(orig[2 : len(orig)-1])
+	} else if strings.HasPrefix(orig, AwsSmPrefix) { // See if we can pull these out of AWS Secret Manager directly
+		new = loadViaAWSSecrets(orig[len(AwsSmPrefix):])
+	} else if strings.HasPrefix(orig, AzureKVPrefix) { // Same but use Azure.
+		new = loadViaAzureKeyVault(orig[len(AzureKVPrefix):])
+	} else if strings.HasPrefix(orig, GCPSmPrefix) { // And Same again but use GCP.
+		new = loadViaGCPSecrets(orig[len(GCPSmPrefix):])
+	}
+	*a = SecureToken{Token: new, origStr: orig}
+	return nil
+}
+
+func (a *SecureToken) MarshalYAML() (interface{}, error) {
+	if a.origStr != "" {
+		return a.origStr, nil
+	}
+	return "", nil
+}
+
+func (a *SecureToken) String() string {
+	if a == nil {
+		return ""
+	}
+	return string(a.Token)
 }
 
 type V3SNMP V3SNMPConfig // Need a 2nd type alias to avoid stack overflow on parsing.


### PR DESCRIPTION
Given a disco config like

```
discovery:
    cidrs: []
    ignore_list: []
    debug: false
    ports:
        - 161
    default_communities:
        - public
    use_snmp_v1: false
    default_v3: null
    add_devices: true
    add_mibs: false
    threads: 4
    replace_devices: true
    no_dedup_engine_id: true
    kentik: null
    no_use_bulkwalkall: false
    netbox:
        host: https://yyyy.cloud.netboxapp.com
        token: ${NETBOX_TOKEN}
        tag: Foxtrot
        site: Sydney
        ip_to_pick: oob
```

ktranslate will now use netbox to find devices to poll vs doing a network scan. Lets you filter by tag and site. 

`token` can be either written directly into the yaml, passed in via environment variable, or else found via AWS, GCP or Azure vaults. 

`ip_to_pick` is one of primary or oob. 