### PR TITLE
Netbox oauth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/liamg/furious v0.0.0-20191231090757-c295c872d6c1
 	github.com/linkedin/goavro/v2 v2.10.1
 	github.com/montanaflynn/stats v0.7.0
-	github.com/netbox-community/go-netbox/v4 v4.3.0
 	github.com/netsampler/goflow2/v2 v2.1.3
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/pkg/errors v0.9.1
@@ -170,6 +169,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
-	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/liamg/furious v0.0.0-20191231090757-c295c872d6c1
 	github.com/linkedin/goavro/v2 v2.10.1
 	github.com/montanaflynn/stats v0.7.0
-	github.com/netbox-community/go-netbox/v4 v4.2.2-3
+	github.com/netbox-community/go-netbox/v4 v4.3.0
 	github.com/netsampler/goflow2/v2 v2.1.3
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/pkg/errors v0.9.1
@@ -170,5 +170,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
+	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -732,10 +732,6 @@ github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a h1:AfneHvfmYgUIcgdUrrDFklLdEzQAvG9AKRTe1x1mx/0=
 github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a/go.mod h1:jZxafo9CAqaKFQE4zitrg5QNlA6CXUsjwXPlIppF3tk=
 github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/netbox-community/go-netbox/v4 v4.2.2-3 h1:NrAkuI41ExiYa6p1o7F0NvxcS2qxsVJfymR5hAZglDs=
-github.com/netbox-community/go-netbox/v4 v4.2.2-3/go.mod h1:X7jbSuzejM0U5uy/ajXidRFEAshl6eKqrcinhMy4aAI=
-github.com/netbox-community/go-netbox/v4 v4.3.0 h1:1kYHscOJG8+GJobC9OdgXX39zBKrBzUE5bxwMgxdlaQ=
-github.com/netbox-community/go-netbox/v4 v4.3.0/go.mod h1:1r1Dhs2sGD3izwvOBZwggFiEGLvyQ5hNgFR16nxsixg=
 github.com/netsampler/goflow2/v2 v2.1.3 h1:glfeG2hIzFlAmEz236nZIAWi848AB+p1pJnuQqiyLkI=
 github.com/netsampler/goflow2/v2 v2.1.3/go.mod h1:94ZaxfHuUwG6KviCxMWuZIvz0UGu657StE/g83hlS8A=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -1543,8 +1539,6 @@ gopkg.in/jcmturner/gokrb5.v7 v7.3.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuv
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
-gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/mostlygeek/arp v0.0.0-20170424181311-541a2129847a/go.mod h1:jZxafo9CA
 github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/netbox-community/go-netbox/v4 v4.2.2-3 h1:NrAkuI41ExiYa6p1o7F0NvxcS2qxsVJfymR5hAZglDs=
 github.com/netbox-community/go-netbox/v4 v4.2.2-3/go.mod h1:X7jbSuzejM0U5uy/ajXidRFEAshl6eKqrcinhMy4aAI=
+github.com/netbox-community/go-netbox/v4 v4.3.0 h1:1kYHscOJG8+GJobC9OdgXX39zBKrBzUE5bxwMgxdlaQ=
+github.com/netbox-community/go-netbox/v4 v4.3.0/go.mod h1:1r1Dhs2sGD3izwvOBZwggFiEGLvyQ5hNgFR16nxsixg=
 github.com/netsampler/goflow2/v2 v2.1.3 h1:glfeG2hIzFlAmEz236nZIAWi848AB+p1pJnuQqiyLkI=
 github.com/netsampler/goflow2/v2 v2.1.3/go.mod h1:94ZaxfHuUwG6KviCxMWuZIvz0UGu657StE/g83hlS8A=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -1541,6 +1543,8 @@ gopkg.in/jcmturner/gokrb5.v7 v7.3.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuv
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -94,7 +94,6 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
 	if conf.Disco.Netbox != nil && conf.Disco.Netbox.NetboxAPIHost != "" {
-		log.Infof("Discovering devices from Netbox with tag [%s] and site [%s]", conf.Disco.Netbox.NetboxTag, conf.Disco.Netbox.NetboxSite)
 		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
 		if err != nil {
 			return nil, err

--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -93,7 +93,7 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 	}
 
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
-	if conf.Disco.Netbox != nil && conf.Disco.Netbox.NetboxAPIHost != "" {
+	if conf.Disco.Netbox != nil {
 		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
 		if err != nil {
 			return nil, err

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -53,7 +53,7 @@ type NBRespOK struct {
 type NBResult struct {
 	ID          int           `json:"id"`
 	Url         *string       `json:"url"`
-	Display     *string       `json:"display"`
+	Name        *string       `json:"name"`
 	DeviceType  *NBDeviceType `json:"device_type"`
 	PrimaryIp   *NBIP         `json:"primary_ip"`
 	PrimaryIpv4 *NBIP         `json:"primary_ip4"`
@@ -62,7 +62,7 @@ type NBResult struct {
 }
 
 type NBDeviceType struct {
-	Display *string `json:"display"`
+	Name *string `json:"name"`
 }
 
 type NBIP struct {
@@ -244,19 +244,19 @@ func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[s
 		for _, res := range res.Results {
 			ipv, err := getIP(res, conf.Disco.Netbox, log)
 			if err != nil {
-				if res.Display != nil {
-					log.Infof("Skipping %v with bad IP: %v", *res.Display, err)
+				if res.Name != nil {
+					log.Infof("Skipping %v with bad IP: %v", *res.Name, err)
 				} else {
 					log.Infof("Skipping null device with bad IP: %v", err)
 				}
 			} else {
-				if res.Display != nil && res.DeviceType != nil && res.DeviceType.Display != nil {
-					*results = append(*results, scan.Result{Name: *res.Display, Manufacturer: *res.DeviceType.Display, Host: net.ParseIP(ipv.Addr().String())})
+				if res.Name != nil && res.DeviceType != nil && res.DeviceType.Name != nil {
+					*results = append(*results, scan.Result{Name: *res.Name, Manufacturer: *res.DeviceType.Name, Host: net.ParseIP(ipv.Addr().String())})
 				} else {
-					if res.Display != nil {
-						*results = append(*results, scan.Result{Name: *res.Display, Manufacturer: "unknwn", Host: net.ParseIP(ipv.Addr().String())})
+					if res.Name != nil {
+						*results = append(*results, scan.Result{Name: *res.Name, Manufacturer: "unknwn", Host: net.ParseIP(ipv.Addr().String())})
 					} else {
-						log.Infof("Skipping device with IP %v because of null Display value.", ipv.Addr().String())
+						log.Infof("Skipping device with IP %v because of null Name value.", ipv.Addr().String())
 					}
 				}
 			}

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -62,7 +62,8 @@ type NBResult struct {
 }
 
 type NBDeviceType struct {
-	Name *string `json:"name"`
+	Name  *string `json:"name"`
+	Model *string `json:"model"`
 }
 
 type NBIP struct {
@@ -245,19 +246,19 @@ func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[s
 			ipv, err := getIP(res, conf.Disco.Netbox, log)
 			if err != nil {
 				if res.Name != nil {
-					log.Infof("Skipping %v with bad IP: %v", *res.Name, err)
+					log.Warnf("Skipping %v with bad IP: %v", *res.Name, err)
 				} else {
-					log.Infof("Skipping null device with bad IP: %v", err)
+					log.Warnf("Skipping null device with bad IP: %v", err)
 				}
 			} else {
-				if res.Name != nil && res.DeviceType != nil && res.DeviceType.Name != nil {
-					*results = append(*results, scan.Result{Name: *res.Name, Manufacturer: *res.DeviceType.Name, Host: net.ParseIP(ipv.Addr().String())})
-				} else {
-					if res.Name != nil {
-						*results = append(*results, scan.Result{Name: *res.Name, Manufacturer: "unknwn", Host: net.ParseIP(ipv.Addr().String())})
-					} else {
-						log.Infof("Skipping device with IP %v because of null Name value.", ipv.Addr().String())
+				if res.Name != nil {
+					model := "unknown"
+					if res.DeviceType != nil && res.DeviceType.Model != nil {
+						model = *res.DeviceType.Model
 					}
+					*results = append(*results, scan.Result{Name: *res.Name, Manufacturer: model, Host: net.ParseIP(ipv.Addr().String())})
+				} else {
+					log.Warnf("Skipping device with IP %v because of null Name value.", ipv.Addr().String())
 				}
 			}
 		}

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -251,6 +251,12 @@ func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[s
 			} else {
 				if res.Display != nil && res.DeviceType != nil && res.DeviceType.Display != nil {
 					*results = append(*results, scan.Result{Name: *res.Display, Manufacturer: *res.DeviceType.Display, Host: net.ParseIP(ipv.Addr().String())})
+				} else {
+					if res.Display != nil {
+						*results = append(*results, scan.Result{Name: *res.Display, Manufacturer: "unknwn", Host: net.ParseIP(ipv.Addr().String())})
+					} else {
+						log.Infof("Skipping device with IP %v because of null Display value.", ipv.Addr().String())
+					}
 				}
 			}
 		}
@@ -313,7 +319,7 @@ func getIP(res NBResult, conf *kt.NetboxConfig, log logger.ContextL) (netip.Pref
 		log.Infof("Looking at primary_ip %s", res.PrimaryIp.GetVal())
 		if res.PrimaryIp != nil && res.PrimaryIp.Address != nil {
 			addr := *res.PrimaryIp.Address
-			if addr == "" {
+			if addr != "" {
 				ipv, err := netip.ParsePrefix(addr)
 				return ipv, err
 			}

--- a/pkg/inputs/snmp/netbox_test.go
+++ b/pkg/inputs/snmp/netbox_test.go
@@ -1,0 +1,34 @@
+package snmp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kentik/ktranslate/pkg/eggs/logger"
+	lt "github.com/kentik/ktranslate/pkg/eggs/logger/testing"
+	"github.com/kentik/ktranslate/pkg/kt"
+)
+
+func TestGetIP(t *testing.T) {
+	assert := assert.New(t)
+	l := lt.NewTestContextL(logger.NilContext, t)
+
+	test := []byte(`{
+        "id": 1639742,
+        "family": {
+          "value": 4,
+          "label": "IPv4"
+        },
+        "address": "10.249.157.132/32"
+      }`)
+
+	conf := kt.NetboxConfig{NetboxIP: "primary"}
+	nbRes := NBIP{}
+	err := json.Unmarshal(test, &nbRes)
+	assert.Nil(err)
+	ipv, err := getIP(NBResult{PrimaryIp: &nbRes}, &conf, l)
+	assert.Nil(err)
+	assert.Equal("10.249.157.132", ipv.Addr().String())
+}

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -268,15 +268,16 @@ type SnmpDiscoConfig struct {
 }
 
 type NetboxConfig struct {
-	NetboxAPIUrl   string       `yaml:"url"`
-	NetboxAPIToken *SecureToken `yaml:"token"`
-	Tag            string       `yaml:"tag"`
-	Site           string       `yaml:"site"`
-	NetboxIP       string       `yaml:"ip_to_pick"` // One of primary or oob. Default to primary.
-	Location       string       `yaml:"location"`
-	Tenant         string       `yaml:"tenant"`
-	Status         string       `yaml:"status"`
-	Role           string       `yaml:"role"`
+	NetboxAPIUrl   string            `yaml:"url"`
+	NetboxAPIToken *SecureToken      `yaml:"token"`
+	NetboxIP       string            `yaml:"ip_to_pick"` // One of primary or oob. Default to primary.
+	Tag            string            `yaml:"tag"`
+	Site           string            `yaml:"site"`
+	Location       string            `yaml:"location"`
+	Tenant         string            `yaml:"tenant"`
+	Status         string            `yaml:"status"`
+	Role           string            `yaml:"role"`
+	CustomFields   map[string]string `yaml:"custom_fields"`
 }
 
 type ProviderMap struct {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -268,7 +268,7 @@ type SnmpDiscoConfig struct {
 }
 
 type NetboxConfig struct {
-	NetboxAPIHost  string       `yaml:"host"`
+	NetboxAPIUrl   string       `yaml:"url"`
 	NetboxAPIToken *SecureToken `yaml:"token"`
 	Tag            string       `yaml:"tag"`
 	Site           string       `yaml:"site"`

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -270,9 +270,13 @@ type SnmpDiscoConfig struct {
 type NetboxConfig struct {
 	NetboxAPIHost  string       `yaml:"host"`
 	NetboxAPIToken *SecureToken `yaml:"token"`
-	NetboxTag      string       `yaml:"tag"`
-	NetboxSite     string       `yaml:"site"`
+	Tag            string       `yaml:"tag"`
+	Site           string       `yaml:"site"`
 	NetboxIP       string       `yaml:"ip_to_pick"` // One of primary or oob. Default to primary.
+	Location       string       `yaml:"location"`
+	Tenant         string       `yaml:"tenant"`
+	Status         string       `yaml:"status"`
+	Role           string       `yaml:"role"`
 }
 
 type ProviderMap struct {


### PR DESCRIPTION
Closes #812 

This is a reworking of how netbox integration works. A new config will look like 

```
    netbox:
        url: https://fcmd3592.cloud.netboxapp.com/api/dcim/devices
        token: ${NETBOX_TOKEN}
        ip_to_pick: primary
        tag: foxtrot
        site: sydney
        location: ""
        tenant: ""
        status: active
        role: access-switch
        custom_fields:
            my_test: fooo-test
```

You can also set `KTRANS_OAUTH_CLIENT_ID`, `KTRANS_OAUTH_CLIENT_SECRET`, `KTRANS_OAUTH_SCOPE` and `KTRANS_OAUTH_TOKEN_URL` environment variables to use andoauth system to get a bearer token for netbox. In this case, leave the token field in the config empty. 

Note that `host` has been replaced with `url`. This is to accommodate different url patterns for this same api call. 

All of the filters are evaluated server side now except for custom_fields. 