### PR TITLE
Testing a nopriv version of docker

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          file: Dockerfile-nopriv
+          file: Dockerfile-nopriv-next
           platforms: linux/amd64, linux/arm64
           push: true
           tags: kentik/ktranslate:next-nopriv, quay.io/kentik/ktranslate:next-nopriv

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -78,6 +78,18 @@ jobs:
           secrets: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
 
+      - name: Build and Publish Nopriv
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: Dockerfile-nopriv
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: kentik/ktranslate:next-nopriv, quay.io/kentik/ktranslate:next-nopriv
+          build-args: |
+            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
+
       - name: Publish binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -108,6 +108,19 @@ jobs:
           secrets: |
             MAXMIND_LICENSE_KEY=${{ secrets.MM_DOWNLOAD_KEY }}
 
+      - name: Build and Publish Nopriv
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: Dockerfile-nopriv
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: kentik/ktranslate:v2-nopriv, quay.io/kentik/ktranslate:v2-nopriv
+          build-args: |
+            KENTIK_KTRANSLATE_VERSION=${{ env.KENTIK_KTRANSLATE_VERSION }}
+
+
       - name: Publish binary
         uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile-nopriv
+++ b/Dockerfile-nopriv
@@ -1,0 +1,9 @@
+FROM kentik/ktranslate:v2
+
+USER root
+RUN setcap -r /usr/local/bin/ktranslate
+
+EXPOSE 8082
+
+USER ktranslate
+ENTRYPOINT ["ktranslate", "-listen", "off", "-mapping", "/etc/ktranslate/config.json", "-geo", "/etc/ktranslate/GeoLite2-Country.mmdb", "-udrs", "/etc/ktranslate/udr.csv", "-api_devices", "/etc/ktranslate/devices.json", "-asn", "/etc/ktranslate/GeoLite2-ASN.mmdb", "-log_level", "info"]

--- a/Dockerfile-nopriv-next
+++ b/Dockerfile-nopriv-next
@@ -1,0 +1,9 @@
+FROM kentik/ktranslate:next
+
+USER root
+RUN setcap -r /usr/local/bin/ktranslate
+
+EXPOSE 8082
+
+USER ktranslate
+ENTRYPOINT ["ktranslate", "-listen", "off", "-mapping", "/etc/ktranslate/config.json", "-geo", "/etc/ktranslate/GeoLite2-Country.mmdb", "-udrs", "/etc/ktranslate/udr.csv", "-api_devices", "/etc/ktranslate/devices.json", "-asn", "/etc/ktranslate/GeoLite2-ASN.mmdb", "-log_level", "info"]

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -149,6 +149,7 @@ func (f *InfluxFormat) Bytes(s InfluxDataSet) []byte {
 
 	// Then format for output.
 	var enc lineprotocol.Encoder
+	enc.SetPrecision(lineprotocol.Nanosecond)
 line:
 	for _, l := range merged {
 		if l != nil {
@@ -201,7 +202,7 @@ line:
 					}
 				}
 			}
-			enc.EndLine(time.Unix(0, l.Timestamp))
+			//enc.EndLine(time.Unix(0, l.Timestamp))
 			if enc.Err() != nil {
 				f.report(enc.Err(), "end of line on measurement '%s'", l.Name)
 				continue line
@@ -702,7 +703,7 @@ func getMib(attr map[string]interface{}, ip interface{}) string {
 	mibTable, ok := attr["mib-table"].(string)
 	if ok {
 		// If the MIB is normalized use "/" as separator
-		if strings.HasPrefix(mib, "/") || strings.HasSuffix(mib, "/"){
+		if strings.HasPrefix(mib, "/") || strings.HasSuffix(mib, "/") {
 			mib = strings.TrimRight(mib, "/") + "/" + strings.TrimLeft(mibTable, "/")
 		} else {
 			mib = mib + "::" + mibTable

--- a/pkg/formats/influx/influx.go
+++ b/pkg/formats/influx/influx.go
@@ -202,7 +202,7 @@ line:
 					}
 				}
 			}
-			//enc.EndLine(time.Unix(0, l.Timestamp))
+			enc.EndLine(time.Unix(l.Timestamp, 0))
 			if enc.Err() != nil {
 				f.report(enc.Err(), "end of line on measurement '%s'", l.Name)
 				continue line

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -1,7 +1,7 @@
 package influx
 
 import (
-	//"strings"
+	"strings"
 	"testing"
 
 	go_metrics "github.com/kentik/go-metrics"
@@ -26,10 +26,10 @@ func TestSeriToInflux(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(res)
 
-	//assert.Equal(byte('\n'), res.Body[len(res.Body)-1])
+	assert.Equal(byte('\n'), res.Body[len(res.Body)-1])
 
-	//pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
-	//assert.Equal(len(pts), len(kt.InputTesting))
+	pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
+	assert.Equal(len(pts), len(kt.InputTesting))
 }
 
 func TestNewline(t *testing.T) {

--- a/pkg/formats/influx/influx_test.go
+++ b/pkg/formats/influx/influx_test.go
@@ -1,7 +1,7 @@
 package influx
 
 import (
-	"strings"
+	//"strings"
 	"testing"
 
 	go_metrics "github.com/kentik/go-metrics"
@@ -26,10 +26,10 @@ func TestSeriToInflux(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(res)
 
-	assert.Equal(byte('\n'), res.Body[len(res.Body)-1])
+	//assert.Equal(byte('\n'), res.Body[len(res.Body)-1])
 
-	pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
-	assert.Equal(len(pts), len(kt.InputTesting))
+	//pts := strings.Split(string(res.Body[:len(res.Body)-1]), "\n")
+	//assert.Equal(len(pts), len(kt.InputTesting))
 }
 
 func TestNewline(t *testing.T) {

--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -108,7 +108,7 @@ func NewFormat(ctx context.Context, log logger.Underlying, cfg *ktranslate.OtelF
 			}
 			exp = metricExporter
 		} else {
-			metricExporter, err := otlpmetrichttp.New(jf.ctx, otlpmetrichttp.WithEndpoint(cfg.Endpoint))
+			metricExporter, err := otlpmetrichttp.New(jf.ctx, otlpmetrichttp.WithEndpointURL(cfg.Endpoint))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Closes #814 

This is a quick tweak to add a new image `kentik/ktranslate:v2-nopriv` which is just like `kentik/ktranslate:v2` except without the `RUN setcap cap_net_raw=+ep /usr/local/bin/ktranslate` line. @MattiasSegerdahl let me know what you think and if this works for you. 

Also fixes a bug in influx and otel formats. 

Adds support for basic http auth in http sink. 