### PR TITLE
Allow ignore list for snmp disco to include cidrs

### DIFF
--- a/pkg/inputs/snmp/disco.go
+++ b/pkg/inputs/snmp/disco.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/netip"
 	"os"
 	"sort"
 	"strings"
@@ -88,19 +89,24 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 	defer mdb.Close()
 
 	ignoreMap := map[string]bool{}
+	ignoreList := []netip.Prefix{}
 	for _, ip := range conf.Disco.IgnoreList {
-		ignoreMap[ip] = true
+		if ipr, err := netip.ParsePrefix(ip); err != nil {
+			ignoreMap[ip] = true
+		} else {
+			ignoreList = append(ignoreList, ipr)
+		}
 	}
 
 	foundDevices := map[string]*kt.SnmpDeviceConfig{}
 	if conf.Disco.Netbox != nil {
-		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
+		err = getDevicesFromNetbox(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap, ignoreList)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		log.Infof("Discovering devices from network scan")
-		err := runScanCheckDisco(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap)
+		err := runScanCheckDisco(ctx, ctl, foundDevices, mdb, conf, kentikDevices, log, ignoreMap, ignoreList)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +131,7 @@ func Discover(ctx context.Context, log logger.ContextL, pollDuration time.Durati
 }
 
 func runScanCheckDisco(ctx context.Context, ctl chan bool, foundDevices map[string]*kt.SnmpDeviceConfig,
-	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool) error {
+	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool, ignoreList []netip.Prefix) error {
 	for _, ipr := range conf.Disco.Cidrs {
 		_, _, err := net.ParseCIDR(ipr)
 		if err != nil {
@@ -158,7 +164,7 @@ func runScanCheckDisco(ctx context.Context, ctl chan bool, foundDevices map[stri
 		log.Infof("Starting to check %d ips in %s", len(results), ipr)
 		for i, result := range results {
 			if strings.HasSuffix(ipr, "/32") || result.IsHostUp() || conf.Disco.CheckAll {
-				if ignoreMap[result.Host.String()] { // If we have marked this ip as to be ignored, don't do anything more with it.
+				if checkIfIgnored(result.Host.String(), ignoreMap, ignoreList) {
 					continue
 				}
 				wg.Add(1)
@@ -171,6 +177,22 @@ func runScanCheckDisco(ctx context.Context, ctl chan bool, foundDevices map[stri
 	}
 
 	return nil
+}
+
+// Does the IP exist in an ignore block?
+func checkIfIgnored(ip string, ignoreMap map[string]bool, ignoreList []netip.Prefix) bool {
+	if ignoreMap[ip] { // If we have marked this ip as to be ignored, don't do anything more with it.
+		return true
+	}
+	for _, ignorer := range ignoreList {
+		aa, err := netip.ParseAddr(ip)
+		if err == nil {
+			if ignorer.Contains(aa) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func RunDiscoOnTimer(ctx context.Context, c chan os.Signal, log logger.ContextL, pollTimeMin int, checkNow bool, cfg *ktranslate.SNMPInputConfig, apic *api.KentikApi, confMgr config.ConfigManager) {

--- a/pkg/inputs/snmp/netbox.go
+++ b/pkg/inputs/snmp/netbox.go
@@ -248,7 +248,7 @@ func checkCustomFields(conf *kt.SnmpConfig, res NBResult) bool {
 }
 
 func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[string]*kt.SnmpDeviceConfig,
-	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool) error {
+	mdb *mibs.MibDB, conf *kt.SnmpConfig, kentikDevices map[string]string, log logger.ContextL, ignoreMap map[string]bool, ignoreList []netip.Prefix) error {
 
 	log.Infof("Discovering devices from Netbox.")
 
@@ -308,7 +308,7 @@ func getDevicesFromNetbox(ctx context.Context, ctl chan bool, foundDevices map[s
 	st := time.Now()
 	log.Infof("Starting to check %d ips from netbox", len(results))
 	for i, result := range results {
-		if ignoreMap[result.Host.String()] { // If we have marked this ip as to be ignored, don't do anything more with it.
+		if checkIfIgnored(result.Host.String(), ignoreMap, ignoreList) {
 			continue
 		}
 		wg.Add(1)

--- a/pkg/inputs/snmp/snmp_test.go
+++ b/pkg/inputs/snmp/snmp_test.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -175,5 +176,31 @@ func TestSetTagsMatch(t *testing.T) {
 			assert.Equal(expt, device.UserTags["tag"], "%s -> %s %v", test, device.Provider, device.UserTags)
 			assert.Equal(expt, device.MatchAttr["match"], "%s -> %s %v", test, device.Provider, device.MatchAttr)
 		}
+	}
+}
+
+func TestIgnoreList(t *testing.T) {
+	assert := assert.New(t)
+
+	ignores := []string{"10.2.3.1", "10.2.10.0/24"}
+
+	tests := map[string]bool{
+		"10.2.3.1":   true,
+		"10.2.10.10": true,
+		"10.2.11.10": false,
+	}
+
+	ignoreMap := map[string]bool{}
+	ignoreList := []netip.Prefix{}
+	for _, ip := range ignores {
+		if ipr, err := netip.ParsePrefix(ip); err != nil {
+			ignoreMap[ip] = true
+		} else {
+			ignoreList = append(ignoreList, ipr)
+		}
+	}
+
+	for tst, res := range tests {
+		assert.Equal(res, checkIfIgnored(tst, ignoreMap, ignoreList), tst)
 	}
 }


### PR DESCRIPTION
Closes #818 

This update allows the snmp disco `ignore_list` value to include cidr blocks now in addition to singe ips. 

For example:

```yaml
    ignore_list:
        - 10.0.10.0/24
```

Will filter out everything in the 10.0.10.0/24 range. 

If the ip doesn't have a prefix the behavior remains the same. 