### PR TITLE
Bumpling base docker image for sec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ else \
 fi
 
 # main image
-FROM alpine:3.21
+FROM alpine:3.22
 RUN apk add -U --no-cache ca-certificates libpcap aws-cli
 RUN addgroup -g 1000 ktranslate && \
 	adduser -D -u 1000 -G ktranslate -H -h /etc/ktranslate ktranslate


### PR DESCRIPTION
This is bumping the base docker image to keep security up to date per a customer ask. 