### PR TITLE
Allow multple ips check snmp

### DIFF
--- a/pkg/inputs/snmp/netbox_test.go
+++ b/pkg/inputs/snmp/netbox_test.go
@@ -11,24 +11,70 @@ import (
 	"github.com/kentik/ktranslate/pkg/kt"
 )
 
+type ntest struct {
+	nbresult []byte
+	target   string
+	res      string
+}
+
 func TestGetIP(t *testing.T) {
 	assert := assert.New(t)
 	l := lt.NewTestContextL(logger.NilContext, t)
 
-	test := []byte(`{
+	tests := []ntest{
+		ntest{
+			res:    "10.249.157.132",
+			target: "primary",
+			nbresult: []byte(`{"primary_ip":{
         "id": 1639742,
         "family": {
           "value": 4,
           "label": "IPv4"
         },
         "address": "10.249.157.132/32"
-      }`)
+      }}`)},
+		ntest{
+			res:    "10.249.157.135",
+			target: "oob",
+			nbresult: []byte(`{"oob_ip":{
+        "id": 1639742,
+        "family": {
+          "value": 4,
+          "label": "IPv4"
+        },
+        "address": "10.249.157.135/32"
+      }}`)},
+		ntest{
+			res:    "10.249.157.135",
+			target: "oob,primary_ip4",
+			nbresult: []byte(`{"oob_ip":null,"primary_ip4":{
+        "id": 1639742,
+        "family": {
+          "value": 4,
+          "label": "IPv4"
+        },
+        "address": "10.249.157.135/32"
+      }}`)},
+		ntest{
+			res:    "dead::beef",
+			target: "oob,primary_ip4,primary_ip6",
+			nbresult: []byte(`{"oob_ip":null,"primary_ip4":null,"primary_ip6":{
+        "id": 1639742,
+        "family": {
+          "value": 6,
+          "label": "IPv6"
+        },
+        "address": "dead::beef/64"
+      }}`)},
+	}
 
-	conf := kt.NetboxConfig{NetboxIP: "primary"}
-	nbRes := NBIP{}
-	err := json.Unmarshal(test, &nbRes)
-	assert.Nil(err)
-	ipv, err := getIP(NBResult{PrimaryIp: &nbRes}, &conf, l)
-	assert.Nil(err)
-	assert.Equal("10.249.157.132", ipv.Addr().String())
+	for _, test := range tests {
+		conf := kt.NetboxConfig{NetboxIP: test.target}
+		nbRes := NBResult{}
+		err := json.Unmarshal(test.nbresult, &nbRes)
+		assert.Nil(err)
+		ipv, err := getIP(nbRes, &conf, l)
+		assert.Nil(err)
+		assert.Equal(test.res, ipv.Addr().String())
+	}
 }


### PR DESCRIPTION
Mattias Segerdahl — 7/3/25, 1:02 AM 
```
Is it possible to use multiple interfaces when using Netbox? For example, I want to start checking the oob interface and if that doesn't respond, check the ip4 one.
```

This will allow multiple interfaces to be listed in the netbox config using a comma separated string. For example, `oob,primary_ip4,primary_ip6`. The first working ip is used for the device and the rest dropped. 