### PR TITLE
Code to allow custom s3 sink endpoints

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -496,6 +496,10 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.S3Sink.AssumeRoleARN = val
 			case "s3_region":
 				cfg.S3Sink.Region = val
+			case "s3_endpoint":
+				cfg.S3Sink.Endpoint = val
+			case "s3_signing_region":
+				cfg.S3Sink.SigningRegion = val
 			case "ec2_instance_profile":
 				v, err := strconv.ParseBool(val)
 				if err != nil {

--- a/config.go
+++ b/config.go
@@ -78,6 +78,8 @@ type S3SinkConfig struct {
 	EC2InstanceProfile                         bool
 	AssumeRoleOrInstanceProfileIntervalSeconds int
 	CheckDangling                              bool
+	Endpoint                                   string
+	SigningRegion                              string
 }
 
 // NetSinkConfig is the config for the net sink
@@ -425,6 +427,8 @@ func DefaultConfig() *Config {
 			EC2InstanceProfile:   false,
 			AssumeRoleOrInstanceProfileIntervalSeconds: 900,
 			CheckDangling: false,
+			Endpoint:      "",
+			SigningRegion: "",
 		},
 		NetSink: &NetSinkConfig{
 			Endpoint: "",


### PR DESCRIPTION
This adds two new flags, `s3_endpoint` and `s3_signing_region`. These let you override the default s3 regions and use an onprem s3 compatible setup. Tested working with a customer system. 