### PR TITLE
Adding a default for otel values so that custom types still get defined

### DIFF
--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -691,6 +691,8 @@ func (d *OtelData) GetTagValues() attribute.Set {
 		case uint64:
 			res = append(res, attribute.Int64(k, int64(t)))
 		default:
+			// Convert unknown types to string representation
+			res = append(res, attribute.String(k, fmt.Sprintf("%v", t)))
 		}
 	}
 	s, _ := attribute.NewSetWithFiltered(res, func(kv attribute.KeyValue) bool { return true })


### PR DESCRIPTION
Closes #836

I forgot that custom types will fall out of this switch. This update will force random types to their string rep. 