### PR TITLE
Fix neg flows

### DIFF
--- a/pkg/formats/avro/avro.go
+++ b/pkg/formats/avro/avro.go
@@ -145,6 +145,10 @@ func (f *AvroFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 	values := make([]map[string]interface{}, len(msgs))
 	for i, m := range msgs {
 		values[i] = m.ToMap()
+		values[i]["in_bytes"] = int64(values[i]["in_bytes"].(uint64))
+		values[i]["in_pkts"] = int64(values[i]["in_pkts"].(uint64))
+		values[i]["out_bytes"] = int64(values[i]["out_bytes"].(uint64))
+		values[i]["out_pkts"] = int64(values[i]["out_pkts"].(uint64))
 	}
 
 	cfg := goavro.OCFConfig{

--- a/pkg/formats/netflow/ipfix_test.go
+++ b/pkg/formats/netflow/ipfix_test.go
@@ -40,8 +40,8 @@ func TestBasic(t *testing.T) {
 		assert.Equal(kt.InputTesting[i].DstAddr, out[i]["dst_addr"])
 		assert.Equal(int(kt.InputTesting[i].L4DstPort), int(out[i]["l4_dst_port"].(int64)))
 		assert.Equal(int(kt.InputTesting[i].OutputPort), int(out[i]["output_port"].(int64)))
-		assert.Equal(int(kt.InputTesting[i].InBytes), int(out[i]["in_bytes"].(int64)))
+		assert.Equal(int(kt.InputTesting[i].InBytes), int(out[i]["in_bytes"].(uint64)))
 		assert.Equal(kt.InputTesting[i].SrcEthMac, out[i]["src_eth_mac"])
-		assert.Equal(int(kt.InputTesting[i].OutBytes), int(out[i]["out_bytes"].(int64)))
+		assert.Equal(int(kt.InputTesting[i].OutBytes), int(out[i]["out_bytes"].(uint64)))
 	}
 }

--- a/pkg/formats/netflow/netflow9_test.go
+++ b/pkg/formats/netflow/netflow9_test.go
@@ -34,6 +34,6 @@ func TestNine(t *testing.T) {
 		assert.Equal(kt.InputTesting[i].DstAddr, out[i]["dst_addr"])
 		assert.Equal(int(kt.InputTesting[i].L4DstPort), int(out[i]["l4_dst_port"].(int64)))
 		assert.Equal(int(kt.InputTesting[i].OutputPort), int(out[i]["output_port"].(int64)))
-		assert.Equal(int(kt.InputTesting[i].InBytes), int(out[i]["in_bytes"].(int64)))
+		assert.Equal(int(kt.InputTesting[i].InBytes), int(out[i]["in_bytes"].(uint64)))
 	}
 }

--- a/pkg/formats/util/util.go
+++ b/pkg/formats/util/util.go
@@ -70,6 +70,10 @@ func SetAttr(attr map[string]interface{}, in *kt.JCHF, metrics map[string]kt.Met
 			if vt > 0 {
 				attr[k] = int(vt)
 			}
+		case uint64:
+			if vt > 0 {
+				attr[k] = int(vt)
+			}
 		default:
 			panic(fmt.Sprintf("Unknown type: %v", v.(int32)))
 		}

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -257,8 +257,8 @@ func (j *JCHF) ToMap() map[string]interface{} {
 	j.avroSet["dst_as"] = int64(j.DstAs)
 	j.avroSet["dst_geo"] = j.DstGeo
 	j.avroSet["header_len"] = int64(j.HeaderLen)
-	j.avroSet["in_bytes"] = int64(j.InBytes)
-	j.avroSet["in_pkts"] = int64(j.InPkts)
+	j.avroSet["in_bytes"] = uint64(j.InBytes)
+	j.avroSet["in_pkts"] = uint64(j.InPkts)
 	j.avroSet["input_port"] = int64(j.InputPort)
 	j.avroSet["dst_addr"] = j.DstAddr
 	j.avroSet["src_addr"] = j.SrcAddr

--- a/pkg/kt/types.go
+++ b/pkg/kt/types.go
@@ -273,8 +273,8 @@ func (j *JCHF) ToMap() map[string]interface{} {
 	j.avroSet["tos"] = int64(j.Tos)
 	j.avroSet["vlan_in"] = int64(j.VlanIn)
 	j.avroSet["vlan_out"] = int64(j.VlanOut)
-	j.avroSet["out_bytes"] = int64(j.OutBytes)
-	j.avroSet["out_pkts"] = int64(j.OutPkts)
+	j.avroSet["out_bytes"] = uint64(j.OutBytes)
+	j.avroSet["out_pkts"] = uint64(j.OutPkts)
 	j.avroSet["tcp_rx"] = int64(j.TcpRetransmit)
 	j.avroSet["src_flow_tags"] = j.SrcFlowTags
 	j.avroSet["dst_flow_tags"] = j.DstFlowTags


### PR DESCRIPTION
Looking at ways to ensure we don't flip around for very large values which really should be uint64s. 