### PR TITLE
Set New Relic 'logtype' attribute correctly for container logs & syslogs in the same batch 

### DIFF
--- a/pkg/util/logger/logger_writer.go
+++ b/pkg/util/logger/logger_writer.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	NumMessages   = 10 * 1024 // number of allowed log messages
-	STDOUT_FORMAT = "2006-01-02T15:04:05.000 "
+	STDOUT_FORMAT = "2006-01-02T15:04:05.000-07:00 "
 
 	LOG_INFO    = 2
 	LOG_DEBUG   = 1


### PR DESCRIPTION
Per the discussion in https://github.com/kentik/ktranslate/issues/842 here is a draft PR that ensures that the `logtype` attribute is correctly set for container logs (aka `ktranslate-health` logs) vs `syslogs`.  This is accomplished by sending the different types of logs in different batch messages as all logs in a batch message share the same set of `Common.Attributes`