### PR TITLE
Add time zone to ktranslate logs so host doesn't need to always be in UTC

### DIFF
--- a/pkg/util/logger/logger_writer.go
+++ b/pkg/util/logger/logger_writer.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	NumMessages   = 10 * 1024 // number of allowed log messages
-	STDOUT_FORMAT = "2006-01-02T15:04:05.000 "
+	STDOUT_FORMAT = "2006-01-02T15:04:05.000-07:00 "
 
 	LOG_INFO    = 2
 	LOG_DEBUG   = 1


### PR DESCRIPTION
As reported in https://github.com/kentik/ktranslate/issues/835, when ktranslate is run on an OS with a non-UTC setting, ktranslate's own logTimeStamp is shifted by the time difference from UTC.  This is because the format of the logs does not include any TZ information, so the destination (like NewRelic) assumes the timestamp is in UTC...but the timestamp isn't really UTC:
https://github.com/kentik/ktranslate/blob/f18e2272ced7d0ca045f0d957ea68754a9cca466/pkg/util/logger/logger_writer.go#L18

This PR proposes the idea of explicitly adding the current OS's time zone offset for ktranslate logs.  As this format matches ISO8601 it's likely that all the sinks will handle this change, I don't really have a way of knowing.  I've tested it with New Relic and it works.

Example log after this change:
`2025-09-10T08:22:15.997-04:00 ktranslate/home-assistant-ktranslate [Info] baseserver.metaserver Listening on 127.0.0.1:38149`