### PR TITLE
Allow multi metric same dim

### DIFF
--- a/pkg/rollup/rollup.go
+++ b/pkg/rollup/rollup.go
@@ -188,6 +188,7 @@ type rollupBase struct {
 	nameSet      []string
 	filters      []filter.FilterWrapper
 	hasFilters   bool
+	splitMetrics bool
 }
 
 type splitDim struct {
@@ -234,7 +235,13 @@ func (r *rollupBase) init(rd RollupDef) error {
 		pts := strings.Split(m, ".")
 		switch len(pts) {
 		case 1:
-			r.metrics = append(r.metrics, m)
+			splitSet := strings.Split(m, ";")
+			if len(splitSet) > 1 {
+				r.splitMetrics = true
+				r.metrics = append(r.metrics, splitSet...)
+			} else {
+				r.metrics = append(r.metrics, m)
+			}
 		case 2:
 			r.multiMetrics = append(r.multiMetrics, pts)
 		default:

--- a/pkg/rollup/rollup.go
+++ b/pkg/rollup/rollup.go
@@ -82,7 +82,7 @@ type RollupDef struct {
 	Method     Method
 	Metrics    []string
 	Dimensions []string
-	Name       string
+	NameSet    []string
 }
 
 /**
@@ -96,7 +96,7 @@ type RollupDef struct {
 */
 
 func (r *RollupDef) String() string {
-	return fmt.Sprintf("Name: %s, Method: %s, Adjust Sample Rate: %v, Metric: %v, Dimensions: %v", r.Name, r.Method, r.Sample, r.Metrics, r.Dimensions)
+	return fmt.Sprintf("Name(s): %v, Method: %s, Adjust Sample Rate: %v, Metric: %v, Dimensions: %v", r.NameSet, r.Method, r.Sample, r.Metrics, r.Dimensions)
 }
 
 type RollupDefs []RollupDef
@@ -121,7 +121,7 @@ func (i *RollupDefs) Set(value string) error {
 	if len(ptn[0]) > 2 && ptn[0][0:2] == "s_" {
 		*i = append(*i, RollupDef{
 			Method:     Method(ptn[0][2:]),
-			Name:       ptn[1],
+			NameSet:    strings.Split(ptn[1], ";"),
 			Metrics:    strings.Split(ptn[2], "+"),
 			Dimensions: ptn[3:],
 			Sample:     true,
@@ -129,7 +129,7 @@ func (i *RollupDefs) Set(value string) error {
 	} else {
 		*i = append(*i, RollupDef{
 			Method:     Method(ptn[0]),
-			Name:       ptn[1],
+			NameSet:    strings.Split(ptn[1], ";"),
 			Metrics:    strings.Split(ptn[2], "+"),
 			Dimensions: ptn[3:],
 		})
@@ -185,7 +185,7 @@ type rollupBase struct {
 	mux          sync.RWMutex
 	sample       bool
 	dtime        time.Time
-	name         string
+	nameSet      []string
 	filters      []filter.FilterWrapper
 	hasFilters   bool
 }
@@ -202,7 +202,7 @@ func (r *rollupBase) init(rd RollupDef) error {
 	r.multiDims = make([][]string, 0)
 	r.splitDims = map[int]splitDim{}
 	r.dtime = time.Now()
-	r.name = rd.Name
+	r.nameSet = rd.NameSet
 	r.eventType = strings.ReplaceAll(fmt.Sprintf(KENTIK_EVENT_TYPE, strings.Join(rd.Metrics, "_"), strings.Join(rd.Dimensions, ":")), ".", "_")
 	r.sample = rd.Sample
 
@@ -342,5 +342,5 @@ func (r *rollupBase) SetFilter(fw filter.FilterWrapper) {
 }
 
 func (r *rollupBase) GetName() string {
-	return r.name
+	return strings.Join(r.nameSet, ";")
 }

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -54,6 +54,12 @@ func TestRollup(t *testing.T) {
 			Formats:       []string{"sum,sum_bytes_in,in_bytes,ccc,custom_str.aaa$$---$$custom_str.bbb"},
 			KeepUndefined: true,
 		},
+		ktranslate.RollupConfig{
+			JoinKey:       "^",
+			TopK:          2,
+			Formats:       []string{"sum,sum_bytes_in;sum_bytes_out,in_bytes;out_bytes,foo,bar"},
+			KeepUndefined: false,
+		},
 	}
 
 	inputs := [][]map[string]interface{}{
@@ -167,6 +173,32 @@ func TestRollup(t *testing.T) {
 				"provider":    kt.Provider("pp"),
 			},
 		},
+		[]map[string]interface{}{
+			map[string]interface{}{
+				"in_bytes":    int64(10),
+				"out_bytes":   int64(10),
+				"foo":         "bbb",
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(34),
+				"out_bytes":   int64(34),
+				"foo":         "bbb",
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+			map[string]interface{}{
+				"in_bytes":    int64(44),
+				"out_bytes":   int64(55),
+				"foo":         "bbb",
+				"bar":         "ccc",
+				"sample_rate": int64(1),
+				"provider":    kt.Provider("pp"),
+			},
+		},
 	}
 
 	outputs := []map[string]interface{}{
@@ -193,6 +225,10 @@ func TestRollup(t *testing.T) {
 		map[string]interface{}{
 			"metric":     40,
 			"dimensions": []string{"ccc", "aaa---bbb"},
+		},
+		map[string]interface{}{
+			"metric":     44,
+			"dimensions": []string{"bbb", "ccc"},
 		},
 	}
 

--- a/pkg/rollup/rollup_test.go
+++ b/pkg/rollup/rollup_test.go
@@ -176,7 +176,7 @@ func TestRollup(t *testing.T) {
 		[]map[string]interface{}{
 			map[string]interface{}{
 				"in_bytes":    int64(10),
-				"out_bytes":   int64(10),
+				"out_bytes":   int64(5),
 				"foo":         "bbb",
 				"bar":         "ccc",
 				"sample_rate": int64(1),
@@ -184,7 +184,7 @@ func TestRollup(t *testing.T) {
 			},
 			map[string]interface{}{
 				"in_bytes":    int64(34),
-				"out_bytes":   int64(34),
+				"out_bytes":   int64(10),
 				"foo":         "bbb",
 				"bar":         "ccc",
 				"sample_rate": int64(1),
@@ -192,7 +192,7 @@ func TestRollup(t *testing.T) {
 			},
 			map[string]interface{}{
 				"in_bytes":    int64(44),
-				"out_bytes":   int64(55),
+				"out_bytes":   int64(1000),
 				"foo":         "bbb",
 				"bar":         "ccc",
 				"sample_rate": int64(1),
@@ -227,7 +227,8 @@ func TestRollup(t *testing.T) {
 			"dimensions": []string{"ccc", "aaa---bbb"},
 		},
 		map[string]interface{}{
-			"metric":     44,
+			"metric":     88,
+			"alt_metric": 1015,
 			"dimensions": []string{"bbb", "ccc"},
 		},
 	}
@@ -243,6 +244,9 @@ func TestRollup(t *testing.T) {
 			res := ri.Export()
 
 			assert.Equal(outputs[i]["metric"].(int), int(res[0].Metric), res)
+			if _, ok := outputs[i]["alt_metric"]; ok {
+				assert.Equal(outputs[i]["alt_metric"].(int), int(res[1].Metric), res)
+			}
 			assert.Equal(roll.TopK, len(res), i)
 			dims := strings.Split(res[0].Dimension, res[0].KeyJoin)
 			for j, dim := range dims {

--- a/pkg/rollup/unique.go
+++ b/pkg/rollup/unique.go
@@ -3,6 +3,7 @@ package rollup
 import (
 	"encoding/binary"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kentik/ktranslate"
@@ -156,9 +157,10 @@ func (r *UniqueRollup) exportUnique(uniques map[string]gohll.HLL, count map[stri
 	r.dtime = time.Now()
 	keys := make([]Rollup, 0, len(uniques))
 	totalc := uint64(0)
+	fullName := strings.Join(r.nameSet, ";")
 	for k, v := range uniques {
 		keys = append(keys, Rollup{
-			Name: r.name, EventType: r.eventType, Dimension: k,
+			Name: fullName, EventType: r.eventType, Dimension: k,
 			Metric: float64(v.EstimateCardinality()), KeyJoin: r.keyJoin, dims: combo(r.multiDims), Interval: r.dtime.Sub(ot),
 			Count: count[k], Provider: prov[k],
 		})


### PR DESCRIPTION
This is a way to save memory when the user wants multiple rollups with things like in_bytes and out_bytes but keeping the same dimensions. Now a rollup definition like `sum,sum_bytes_in;sum_bytes_out,in_bytes;out_bytes,foo,bar` where the metrics are joined by a `;` token will result in 2 separate rollup values emitted, one for the in_bytes and one for out_bytes.