### PR TITLE
Better trap handling for otel

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -648,14 +648,14 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 	}
 
 	// Set up formatter
-	fmtr, err := formats.NewFormat(ctx, format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config)
+	fmtr, err := formats.NewFormat(ctx, format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config, kc.logTee)
 	if err != nil {
 		return err
 	}
 	kc.format = fmtr
 
 	if kc.config.FormatRollup != "" { // Rollups default to using the same format as main, but can be seperated out.
-		fmtr, err := formats.NewFormat(ctx, formatRollup, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config)
+		fmtr, err := formats.NewFormat(ctx, formatRollup, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config, kc.logTee)
 		if err != nil {
 			return err
 		}
@@ -802,7 +802,7 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 			format = formats.Format(kc.config.FormatMetric)
 		}
 
-		fmtr, err := formats.NewFormat(ctx, format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config)
+		fmtr, err := formats.NewFormat(ctx, format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config, kc.logTee)
 		if err != nil {
 			return err
 		}

--- a/pkg/formats/format.go
+++ b/pkg/formats/format.go
@@ -55,7 +55,7 @@ const (
 	FORMAT_PARQUET              = "parquet"
 )
 
-func NewFormat(ctx context.Context, format Format, log logger.Underlying, registry go_metrics.Registry, compression kt.Compression, cfg *ktranslate.Config) (Formatter, error) {
+func NewFormat(ctx context.Context, format Format, log logger.Underlying, registry go_metrics.Registry, compression kt.Compression, cfg *ktranslate.Config, logTee chan string) (Formatter, error) {
 	switch format {
 	case FORMAT_AVRO:
 		return avro.NewFormat(log, compression)
@@ -84,7 +84,7 @@ func NewFormat(ctx context.Context, format Format, log logger.Underlying, regist
 	case FORMAT_PROM_REMOTE:
 		return prom.NewRemoteFormat(log, compression, cfg.PrometheusFormat)
 	case FORMAT_OTEL:
-		return otel.NewFormat(ctx, log, cfg.OtelFormat)
+		return otel.NewFormat(ctx, log, cfg.OtelFormat, logTee)
 	case FORMAT_SNMP:
 		return snmp.NewFormat(log, cfg.SnmpFormat)
 	case FORMAT_PARQUET:

--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -326,12 +326,6 @@ func (f *OtelFormat) toOtelMetric(in *kt.JCHF) []OtelData {
 		return f.fromKtranslate(in)
 	case kt.KENTIK_EVENT_SNMP_TRAP, kt.KENTIK_EVENT_EXT:
 		// This is actually an event, send out as an event to sink directly.
-
-		//err := f.trapLog.RecordLog(in, "New Trap Event")
-		//if err != nil {
-		//	f.Errorf("There was an error when sending an event: %v.", err)
-		//	}
-		// Debug in progress. Again.
 		flat := in.Flatten()
 		strip(flat)
 		b, err := json.Marshal(flat)

--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -331,7 +331,7 @@ func (f *OtelFormat) toOtelMetric(in *kt.JCHF) []OtelData {
 		//if err != nil {
 		//	f.Errorf("There was an error when sending an event: %v.", err)
 		//	}
-		// Debug in progress.
+		// Debug in progress. Again.
 		flat := in.Flatten()
 		strip(flat)
 		b, err := json.Marshal(flat)


### PR DESCRIPTION
Since otel likes logs, this is just writting traps to the log and letting otel forward it to whatever handler is needed. 