### PR TITLE
Adding a global ping only section to make config easier

### DIFF
--- a/pkg/inputs/snmp/snmp.go
+++ b/pkg/inputs/snmp/snmp.go
@@ -291,7 +291,7 @@ func launchSnmpTrap(ctx context.Context, conf *kt.SnmpConfig, jchfChan chan []*k
 
 func launchSnmp(ctx context.Context, conf *kt.SnmpGlobalConfig, device *kt.SnmpDeviceConfig, jchfChan chan []*kt.JCHF, connectTimeout time.Duration, retries int, metrics *kt.SnmpDeviceMetric, profile *mibs.Profile, log logger.ContextL, logchan chan string) error {
 	// Sometimes this device is pinging only. In this case, start the ping loop and return.
-	if device.PingOnly {
+	if conf.PingOnly || device.PingOnly {
 		return launchPingOnly(ctx, conf, device, jchfChan, connectTimeout, retries, metrics, profile, log)
 	} else if conf.RunPing || device.RunPing {
 		if err := launchPingOnly(ctx, conf, device, jchfChan, connectTimeout, retries, metrics, profile, log); err != nil {

--- a/pkg/kt/snmp.go
+++ b/pkg/kt/snmp.go
@@ -296,6 +296,7 @@ type SnmpGlobalConfig struct {
 	GlobalV3              *V3SNMPConfig          `yaml:"global_v3"`
 	RunPing               bool                   `yaml:"response_time"`
 	PingSec               int                    `yaml:"ping_interval_sec,omitempty"`
+	PingOnly              bool                   `yaml:"ping_only,omitempty"`
 	PurgeDevices          int                    `yaml:"purge_devices_after_num"` // Delete any device if its not seen after X discovery attempts. Default is 0, which means things never get purged.
 	NoDeviceHardcodedOids bool                   `yaml:"no_device_hardcoded_oids"`
 	UserTags              map[string]string      `yaml:"user_tags"`


### PR DESCRIPTION
Closes #840 

Allows a user to specify `ping_only: true` in the global section and set ping only for all devices.  