### PR TITLE
Bumb base image and remove unused aws-cli import.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ fi
 
 # main image
 FROM alpine:3.23
-RUN apk add -U --no-cache ca-certificates libpcap aws-cli
+RUN apk add -U --no-cache ca-certificates libpcap
 RUN addgroup -g 1000 ktranslate && \
 	adduser -D -u 1000 -G ktranslate -H -h /etc/ktranslate ktranslate
 #RUN set -eux; \


### PR DESCRIPTION
This should fix a lot of security warnings on the base image.