### PR TITLE
logging and metrics for otel when the export chan gets full

### DIFF
--- a/cmd/ktranslate/main.go
+++ b/cmd/ktranslate/main.go
@@ -455,6 +455,13 @@ func applyFlags(cfg *ktranslate.Config) error {
 				cfg.OtelFormat.ClientKey = val
 			case "otel.root_ca":
 				cfg.OtelFormat.RootCA = val
+			case "otel.no_block":
+				v, err := strconv.ParseBool(val)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				cfg.OtelFormat.NoBlockExport = v
 			// pkg/formats/elasticsearch
 			case "elastic.action":
 				cfg.ElasticFormat.Action = val

--- a/config.go
+++ b/config.go
@@ -42,11 +42,12 @@ type ElasticFormatConfig struct {
 
 // OtelFormatConfig is the config for the otel format
 type OtelFormatConfig struct {
-	Endpoint   string
-	Protocol   string
-	ClientCert string
-	ClientKey  string
-	RootCA     string
+	Endpoint      string
+	Protocol      string
+	ClientCert    string
+	ClientKey     string
+	RootCA        string
+	NoBlockExport bool
 }
 
 // SnmpFormatConfig is the config for the snmp format
@@ -402,11 +403,12 @@ func DefaultConfig() *Config {
 			FlowsNeeded:          10,
 		},
 		OtelFormat: &OtelFormatConfig{
-			Endpoint:   "",
-			Protocol:   "stdout",
-			ClientKey:  "",
-			ClientCert: "",
-			RootCA:     "",
+			Endpoint:      "",
+			Protocol:      "stdout",
+			ClientKey:     "",
+			ClientCert:    "",
+			RootCA:        "",
+			NoBlockExport: false,
 		},
 		ElasticFormat: &ElasticFormatConfig{
 			Action: "index",

--- a/pkg/formats/format.go
+++ b/pkg/formats/format.go
@@ -84,7 +84,7 @@ func NewFormat(ctx context.Context, format Format, log logger.Underlying, regist
 	case FORMAT_PROM_REMOTE:
 		return prom.NewRemoteFormat(log, compression, cfg.PrometheusFormat)
 	case FORMAT_OTEL:
-		return otel.NewFormat(ctx, log, cfg.OtelFormat, logTee)
+		return otel.NewFormat(ctx, log, cfg.OtelFormat, logTee, registry)
 	case FORMAT_SNMP:
 		return snmp.NewFormat(log, cfg.SnmpFormat)
 	case FORMAT_PARQUET:


### PR DESCRIPTION
Closes #868 

Adds a debug level log line: 
```
	f.Debugf("Channel queue at CHAN_SLACK limit for %s: %d/%d (100%%)", m.Name, queueDepth, CHAN_SLACK)
```

Also adds a new flag, `otel.no_block`. When this flag is enabled, rather than blocking on a full otel chan metrics will be dropped. When dropped, the internal metric `otel_export_drops` is incremented.

Thoughts @dconnolly-sfdc?