### PR TITLE
Faster api update

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -465,10 +465,10 @@ func (api *KentikApi) getSynthAndDeviceInfo(ctx context.Context) error {
 	api.synTests = synTests
 	api.Infof("Loaded %d Kentik Tests and %d Agents Total via API", len(api.synTests), len(api.synAgents))
 
-	return api.getDevceInfoNew(ctx)
+	return api.getDeviceInfoNew(ctx)
 }
 
-func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
+func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 
 	stime := time.Now()
 	resDev := map[kt.Cid]kt.Devices{}
@@ -549,25 +549,29 @@ func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) err
 			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
 		}
 		r, err := api.interfaceClient.ListInterface(ctxo, lt)
-		if err != nil {
 			if status.Code(err) == codes.Unimplemented {
-				api.Warnf("Interface ListInterfaces endpoint not implemented (deprecated API); skipping.")
+				api.Warnf("Interface ListInterface endpoint not implemented (deprecated API); skipping.")
 				return nil
 			}
 			return err
 		}
 
+		deviceIndex := make(map[kt.DeviceID]*kt.Device)
+		for _, clist := range api.devices {
+			for did, d := range clist {
+				deviceIndex[did] = d
+			}
+		}
+
 		found := 0
 		for _, intf := range r.GetInterfaces() {
-			for _, clist := range api.devices {
-				deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
-				if err != nil {
-					continue
-				}
-				if dd, ok := clist[kt.DeviceID(deviceID)]; ok {
-					dd.AddInterface(intf)
-					found++
-				}
+			deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
+			if err != nil {
+				continue
+			}
+			if dd, ok := deviceIndex[kt.DeviceID(deviceID)]; ok {
+				dd.AddInterface(intf)
+				found++
 			}
 		}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -112,7 +112,7 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 	return kapi, err
 }
 
-func (api *KentikApi) getDeviceInfo(ctx context.Context, apiUrl string, apiEmail string, apiToken string) ([]byte, error) {
+func (api *KentikApi) callRestAPI(ctx context.Context, apiUrl string, apiEmail string, apiToken string) ([]byte, error) {
 	if apiEmail == "" {
 		if v := api.config.API.DeviceFile; v != "" {
 			api.Infof("Reading devices from local file: %s", v)
@@ -243,68 +243,6 @@ func (api *KentikApi) GetDevice(cid kt.Cid, did kt.DeviceID) *kt.Device {
 	return nil
 }
 
-/**
-func (api *KentikApi) getInterfaces(ctx context.Context, did kt.DeviceID, info ktranslate.KentikCred) ([]kt.Interface, error) {
-	res, err := api.getDeviceInfo(ctx, fmt.Sprintf(api.config.APIBaseURL+"/api/internal/device/%d/interfaces", did), info.APIEmail, info.APIToken)
-	if err != nil {
-		return nil, err
-	}
-	interfaces := []kt.Interface{}
-	err = json.Unmarshal(res, &interfaces)
-	return interfaces, err
-}
-
-func (api *KentikApi) getDevices(ctx context.Context) error {
-	stime := time.Now()
-	resDev := map[kt.Cid]kt.Devices{}
-	num := 0
-	for _, info := range api.config.KentikCreds {
-		res, err := api.getDeviceInfo(ctx, api.config.APIBaseURL+"/api/internal/devices", info.APIEmail, info.APIToken)
-		if err != nil {
-			return err
-		}
-		var devices kt.DeviceList
-		err = json.Unmarshal(res, &devices)
-		if err != nil {
-			return err
-		}
-
-		for _, device := range devices.Devices {
-			myd := device
-			if _, ok := resDev[device.CompanyID]; !ok {
-				resDev[device.CompanyID] = map[kt.DeviceID]*kt.Device{}
-			}
-			myd.Interfaces = map[kt.IfaceID]kt.Interface{}
-			interfaces, err := api.getInterfaces(ctx, device.ID, info)
-			if err != nil {
-				api.Errorf("Cannot get interfaces for %v: %v", device.Name, err)
-			} else {
-				for _, intf := range interfaces {
-					intfl := intf // Should this be a pointer?
-					myd.Interfaces[intf.SnmpID] = intfl
-				}
-			}
-			resDev[device.CompanyID][device.ID] = &myd
-			num++
-		}
-
-		api.Infof("Loaded %d Kentik devices via API for %s", len(devices.Devices), info.APIEmail)
-	}
-
-	api.setTime = time.Now()
-	api.Infof("Loaded %d Kentik devices via API in %v", num, api.setTime.Sub(stime))
-	api.devices = resDev
-
-	// Now pull in site info for these devices.
-	err := api.getSites(ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-*/
-
 func (api *KentikApi) getSites(ctx context.Context) error {
 	stime := time.Now()
 	num := 0
@@ -314,7 +252,7 @@ func (api *KentikApi) getSites(ctx context.Context) error {
 
 	for _, info := range api.config.KentikCreds {
 		for _, version := range versions {
-			res, err := api.getDeviceInfo(ctx, fmt.Sprintf("%s/site/%s/sites", api.config.GRPCBaseURL, version), info.APIEmail, info.APIToken)
+			res, err := api.callRestAPI(ctx, fmt.Sprintf("%s/site/%s/sites", api.config.GRPCBaseURL, version), info.APIEmail, info.APIToken)
 			if err != nil {
 				api.Warnf("Skipping site version %s", version)
 				continue

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,6 +19,7 @@ import (
 
 	devicepb "github.com/kentik/api-schema-public/gen/go/kentik/device/v202504beta2"
 	tagging "github.com/kentik/api-schema-public/gen/go/kentik/enrichments/enumerations/v202601alpha1"
+	interfacepb "github.com/kentik/api-schema-public/gen/go/kentik/interface/v202108alpha1"
 	synthetics "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202309"
 	"github.com/kentik/ktranslate"
 	"github.com/kentik/ktranslate/pkg/eggs/logger"
@@ -39,6 +40,7 @@ const (
 	API_EMAIL_HEADER              = "X-CH-Auth-Email"
 	API_PASSWORD_HEADER           = "X-CH-Auth-API-Token"
 	MIN_TIME_BETWEEN_SYNTH_CHECKS = 60 * time.Second
+	KT_API_LOAD_INTERFACES        = "KT_API_LOAD_INTERFACES"
 )
 
 var (
@@ -61,10 +63,12 @@ type KentikApi struct {
 	apiTimeout      time.Duration
 	synClient       synthetics.SyntheticsAdminServiceClient
 	deviceClient    devicepb.DeviceServiceClient
+	interfaceClient interfacepb.InterfaceServiceClient
 	mux             sync.RWMutex
 	lastSynth       time.Time
 	config          *ktranslate.Config
 	tagLookupClient tagging.EnumerationsAdminServiceClient
+	loadInterfaces  bool
 }
 
 func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Config) (*KentikApi, error) {
@@ -87,11 +91,12 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 	client := &http.Client{Transport: tr, Timeout: apiTimeout}
 
 	kapi := &KentikApi{
-		ContextL:   log,
-		tr:         tr,
-		client:     client,
-		apiTimeout: apiTimeout,
-		config:     cfg,
+		ContextL:       log,
+		tr:             tr,
+		client:         client,
+		apiTimeout:     apiTimeout,
+		config:         cfg,
+		loadInterfaces: kt.LookupEnvBool(KT_API_LOAD_INTERFACES, false),
 	}
 
 	// Now, check to see if synthetics API works.
@@ -99,9 +104,6 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 	if err != nil {
 		return nil, err
 	}
-
-	// check api works and also pre-populate cache.
-	//err = kapi.getDevices(ctx)
 
 	// Drop cache every hour to keep up to date
 	go kapi.manageCache(ctx)
@@ -436,10 +438,12 @@ func (api *KentikApi) connectSynthAndLookup(ctxIn context.Context) error {
 	}
 
 	api.Infof("Connecting to API server at %s", address)
+	maxMsgSize := 50 * 1024 * 1024 // 50 MB
 	opts := []grpc.DialOption{
 		grpc.WithUserAgent(userAgent()),
 		grpc.WithKeepaliveParams(api.getClientKeepAlive()),
 		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
 	}
 
 	conn, err := grpc.NewClient(address, opts...)
@@ -458,6 +462,12 @@ func (api *KentikApi) connectSynthAndLookup(ctxIn context.Context) error {
 	deviceLookup := devicepb.NewDeviceServiceClient(conn)
 	api.Infof("Connected to Device Lookup API server at %s", address)
 	api.deviceClient = deviceLookup
+
+	if api.loadInterfaces {
+		interfaceLookup := interfacepb.NewInterfaceServiceClient(conn)
+		api.Infof("Connected to Interface Lookup API server at %s", address)
+		api.interfaceClient = interfaceLookup
+	}
 
 	return api.getSynthAndDeviceInfo(ctx)
 }
@@ -524,6 +534,7 @@ func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
 	stime := time.Now()
 	resDev := map[kt.Cid]kt.Devices{}
 	num := 0
+	deviceIds := []string{}
 
 	for _, info := range api.config.KentikCreds {
 		md := metadata.New(map[string]string{
@@ -533,7 +544,7 @@ func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
 		ctxo := metadata.NewOutgoingContext(ctx, md)
 
 		lt := &devicepb.ListDevicesRequest{
-			Query: &devicepb.DeviceQuery{NoCustomColumns: true},
+			Query: &devicepb.DeviceQuery{NoCustomColumns: false},
 		}
 		r, err := api.deviceClient.ListDevices(ctxo, lt)
 		if err != nil {
@@ -552,6 +563,7 @@ func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
 			if _, ok := resDev[dev.CompanyID]; !ok {
 				resDev[dev.CompanyID] = map[kt.DeviceID]*kt.Device{}
 			}
+			deviceIds = append(deviceIds, device.Id)
 			resDev[dev.CompanyID][dev.ID] = dev
 			num++
 		}
@@ -567,8 +579,62 @@ func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
 		return err
 	}
 
+	// If we are loading interfaces, pull in interface data now also.
+	if api.loadInterfaces {
+		const batchSize = 100
+		for i := 0; i < len(deviceIds); i += batchSize {
+			end := min(i+batchSize, len(deviceIds))
+			err := api.getInterfaces(ctx, deviceIds[i:end])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	api.setTime = time.Now()
 	api.Infof("Loaded %d Kentik Devices total via GRPC in %v", num, api.setTime.Sub(stime))
+	return nil
+}
+
+func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) error {
+	api.Infof("Loading %d device interfaces", len(deviceIds))
+
+	for _, info := range api.config.KentikCreds {
+		md := metadata.New(map[string]string{
+			"X-CH-Auth-Email":     info.APIEmail,
+			"X-CH-Auth-API-Token": info.APIToken,
+		})
+		ctxo := metadata.NewOutgoingContext(ctx, md)
+
+		lt := &interfacepb.ListInterfaceRequest{
+			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds},
+		}
+		r, err := api.interfaceClient.ListInterface(ctxo, lt)
+		if err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				api.Warnf("Device ListDevices endpoint not implemented (deprecated API); skipping.")
+				return nil
+			}
+			return err
+		}
+
+		found := 0
+		for _, intf := range r.GetInterfaces() {
+			for _, clist := range api.devices {
+				deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
+				if err != nil {
+					continue
+				}
+				if dd, ok := clist[kt.DeviceID(deviceID)]; ok {
+					dd.AddInterface(intf)
+					found++
+				}
+			}
+		}
+
+		api.Infof("Loaded %d Kentik Interfaces via GRPC for %s", found, info.APIEmail)
+	}
+
 	return nil
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -34,13 +34,14 @@ import (
 )
 
 const (
-	CACHE_TIME_DEVICE             = 1 * time.Hour
-	API_TIMEOUT                   = 60 * time.Second
-	HTTP_USER_AGENT               = "User-Agent"
-	API_EMAIL_HEADER              = "X-CH-Auth-Email"
-	API_PASSWORD_HEADER           = "X-CH-Auth-API-Token"
-	MIN_TIME_BETWEEN_SYNTH_CHECKS = 60 * time.Second
-	KT_API_LOAD_INTERFACES        = "KT_API_LOAD_INTERFACES"
+	CACHE_TIME_DEVICE               = 1 * time.Hour
+	API_TIMEOUT                     = 60 * time.Second
+	HTTP_USER_AGENT                 = "User-Agent"
+	API_EMAIL_HEADER                = "X-CH-Auth-Email"
+	API_PASSWORD_HEADER             = "X-CH-Auth-API-Token"
+	MIN_TIME_BETWEEN_SYNTH_CHECKS   = 60 * time.Second
+	KT_API_LOAD_INTERFACES          = "KT_API_LOAD_INTERFACES"
+	KT_INTERFACE_LOOKUP_TEXT_FILTER = "KT_INTERFACE_LOOKUP_TEXT_FILTER"
 )
 
 var (
@@ -607,12 +608,12 @@ func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) err
 		ctxo := metadata.NewOutgoingContext(ctx, md)
 
 		lt := &interfacepb.ListInterfaceRequest{
-			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds},
+			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
 		}
 		r, err := api.interfaceClient.ListInterface(ctxo, lt)
 		if err != nil {
 			if status.Code(err) == codes.Unimplemented {
-				api.Warnf("Device ListDevices endpoint not implemented (deprecated API); skipping.")
+				api.Warnf("Interface ListInterfaces endpoint not implemented (deprecated API); skipping.")
 				return nil
 			}
 			return err

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -536,9 +536,8 @@ func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 }
 
 func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) error {
-	api.Infof("Loading %d device interfaces", len(deviceIds))
-
 	for _, info := range api.config.KentikCreds {
+		api.Infof("Loading %d device interfaces for %s", len(deviceIds), info.APIEmail)
 		md := metadata.New(map[string]string{
 			"X-CH-Auth-Email":     info.APIEmail,
 			"X-CH-Auth-API-Token": info.APIToken,
@@ -549,6 +548,7 @@ func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) err
 			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
 		}
 		r, err := api.interfaceClient.ListInterface(ctxo, lt)
+		if err != nil {
 			if status.Code(err) == codes.Unimplemented {
 				api.Warnf("Interface ListInterface endpoint not implemented (deprecated API); skipping.")
 				return nil

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	devicepb "github.com/kentik/api-schema-public/gen/go/kentik/device/v202504beta2"
 	tagging "github.com/kentik/api-schema-public/gen/go/kentik/enrichments/enumerations/v202601alpha1"
 	synthetics "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202309"
 	"github.com/kentik/ktranslate"
@@ -59,6 +60,7 @@ type KentikApi struct {
 	setTime         time.Time
 	apiTimeout      time.Duration
 	synClient       synthetics.SyntheticsAdminServiceClient
+	deviceClient    devicepb.DeviceServiceClient
 	mux             sync.RWMutex
 	lastSynth       time.Time
 	config          *ktranslate.Config
@@ -99,7 +101,7 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 	}
 
 	// check api works and also pre-populate cache.
-	err = kapi.getDevices(ctx)
+	//err = kapi.getDevices(ctx)
 
 	// Drop cache every hour to keep up to date
 	go kapi.manageCache(ctx)
@@ -176,7 +178,7 @@ func (api *KentikApi) UpdateTests(ctx context.Context) {
 	}
 
 	go func() {
-		err := api.getSynthInfo(ctx)
+		err := api.getSynthAndDeviceInfo(ctx)
 		if err != nil {
 			api.Errorf("Cannot get API synth on demand: %v", err)
 		}
@@ -238,6 +240,7 @@ func (api *KentikApi) GetDevice(cid kt.Cid, did kt.DeviceID) *kt.Device {
 	return nil
 }
 
+/**
 func (api *KentikApi) getInterfaces(ctx context.Context, did kt.DeviceID, info ktranslate.KentikCred) ([]kt.Interface, error) {
 	res, err := api.getDeviceInfo(ctx, fmt.Sprintf(api.config.APIBaseURL+"/api/internal/device/%d/interfaces", did), info.APIEmail, info.APIToken)
 	if err != nil {
@@ -297,6 +300,7 @@ func (api *KentikApi) getDevices(ctx context.Context) error {
 
 	return nil
 }
+*/
 
 func (api *KentikApi) getSites(ctx context.Context) error {
 	stime := time.Now()
@@ -383,11 +387,7 @@ func (api *KentikApi) manageCache(ctx context.Context) {
 	for {
 		select {
 		case _ = <-checkTicker.C:
-			err := api.getDevices(ctx)
-			if err != nil {
-				api.Errorf("Cannot get API devices: %v", err)
-			}
-			err = api.getSynthInfo(ctx)
+			err := api.getSynthAndDeviceInfo(ctx)
 			if err != nil {
 				api.Errorf("Cannot get API synth: %v", err)
 			}
@@ -455,10 +455,14 @@ func (api *KentikApi) connectSynthAndLookup(ctxIn context.Context) error {
 	api.Infof("Connected to Tag Enum Lookup API server at %s", address)
 	api.tagLookupClient = clientLookup
 
-	return api.getSynthInfo(ctx)
+	deviceLookup := devicepb.NewDeviceServiceClient(conn)
+	api.Infof("Connected to Device Lookup API server at %s", address)
+	api.deviceClient = deviceLookup
+
+	return api.getSynthAndDeviceInfo(ctx)
 }
 
-func (api *KentikApi) getSynthInfo(ctx context.Context) error {
+func (api *KentikApi) getSynthAndDeviceInfo(ctx context.Context) error {
 	api.mux.Lock() // Guard this function totally.
 	defer api.mux.Unlock()
 	api.lastSynth = time.Now()
@@ -512,6 +516,59 @@ func (api *KentikApi) getSynthInfo(ctx context.Context) error {
 	api.synTests = synTests
 	api.Infof("Loaded %d Kentik Tests and %d Agents Total via API", len(api.synTests), len(api.synAgents))
 
+	return api.getDevceInfoNew(ctx)
+}
+
+func (api *KentikApi) getDevceInfoNew(ctx context.Context) error {
+
+	stime := time.Now()
+	resDev := map[kt.Cid]kt.Devices{}
+	num := 0
+
+	for _, info := range api.config.KentikCreds {
+		md := metadata.New(map[string]string{
+			"X-CH-Auth-Email":     info.APIEmail,
+			"X-CH-Auth-API-Token": info.APIToken,
+		})
+		ctxo := metadata.NewOutgoingContext(ctx, md)
+
+		lt := &devicepb.ListDevicesRequest{
+			Query: &devicepb.DeviceQuery{NoCustomColumns: true},
+		}
+		r, err := api.deviceClient.ListDevices(ctxo, lt)
+		if err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				api.Warnf("Device ListDevices endpoint not implemented (deprecated API); skipping.")
+				return nil
+			}
+			return err
+		}
+
+		for _, device := range r.GetDevices() {
+			dev, err := kt.MapDeviceDetailedToDevice(device)
+			if err != nil {
+				continue
+			}
+			if _, ok := resDev[dev.CompanyID]; !ok {
+				resDev[dev.CompanyID] = map[kt.DeviceID]*kt.Device{}
+			}
+			resDev[dev.CompanyID][dev.ID] = dev
+			num++
+		}
+
+		api.Infof("Loaded %d Kentik Devices via GRPC for %s", len(r.GetDevices()), info.APIEmail)
+	}
+
+	api.devices = resDev
+
+	// Now pull in site info for these devices.
+	err := api.getSites(ctx)
+	if err != nil {
+		return err
+	}
+
+	api.setTime = time.Now()
+	api.Infof("Loaded %d Kentik Devices total via GRPC in %v", num, api.setTime.Sub(stime))
 	return nil
 }
 

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -135,6 +135,9 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.CustomStr["SamplerAddress"] = d.SendingIps[0].String()
 		}
 		dst.CustomStr["device_site"] = d.Site.SiteName
+
+		fmt.Printf("DD %v %v\n", dst.InputPort, d.Interfaces)
+
 		if i, ok := d.Interfaces[dst.InputPort]; ok {
 			dst.InputIntDesc = i.Description
 			dst.InputIntAlias = i.Alias

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -135,14 +135,11 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.CustomStr["SamplerAddress"] = d.SendingIps[0].String()
 		}
 		dst.CustomStr["device_site"] = d.Site.SiteName
-
-		fmt.Printf("DD %v %v\n", dst.InputPort, d.Interfaces)
-
 		if i, ok := d.Interfaces[dst.InputPort]; ok {
 			dst.InputIntDesc = i.Description
 			dst.InputIntAlias = i.Alias
 			dst.InputInterfaceCapacity = i.SnmpSpeedMbps
-			//dst.InputInterfaceIP = i.Address
+			dst.InputInterfaceIP = i.Address
 			dst.CustomStr["input_provider"] = i.Provider
 			dst.CustomStr["input_network_boundary"] = i.NetworkBoundary
 			dst.CustomStr["input_connectivity_type"] = i.ConnectivityType
@@ -151,7 +148,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.OutputIntDesc = i.Description
 			dst.OutputIntAlias = i.Alias
 			dst.OutputInterfaceCapacity = i.SnmpSpeedMbps
-			//dst.OutputInterfaceIP = i.Address
+			dst.OutputInterfaceIP = i.Address
 			dst.CustomStr["output_provider"] = i.Provider
 			dst.CustomStr["output_network_boundary"] = i.NetworkBoundary
 			dst.CustomStr["output_connectivity_type"] = i.ConnectivityType

--- a/pkg/cat/jchf.go
+++ b/pkg/cat/jchf.go
@@ -139,7 +139,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.InputIntDesc = i.Description
 			dst.InputIntAlias = i.Alias
 			dst.InputInterfaceCapacity = i.SnmpSpeedMbps
-			dst.InputInterfaceIP = i.Address
+			//dst.InputInterfaceIP = i.Address
 			dst.CustomStr["input_provider"] = i.Provider
 			dst.CustomStr["input_network_boundary"] = i.NetworkBoundary
 			dst.CustomStr["input_connectivity_type"] = i.ConnectivityType
@@ -148,7 +148,7 @@ func (kc *KTranslate) flowToJCHF(ctx context.Context, dst *kt.JCHF, src *Flow, c
 			dst.OutputIntDesc = i.Description
 			dst.OutputIntAlias = i.Alias
 			dst.OutputInterfaceCapacity = i.SnmpSpeedMbps
-			dst.OutputInterfaceIP = i.Address
+			//dst.OutputInterfaceIP = i.Address
 			dst.CustomStr["output_provider"] = i.Provider
 			dst.CustomStr["output_network_boundary"] = i.NetworkBoundary
 			dst.CustomStr["output_connectivity_type"] = i.ConnectivityType

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -2,9 +2,11 @@ package kt
 
 import (
 	devicepb "github.com/kentik/api-schema-public/gen/go/kentik/device/v202504beta2"
+	interfacepb "github.com/kentik/api-schema-public/gen/go/kentik/interface/v202108alpha1"
 	sfmt "github.com/kentik/the-library-formally-known-as-go-syslog/format"
 
 	"fmt"
+	"github.com/kentik/ktranslate/pkg/util/ic"
 	"net"
 	"strconv"
 )
@@ -39,6 +41,7 @@ type Device struct {
 	Site          DeviceSite            `json:"site"`
 	allUserTags   map[string]string
 	FullSite      *FullSite
+	IDStr         string
 }
 
 type DeviceLabel struct {
@@ -167,6 +170,36 @@ type SiteMarket struct {
 	Desc string `json:"description"`
 }
 
+func (d *Device) AddInterface(p *interfacepb.Interface) {
+	if p == nil {
+		return
+	}
+
+	snmpID, err := strconv.ParseInt(p.GetSnmpId(), 10, 64)
+	if err != nil {
+		snmpID = 0
+	}
+
+	devID, err := strconv.ParseInt(p.GetDeviceId(), 10, 64)
+	if err != nil {
+		devID = 0
+	}
+
+	iface := Interface{
+		DeviceID:         DeviceID(devID),
+		Description:      p.GetInterfaceDescription(),
+		NetworkBoundary:  ic.NETWORK_BOUNDARY_INT_TO_NAME[int(p.GetNetworkBoundary())],
+		ConnectivityType: ic.CONNECTIVITY_TYPE_INT_TO_NAME[int(p.GetConnectivityType())],
+		Provider:         p.GetProvider(),
+		SnmpID:           IfaceID(snmpID),
+		Alias:            p.GetSnmpAlias(),
+		SnmpSpeedMbps:    int64(p.GetSnmpSpeed()),
+	}
+
+	d.AllInterfaces = append(d.AllInterfaces, iface)
+	d.Interfaces[IfaceID(snmpID)] = iface
+}
+
 func MapDeviceDetailedToDevice(dd *devicepb.DeviceDetailed) (*Device, error) {
 	if dd == nil {
 		return nil, fmt.Errorf("DeviceDetailed is nil")
@@ -241,6 +274,7 @@ func MapDeviceDetailedToDevice(dd *devicepb.DeviceDetailed) (*Device, error) {
 
 	return &Device{
 		ID:            DeviceID(deviceID),
+		IDStr:         dd.GetId(),
 		Name:          dd.GetDeviceName(),
 		CompanyID:     Cid(companyID),
 		DeviceType:    dd.GetDeviceType(),

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -1,9 +1,12 @@
 package kt
 
 import (
+	devicepb "github.com/kentik/api-schema-public/gen/go/kentik/device/v202504beta2"
 	sfmt "github.com/kentik/the-library-formally-known-as-go-syslog/format"
 
+	"fmt"
 	"net"
+	"strconv"
 )
 
 // Devices is a map of device ids to devices for a company.
@@ -53,10 +56,10 @@ type DeviceSite struct {
 // It corresponds to a row in mn_interface, joined with information
 // from mn_device and mn_site.
 type Interface struct {
-	DeviceID    DeviceID `json:"device_id,string"`
-	Address     string   `json:"interface_ip"`
-	Netmask     string   `json:"interface_ip_netmask"`
-	Description string   `json:"interface_description"`
+	DeviceID DeviceID `json:"device_id,string"`
+	//Address     string   `json:"interface_ip"`
+	Netmask     string `json:"interface_ip_netmask"`
+	Description string `json:"interface_description"`
 
 	NetworkBoundary  string `json:"network_boundary"`
 	ConnectivityType string `json:"connectivity_type"`
@@ -108,9 +111,13 @@ type Plan struct {
 }
 
 type Column struct {
-	ID   uint32 `json:"field_id,string"`
-	Name string `json:"col_name"`
-	Type string `json:"col_type"`
+	ID          uint32 `json:"field_id,string"`
+	Name        string `json:"col_name"`
+	Type        string `json:"col_type"`
+	DeviceID    string
+	FieldID     string
+	Description string
+	DeviceType  string
 }
 
 func (d *Device) InitUserTags(serviceName string, tags map[string]string) {
@@ -158,4 +165,182 @@ type SiteMarket struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Desc string `json:"description"`
+}
+
+func MapDeviceDetailedToDevice(dd *devicepb.DeviceDetailed) (*Device, error) {
+	if dd == nil {
+		return nil, fmt.Errorf("DeviceDetailed is nil")
+	}
+
+	deviceID, err := strconv.ParseInt(dd.GetId(), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing device ID %q: %w", dd.GetId(), err)
+	}
+
+	companyID, err := strconv.ParseInt(dd.GetCompanyId(), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing company ID %q: %w", dd.GetCompanyId(), err)
+	}
+
+	sampleRate, err := strconv.ParseUint(dd.GetDeviceSampleRate(), 10, 32)
+	if err != nil {
+		// Default to 0 if unparseable rather than failing hard
+		sampleRate = 0
+	}
+
+	ip := net.ParseIP(dd.GetDeviceSnmpIp())
+
+	sendingIPs := make([]net.IP, 0, len(dd.GetSendingIps()))
+	for _, s := range dd.GetSendingIps() {
+		if parsed := net.ParseIP(s); parsed != nil {
+			sendingIPs = append(sendingIPs, parsed)
+		}
+	}
+
+	ifaces, ifaceMap := mapInterfaces(dd.GetId(), dd.GetAllInterfaces())
+
+	labels := make([]DeviceLabel, 0, len(dd.GetLabels()))
+	for _, l := range dd.GetLabels() {
+		labelID, err := strconv.Atoi(l.GetId())
+		if err != nil {
+			labelID = 0
+		}
+		labels = append(labels, DeviceLabel{
+			ID:   labelID,
+			Name: l.GetName(),
+			Desc: l.GetDescription(),
+		})
+	}
+
+	site := DeviceSite{}
+	if s := dd.GetSite(); s != nil {
+		siteID, err := strconv.Atoi(s.GetId())
+		if err != nil {
+			siteID = 0
+		}
+		site = DeviceSite{
+			ID:       siteID,
+			SiteName: s.GetSiteName(),
+		}
+	}
+
+	plan := mapPlan(dd.GetPlan())
+
+	customs := mapCustomColumns(dd.GetCustomColumnData())
+
+	var snmpV3 *V3SNMPConfig
+	if v3 := dd.GetDeviceSnmpV3Conf(); v3 != nil {
+		snmpV3 = &V3SNMPConfig{
+			UserName:                 v3.GetUsername(),
+			AuthenticationProtocol:   v3.GetAuthenticationProtocol(),
+			AuthenticationPassphrase: v3.GetAuthenticationPassphrase(),
+			PrivacyProtocol:          v3.GetPrivacyProtocol(),
+			PrivacyPassphrase:        v3.GetPrivacyPassphrase(),
+		}
+	}
+
+	return &Device{
+		ID:            DeviceID(deviceID),
+		Name:          dd.GetDeviceName(),
+		CompanyID:     Cid(companyID),
+		DeviceType:    dd.GetDeviceType(),
+		DeviceSubtype: dd.GetDeviceSubtype(),
+		Description:   dd.GetDeviceDescription(),
+		IP:            ip,
+		Interfaces:    ifaceMap,
+		AllInterfaces: ifaces,
+		SendingIps:    sendingIPs,
+		SampleRate:    uint32(sampleRate),
+		BgpType:       dd.GetDeviceBgpType(),
+		Plan:          plan,
+		CdnAttr:       dd.GetCdnAttr(),
+		MaxFlowRate:   int(dd.GetMaxFlowRate()),
+		Customs:       customs,
+		CustomStr:     dd.GetCustomColumns(),
+		SnmpCommunity: dd.GetDeviceSnmpCommunity(),
+		SnmpIp:        dd.GetDeviceSnmpIp(),
+		SnmpV3:        snmpV3,
+		Labels:        labels,
+		Site:          site,
+	}, nil
+}
+
+func mapInterfaces(deviceID string, protos []*devicepb.Interface) ([]Interface, map[IfaceID]Interface) {
+	ifaces := make([]Interface, 0, len(protos))
+	ifaceMap := make(map[IfaceID]Interface, len(protos))
+
+	for _, p := range protos {
+		if p == nil {
+			continue
+		}
+
+		snmpID, err := strconv.ParseInt(p.GetSnmpId(), 10, 64)
+		if err != nil {
+			snmpID = 0
+		}
+
+		devID, err := strconv.ParseInt(deviceID, 10, 64)
+		if err != nil {
+			devID = 0
+		}
+
+		snmpSpeed, err := strconv.ParseInt(p.GetSnmpSpeed(), 10, 64)
+		if err != nil {
+			snmpSpeed = 0
+		}
+
+		iface := Interface{
+			DeviceID:         DeviceID(devID),
+			Description:      p.GetInterfaceDescription(),
+			NetworkBoundary:  p.GetNetworkBoundary(),
+			ConnectivityType: p.GetConnectivityType(),
+			Provider:         p.GetProvider(),
+			SnmpID:           IfaceID(snmpID),
+			Alias:            p.GetSnmpAlias(),
+			SnmpSpeedMbps:    snmpSpeed,
+		}
+
+		ifaces = append(ifaces, iface)
+		ifaceMap[IfaceID(snmpID)] = iface
+	}
+
+	return ifaces, ifaceMap
+}
+
+func mapPlan(p *devicepb.Plan) Plan {
+	if p == nil {
+		return Plan{}
+	}
+
+	planID, err := strconv.Atoi(p.GetId())
+	if err != nil {
+		planID = 0
+	}
+
+	return Plan{
+		ID:   uint64(planID),
+		Name: p.GetName(),
+	}
+}
+
+func mapCustomColumns(cols []*devicepb.CustomColumnData) []Column {
+	if len(cols) == 0 {
+		return nil
+	}
+
+	result := make([]Column, 0, len(cols))
+	for _, c := range cols {
+		if c == nil {
+			continue
+		}
+		result = append(result, Column{
+			DeviceID:    c.GetDeviceId(),
+			FieldID:     c.GetFieldId(),
+			Name:        c.GetColName(),
+			Description: c.GetDescription(),
+			Type:        c.GetColType(),
+			DeviceType:  c.GetDeviceType(),
+		})
+	}
+	return result
 }

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -59,10 +59,10 @@ type DeviceSite struct {
 // It corresponds to a row in mn_interface, joined with information
 // from mn_device and mn_site.
 type Interface struct {
-	DeviceID DeviceID `json:"device_id,string"`
-	//Address     string   `json:"interface_ip"`
-	Netmask     string `json:"interface_ip_netmask"`
-	Description string `json:"interface_description"`
+	DeviceID    DeviceID `json:"device_id,string"`
+	Address     string   `json:"interface_ip"`
+	Netmask     string   `json:"interface_ip_netmask"`
+	Description string   `json:"interface_description"`
 
 	NetworkBoundary  string `json:"network_boundary"`
 	ConnectivityType string `json:"connectivity_type"`
@@ -194,6 +194,7 @@ func (d *Device) AddInterface(p *interfacepb.Interface) {
 		SnmpID:           IfaceID(snmpID),
 		Alias:            p.GetSnmpAlias(),
 		SnmpSpeedMbps:    int64(p.GetSnmpSpeed()),
+		Address:          p.GetInterfaceIp(),
 	}
 
 	d.AllInterfaces = append(d.AllInterfaces, iface)

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -188,8 +188,8 @@ func (d *Device) AddInterface(p *interfacepb.Interface) {
 	iface := Interface{
 		DeviceID:         DeviceID(devID),
 		Description:      p.GetInterfaceDescription(),
-		NetworkBoundary:  ic.NETWORK_BOUNDARY_INT_TO_NAME[int(p.GetNetworkBoundary())],
-		ConnectivityType: ic.CONNECTIVITY_TYPE_INT_TO_NAME[int(p.GetConnectivityType())],
+		NetworkBoundary:  ic.NameFromNBInt(int(p.GetNetworkBoundary())),
+		ConnectivityType: ic.NameFromCTInt(int(p.GetConnectivityType())),
 		Provider:         p.GetProvider(),
 		SnmpID:           IfaceID(snmpID),
 		Alias:            p.GetSnmpAlias(),
@@ -368,7 +368,12 @@ func mapCustomColumns(cols []*devicepb.CustomColumnData) []Column {
 		if c == nil {
 			continue
 		}
+		fieldIDUint, err := strconv.ParseUint(c.GetFieldId(), 10, 32)
+		if err != nil {
+			fieldIDUint = 0
+		}
 		result = append(result, Column{
+			ID:          uint32(fieldIDUint),
 			DeviceID:    c.GetDeviceId(),
 			FieldID:     c.GetFieldId(),
 			Name:        c.GetColName(),

--- a/pkg/kt/device_types_test.go
+++ b/pkg/kt/device_types_test.go
@@ -1,0 +1,382 @@
+package kt
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kentik/api-schema-public/gen/go/kentik/device/v202504beta2"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// Helper to ptr-ify a bool, since MinimizeSnmp is *bool in the proto.
+func boolPtr(b bool) *bool { return &b }
+
+// --- happy path ---
+
+func TestMapDeviceDetailedToDevice_Full(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:                  "42",
+		CompanyId:           "7",
+		DeviceName:          "core-router-01",
+		DeviceType:          "router",
+		DeviceSubtype:       "cisco_csr",
+		DeviceDescription:   "Core router",
+		DeviceSampleRate:    "1024",
+		DeviceSnmpIp:        "10.0.0.1",
+		DeviceSnmpCommunity: "public",
+		DeviceBgpType:       "device",
+		CdnAttr:             "N",
+		MaxFlowRate:         500,
+		CustomColumns:       "col1,col2",
+		SendingIps:          []string{"192.168.1.1", "192.168.1.2"},
+		MinimizeSnmp:        boolPtr(false),
+
+		Site: &device.Site{
+			Id:       "99",
+			SiteName: "HQ",
+		},
+		Plan: &device.Plan{
+			Id:   "12",
+			Name: "Premium",
+		},
+		Labels: []*device.Label{
+			{Id: "1", Name: "prod", Description: "Production"},
+			{Id: "2", Name: "core", Description: "Core network"},
+		},
+		DeviceSnmpV3Conf: &device.DeviceSnmpV3Conf{
+			Username:                 "snmpuser",
+			AuthenticationProtocol:   "SHA",
+			AuthenticationPassphrase: "authpass",
+			PrivacyProtocol:          "AES",
+			PrivacyPassphrase:        "privpass",
+		},
+		AllInterfaces: []*device.Interface{
+			{
+				SnmpId:               "101",
+				SnmpAlias:            "eth0",
+				SnmpSpeed:            "1000",
+				InterfaceDescription: "Uplink",
+				NetworkBoundary:      "external",
+				ConnectivityType:     "transit",
+				Provider:             "ISP-A",
+			},
+			{
+				SnmpId:               "102",
+				SnmpAlias:            "eth1",
+				SnmpSpeed:            "10000",
+				InterfaceDescription: "Peering",
+				NetworkBoundary:      "external",
+				ConnectivityType:     "peering",
+				Provider:             "IX-B",
+			},
+		},
+		CustomColumnData: []*device.CustomColumnData{
+			{
+				DeviceId:    "42",
+				FieldId:     "f1",
+				ColName:     "region",
+				Description: "Region tag",
+				ColType:     "string",
+				DeviceType:  "router",
+			},
+		},
+	}
+
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// --- scalar fields ---
+	assertEqual(t, "ID", int64(got.ID), int64(42))
+	assertEqual(t, "CompanyID", int64(got.CompanyID), int64(7))
+	assertEqual(t, "Name", got.Name, "core-router-01")
+	assertEqual(t, "DeviceType", got.DeviceType, "router")
+	assertEqual(t, "DeviceSubtype", got.DeviceSubtype, "cisco_csr")
+	assertEqual(t, "Description", got.Description, "Core router")
+	assertEqual(t, "SampleRate", got.SampleRate, uint32(1024))
+	assertEqual(t, "BgpType", got.BgpType, "device")
+	assertEqual(t, "CdnAttr", got.CdnAttr, "N")
+	assertEqual(t, "MaxFlowRate", got.MaxFlowRate, 500)
+	assertEqual(t, "CustomStr", got.CustomStr, "col1,col2")
+	assertEqual(t, "SnmpCommunity", got.SnmpCommunity, "public")
+	assertEqual(t, "SnmpIp", got.SnmpIp, "10.0.0.1")
+
+	// --- IP ---
+	wantIP := net.ParseIP("10.0.0.1")
+	if !got.IP.Equal(wantIP) {
+		t.Errorf("IP: got %v, want %v", got.IP, wantIP)
+	}
+
+	// --- SendingIps ---
+	if len(got.SendingIps) != 2 {
+		t.Fatalf("SendingIps: got %d entries, want 2", len(got.SendingIps))
+	}
+	assertEqual(t, "SendingIps[0]", got.SendingIps[0].String(), "192.168.1.1")
+	assertEqual(t, "SendingIps[1]", got.SendingIps[1].String(), "192.168.1.2")
+
+	// --- Site ---
+	assertEqual(t, "Site.ID", got.Site.ID, 99)
+	assertEqual(t, "Site.SiteName", got.Site.SiteName, "HQ")
+
+	// --- Plan ---
+	assertEqual(t, "Plan.ID", got.Plan.ID, 12)
+	assertEqual(t, "Plan.Name", got.Plan.Name, "Premium")
+
+	// --- Labels ---
+	if len(got.Labels) != 2 {
+		t.Fatalf("Labels: got %d, want 2", len(got.Labels))
+	}
+	assertEqual(t, "Labels[0].ID", got.Labels[0].ID, 1)
+	assertEqual(t, "Labels[0].Name", got.Labels[0].Name, "prod")
+	assertEqual(t, "Labels[0].Desc", got.Labels[0].Desc, "Production")
+	assertEqual(t, "Labels[1].ID", got.Labels[1].ID, 2)
+	assertEqual(t, "Labels[1].Name", got.Labels[1].Name, "core")
+
+	// --- SnmpV3 ---
+	if got.SnmpV3 == nil {
+		t.Fatal("SnmpV3: got nil, want non-nil")
+	}
+	assertEqual(t, "SnmpV3.UserName", got.SnmpV3.UserName, "snmpuser")
+	assertEqual(t, "SnmpV3.AuthenticationProtocol", got.SnmpV3.AuthenticationProtocol, "SHA")
+	assertEqual(t, "SnmpV3.AuthenticationPassphrase", got.SnmpV3.AuthenticationPassphrase, "authpass")
+	assertEqual(t, "SnmpV3.PrivacyProtocol", got.SnmpV3.PrivacyProtocol, "AES")
+	assertEqual(t, "SnmpV3.PrivacyPassphrase", got.SnmpV3.PrivacyPassphrase, "privpass")
+
+	// --- AllInterfaces ---
+	if len(got.AllInterfaces) != 2 {
+		t.Fatalf("AllInterfaces: got %d, want 2", len(got.AllInterfaces))
+	}
+	iface0 := got.AllInterfaces[0]
+	assertEqual(t, "AllInterfaces[0].DeviceID", int64(iface0.DeviceID), int64(42))
+	assertEqual(t, "AllInterfaces[0].SnmpID", int64(iface0.SnmpID), int64(101))
+	assertEqual(t, "AllInterfaces[0].Alias", iface0.Alias, "eth0")
+	assertEqual(t, "AllInterfaces[0].SnmpSpeedMbps", iface0.SnmpSpeedMbps, int64(1000))
+	assertEqual(t, "AllInterfaces[0].Description", iface0.Description, "Uplink")
+	assertEqual(t, "AllInterfaces[0].NetworkBoundary", iface0.NetworkBoundary, "external")
+	assertEqual(t, "AllInterfaces[0].ConnectivityType", iface0.ConnectivityType, "transit")
+	assertEqual(t, "AllInterfaces[0].Provider", iface0.Provider, "ISP-A")
+
+	// --- Interfaces map ---
+	if len(got.Interfaces) != 2 {
+		t.Fatalf("Interfaces map: got %d entries, want 2", len(got.Interfaces))
+	}
+	if _, ok := got.Interfaces[IfaceID(101)]; !ok {
+		t.Error("Interfaces map: missing key 101")
+	}
+	if _, ok := got.Interfaces[IfaceID(102)]; !ok {
+		t.Error("Interfaces map: missing key 102")
+	}
+
+	// --- Customs ---
+	if len(got.Customs) != 1 {
+		t.Fatalf("Customs: got %d, want 1", len(got.Customs))
+	}
+	col := got.Customs[0]
+	assertEqual(t, "Customs[0].Name", col.Name, "region")
+	assertEqual(t, "Customs[0].Description", col.Description, "Region tag")
+	assertEqual(t, "Customs[0].Type", col.Type, "string")
+}
+
+// --- nil input ---
+
+func TestMapDeviceDetailedToDevice_NilInput(t *testing.T) {
+	_, err := MapDeviceDetailedToDevice(nil)
+	if err == nil {
+		t.Fatal("expected error for nil input, got nil")
+	}
+}
+
+// --- invalid IDs ---
+
+func TestMapDeviceDetailedToDevice_InvalidDeviceID(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "not-a-number",
+		CompanyId:        "7",
+		DeviceSampleRate: "1",
+	}
+	_, err := MapDeviceDetailedToDevice(proto)
+	if err == nil {
+		t.Fatal("expected error for non-numeric device ID, got nil")
+	}
+}
+
+func TestMapDeviceDetailedToDevice_InvalidCompanyID(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "not-a-number",
+		DeviceSampleRate: "1",
+	}
+	_, err := MapDeviceDetailedToDevice(proto)
+	if err == nil {
+		t.Fatal("expected error for non-numeric company ID, got nil")
+	}
+}
+
+// --- graceful degradation ---
+
+func TestMapDeviceDetailedToDevice_EmptySendingIps(t *testing.T) {
+	proto := &device.DeviceDetailed{Id: "1", CompanyId: "2", DeviceSampleRate: "100"}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.SendingIps) != 0 {
+		t.Errorf("SendingIps: got %v, want empty", got.SendingIps)
+	}
+}
+
+func TestMapDeviceDetailedToDevice_InvalidSendingIpSkipped(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		SendingIps:       []string{"bad-ip", "10.1.2.3", "also-bad"},
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.SendingIps) != 1 {
+		t.Fatalf("SendingIps: got %d entries, want 1", len(got.SendingIps))
+	}
+	assertEqual(t, "SendingIps[0]", got.SendingIps[0].String(), "10.1.2.3")
+}
+
+func TestMapDeviceDetailedToDevice_InvalidSampleRateDefaultsToZero(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "not-a-number",
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertEqual(t, "SampleRate", got.SampleRate, uint32(0))
+}
+
+func TestMapDeviceDetailedToDevice_NilSnmpV3ConfYieldsNilPointer(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		DeviceSnmpV3Conf: nil,
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SnmpV3 != nil {
+		t.Errorf("SnmpV3: expected nil, got %+v", got.SnmpV3)
+	}
+}
+
+func TestMapDeviceDetailedToDevice_NilSiteAndPlan(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		Site:             nil,
+		Plan:             nil,
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertEqual(t, "Site.ID", got.Site.ID, 0)
+	assertEqual(t, "Site.SiteName", got.Site.SiteName, "")
+	assertEqual(t, "Plan.ID", got.Plan.ID, 0)
+	assertEqual(t, "Plan.Name", got.Plan.Name, "")
+}
+
+func TestMapDeviceDetailedToDevice_LabelWithNonNumericID(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		Labels: []*device.Label{
+			{Id: "bad", Name: "whatever", Description: "desc"},
+		},
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Labels) != 1 {
+		t.Fatalf("Labels: got %d, want 1", len(got.Labels))
+	}
+	// Non-numeric label ID should fall back to 0.
+	assertEqual(t, "Labels[0].ID", got.Labels[0].ID, 0)
+	assertEqual(t, "Labels[0].Name", got.Labels[0].Name, "whatever")
+}
+
+func TestMapDeviceDetailedToDevice_InterfaceWithBadSnmpIDDefaultsToZero(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "5",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		AllInterfaces: []*device.Interface{
+			{SnmpId: "not-a-number", SnmpAlias: "eth0", SnmpSpeed: "1000"},
+		},
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.AllInterfaces) != 1 {
+		t.Fatalf("AllInterfaces: got %d, want 1", len(got.AllInterfaces))
+	}
+	assertEqual(t, "AllInterfaces[0].SnmpID", int64(got.AllInterfaces[0].SnmpID), int64(0))
+}
+
+func TestMapDeviceDetailedToDevice_EmptyDeviceHasEmptyInterfaceMap(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+	}
+	got, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Interfaces == nil {
+		t.Error("Interfaces map should be non-nil even when empty")
+	}
+	if len(got.Interfaces) != 0 {
+		t.Errorf("Interfaces: got %d entries, want 0", len(got.Interfaces))
+	}
+}
+
+// Verify that NMS config (present in the proto but absent from Device) does not
+// cause a panic — the mapping simply ignores it.
+func TestMapDeviceDetailedToDevice_NmsConfigIgnored(t *testing.T) {
+	proto := &device.DeviceDetailed{
+		Id:               "1",
+		CompanyId:        "2",
+		DeviceSampleRate: "100",
+		Nms: &device.DeviceNmsConfig{
+			AgentId:   "agent-xyz",
+			IpAddress: "10.0.0.5",
+			Snmp: &device.DeviceNmsSnmpConfig{
+				CredentialName: "my-cred",
+				Port:           161,
+				Timeout:        durationpb.New(2e9),
+			},
+		},
+	}
+	_, err := MapDeviceDetailedToDevice(proto)
+	if err != nil {
+		t.Fatalf("unexpected error with NMS config present: %v", err)
+	}
+}
+
+// --- helper ---
+
+// assertEqual is a typed-equality helper that avoids importing testify.
+func assertEqual[T comparable](t *testing.T, field string, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s: got %v, want %v", field, got, want)
+	}
+}


### PR DESCRIPTION
Redo of the device and interface loading apis to use the grpc v6 ones.

By default, will only load device info, not interfaces.

Turn on interface loading with env var:
```
KT_API_LOAD_INTERFACES=true
```

Fine tune which interfaces get loaded with:
```
KT_INTERFACE_LOOKUP_TEXT_FILTER=$QUERY
```

where `$QUERY` is matched against interface alias and descriptions. For example, `KT_INTERFACE_LOOKUP_TEXT_FILTER=PEERING`

