### PR TITLE
Allowing for lazy loading of interfaces

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,7 +40,6 @@ const (
 	API_EMAIL_HEADER                = "X-CH-Auth-Email"
 	API_PASSWORD_HEADER             = "X-CH-Auth-API-Token"
 	MIN_TIME_BETWEEN_SYNTH_CHECKS   = 60 * time.Second
-	KT_API_LOAD_INTERFACES          = "KT_API_LOAD_INTERFACES"
 	KT_INTERFACE_LOOKUP_TEXT_FILTER = "KT_INTERFACE_LOOKUP_TEXT_FILTER"
 	KT_LOAD_CUSTOM_COLUMNS          = "KT_LOAD_CUSTOM_COLUMNS"
 	KT_API_LAZY_LOAD_CUSTOMS        = "KT_API_LAZY_LOAD_CUSTOMS"
@@ -57,24 +56,25 @@ func init() {
 
 type KentikApi struct {
 	logger.ContextL
-	tr              *http.Transport
-	client          *http.Client
-	devices         map[kt.Cid]kt.Devices
-	synAgents       map[kt.AgentId]*synthetics.Agent
-	synAgentsByIP   map[string]*synthetics.Agent
-	synTests        map[kt.TestId]*synthetics.Test
-	setTime         time.Time
-	apiTimeout      time.Duration
-	synClient       synthetics.SyntheticsAdminServiceClient
-	deviceClient    devicepb.DeviceServiceClient
-	interfaceClient interfacepb.InterfaceServiceClient
-	mux             sync.RWMutex
-	lastSynth       time.Time
-	config          *ktranslate.Config
-	tagLookupClient tagging.EnumerationsAdminServiceClient
-	lazyLoadCustoms bool
-	fullLoadCustoms bool
-	lazyLoadInts    bool
+	tr                  *http.Transport
+	client              *http.Client
+	devices             map[kt.Cid]kt.Devices
+	synAgents           map[kt.AgentId]*synthetics.Agent
+	synAgentsByIP       map[string]*synthetics.Agent
+	synTests            map[kt.TestId]*synthetics.Test
+	setTime             time.Time
+	apiTimeout          time.Duration
+	synClient           synthetics.SyntheticsAdminServiceClient
+	deviceClient        devicepb.DeviceServiceClient
+	interfaceClient     interfacepb.InterfaceServiceClient
+	mux                 sync.RWMutex
+	lastSynth           time.Time
+	config              *ktranslate.Config
+	tagLookupClient     tagging.EnumerationsAdminServiceClient
+	lazyLoadCustoms     bool
+	fullLoadCustoms     bool
+	lazyLoadInts        bool
+	interfaceFilterText string
 }
 
 func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Config) (*KentikApi, error) {
@@ -96,14 +96,15 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 	client := &http.Client{Transport: tr, Timeout: apiTimeout}
 
 	kapi := &KentikApi{
-		ContextL:        log,
-		tr:              tr,
-		client:          client,
-		apiTimeout:      apiTimeout,
-		config:          cfg,
-		lazyLoadCustoms: kt.LookupEnvBool(KT_API_LAZY_LOAD_CUSTOMS, false),
-		fullLoadCustoms: kt.LookupEnvBool(KT_LOAD_CUSTOM_COLUMNS, false),
-		lazyLoadInts:    kt.LookupEnvBool(KT_API_LAZY_LOAD_INTERFACES, false),
+		ContextL:            log,
+		tr:                  tr,
+		client:              client,
+		apiTimeout:          apiTimeout,
+		config:              cfg,
+		lazyLoadCustoms:     kt.LookupEnvBool(KT_API_LAZY_LOAD_CUSTOMS, false),
+		fullLoadCustoms:     kt.LookupEnvBool(KT_LOAD_CUSTOM_COLUMNS, false),
+		lazyLoadInts:        kt.LookupEnvBool(KT_API_LAZY_LOAD_INTERFACES, false),
+		interfaceFilterText: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, ""),
 	}
 
 	log.Infof("Setting API timeout to %v, lazyLoadInterfaces=%v, lazyLoadCustoms=%v, fullyLoadCustoms=%v",
@@ -585,7 +586,7 @@ func (api *KentikApi) getInterfaces(ctx context.Context, deviceId string, dev *k
 
 	api.Debugf("Loading interfaces for %s", deviceId)
 	lt := &interfacepb.ListInterfaceRequest{
-		Filters: &interfacepb.InterfaceFilter{DeviceIds: []string{deviceId}, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
+		Filters: &interfacepb.InterfaceFilter{DeviceIds: []string{deviceId}, Text: api.interfaceFilterText},
 	}
 	r, err := api.interfaceClient.ListInterface(ctx, lt)
 	if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -44,6 +44,7 @@ const (
 	KT_INTERFACE_LOOKUP_TEXT_FILTER = "KT_INTERFACE_LOOKUP_TEXT_FILTER"
 	KT_LOAD_CUSTOM_COLUMNS          = "KT_LOAD_CUSTOM_COLUMNS"
 	KT_API_LAZY_LOAD_CUSTOMS        = "KT_API_LAZY_LOAD_CUSTOMS"
+	KT_API_LAZY_LOAD_INTERFACES     = "KT_API_LAZY_LOAD_INTERFACES"
 )
 
 var (
@@ -74,6 +75,7 @@ type KentikApi struct {
 	loadInterfaces  bool
 	lazyLoadCustoms bool
 	fullLoadCustoms bool
+	lazyLoadInts    bool
 }
 
 func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Config) (*KentikApi, error) {
@@ -103,9 +105,11 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 		loadInterfaces:  kt.LookupEnvBool(KT_API_LOAD_INTERFACES, false),
 		lazyLoadCustoms: kt.LookupEnvBool(KT_API_LAZY_LOAD_CUSTOMS, false),
 		fullLoadCustoms: kt.LookupEnvBool(KT_LOAD_CUSTOM_COLUMNS, false),
+		lazyLoadInts:    kt.LookupEnvBool(KT_API_LAZY_LOAD_INTERFACES, false),
 	}
 
-	log.Infof("Setting API timeout to %v, loadInterfaces=%v, lazyLoadCustoms=%v, fullyLoadCustoms=%v", apiTimeout, kapi.loadInterfaces, kapi.lazyLoadCustoms, kapi.fullLoadCustoms)
+	log.Infof("Setting API timeout to %v, loadInterfaces=%v, lazyLoadInterfaces=%v, lazyLoadCustoms=%v, fullyLoadCustoms=%v",
+		apiTimeout, kapi.loadInterfaces, kapi.lazyLoadInts, kapi.lazyLoadCustoms, kapi.fullLoadCustoms)
 
 	// Now, check to see if synthetics API works.
 	err := kapi.connectSynthAndLookup(ctx)
@@ -261,6 +265,12 @@ func (api *KentikApi) GetDevice(ctx context.Context, cid kt.Cid, did kt.DeviceID
 					if err != nil {
 						api.Warnf("Cannot load customs for %s %s, %v", dev.IDStr, info.APIEmail, err)
 					} else {
+						if api.lazyLoadInts {
+							err := api.getInterfaces(ctxo, []string{dev.IDStr})
+							if err != nil {
+								api.Warnf("Cannot load interfaces for %s %s, %v", dev.IDStr, info.APIEmail, err)
+							}
+						}
 						return
 					}
 				}
@@ -430,7 +440,7 @@ func (api *KentikApi) connectSynthAndLookup(ctxIn context.Context) error {
 	api.Infof("Connected to Device Lookup API server at %s", address)
 	api.deviceClient = deviceLookup
 
-	if api.loadInterfaces {
+	if api.loadInterfaces || api.lazyLoadInts {
 		interfaceLookup := interfacepb.NewInterfaceServiceClient(conn)
 		api.Infof("Connected to Interface Lookup API server at %s", address)
 		api.interfaceClient = interfaceLookup
@@ -557,6 +567,18 @@ func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 			num++
 		}
 
+		// If we are loading interfaces, pull in interface data now also.
+		if api.loadInterfaces {
+			const batchSize = 100
+			for i := 0; i < len(deviceIds); i += batchSize {
+				end := min(i+batchSize, len(deviceIds))
+				err := api.getInterfaces(ctxo, deviceIds[i:end])
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		api.Infof("Loaded %d Kentik Devices via GRPC for %s", len(r.GetDevices()), info.APIEmail)
 	}
 
@@ -568,65 +590,45 @@ func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 		return err
 	}
 
-	// If we are loading interfaces, pull in interface data now also.
-	if api.loadInterfaces {
-		const batchSize = 100
-		for i := 0; i < len(deviceIds); i += batchSize {
-			end := min(i+batchSize, len(deviceIds))
-			err := api.getInterfaces(ctx, deviceIds[i:end])
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	api.setTime = time.Now()
 	api.Infof("Loaded %d Kentik Devices total via GRPC in %v", num, api.setTime.Sub(stime))
 	return nil
 }
 
 func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) error {
-	for _, info := range api.config.KentikCreds {
-		api.Infof("Loading %d device interfaces for %s", len(deviceIds), info.APIEmail)
-		md := metadata.New(map[string]string{
-			"X-CH-Auth-Email":     info.APIEmail,
-			"X-CH-Auth-API-Token": info.APIToken,
-		})
-		ctxo := metadata.NewOutgoingContext(ctx, md)
 
-		lt := &interfacepb.ListInterfaceRequest{
-			Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
-		}
-		r, err := api.interfaceClient.ListInterface(ctxo, lt)
-		if err != nil {
-			if status.Code(err) == codes.Unimplemented {
-				api.Warnf("Interface ListInterface endpoint not implemented (deprecated API); skipping.")
-				return nil
-			}
-			return err
-		}
-
-		deviceIndex := make(map[kt.DeviceID]*kt.Device)
-		for _, clist := range api.devices {
-			for did, d := range clist {
-				deviceIndex[did] = d
-			}
-		}
-
-		found := 0
-		for _, intf := range r.GetInterfaces() {
-			deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
-			if err != nil {
-				continue
-			}
-			if dd, ok := deviceIndex[kt.DeviceID(deviceID)]; ok {
-				dd.AddInterface(intf)
-				found++
-			}
-		}
-
-		api.Infof("Loaded %d Kentik Interfaces via GRPC for %s", found, info.APIEmail)
+	api.Debugf("Loading interfaces for %v", deviceIds)
+	lt := &interfacepb.ListInterfaceRequest{
+		Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
 	}
+	r, err := api.interfaceClient.ListInterface(ctx, lt)
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			api.Warnf("Interface ListInterface endpoint not implemented (deprecated API); skipping.")
+			return nil
+		}
+		return err
+	}
+
+	deviceIndex := make(map[kt.DeviceID]*kt.Device)
+	for _, clist := range api.devices {
+		for did, d := range clist {
+			deviceIndex[did] = d
+		}
+	}
+
+	found := 0
+	for _, intf := range r.GetInterfaces() {
+		deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
+		if err != nil {
+			continue
+		}
+		if dd, ok := deviceIndex[kt.DeviceID(deviceID)]; ok {
+			dd.AddInterface(intf)
+			found++
+		}
+	}
+	api.Debugf("Added %d interfaces for %d devices", found, len(deviceIds))
 
 	return nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -72,7 +72,6 @@ type KentikApi struct {
 	lastSynth       time.Time
 	config          *ktranslate.Config
 	tagLookupClient tagging.EnumerationsAdminServiceClient
-	loadInterfaces  bool
 	lazyLoadCustoms bool
 	fullLoadCustoms bool
 	lazyLoadInts    bool
@@ -102,14 +101,13 @@ func NewKentikApi(ctx context.Context, log logger.ContextL, cfg *ktranslate.Conf
 		client:          client,
 		apiTimeout:      apiTimeout,
 		config:          cfg,
-		loadInterfaces:  kt.LookupEnvBool(KT_API_LOAD_INTERFACES, false),
 		lazyLoadCustoms: kt.LookupEnvBool(KT_API_LAZY_LOAD_CUSTOMS, false),
 		fullLoadCustoms: kt.LookupEnvBool(KT_LOAD_CUSTOM_COLUMNS, false),
 		lazyLoadInts:    kt.LookupEnvBool(KT_API_LAZY_LOAD_INTERFACES, false),
 	}
 
-	log.Infof("Setting API timeout to %v, loadInterfaces=%v, lazyLoadInterfaces=%v, lazyLoadCustoms=%v, fullyLoadCustoms=%v",
-		apiTimeout, kapi.loadInterfaces, kapi.lazyLoadInts, kapi.lazyLoadCustoms, kapi.fullLoadCustoms)
+	log.Infof("Setting API timeout to %v, lazyLoadInterfaces=%v, lazyLoadCustoms=%v, fullyLoadCustoms=%v",
+		apiTimeout, kapi.lazyLoadInts, kapi.lazyLoadCustoms, kapi.fullLoadCustoms)
 
 	// Now, check to see if synthetics API works.
 	err := kapi.connectSynthAndLookup(ctx)
@@ -266,7 +264,7 @@ func (api *KentikApi) GetDevice(ctx context.Context, cid kt.Cid, did kt.DeviceID
 						api.Warnf("Cannot load customs for %s %s, %v", dev.IDStr, info.APIEmail, err)
 					} else {
 						if api.lazyLoadInts {
-							err := api.getInterfaces(ctxo, []string{dev.IDStr})
+							err := api.getInterfaces(ctxo, dev.IDStr, dev)
 							if err != nil {
 								api.Warnf("Cannot load interfaces for %s %s, %v", dev.IDStr, info.APIEmail, err)
 							}
@@ -440,7 +438,7 @@ func (api *KentikApi) connectSynthAndLookup(ctxIn context.Context) error {
 	api.Infof("Connected to Device Lookup API server at %s", address)
 	api.deviceClient = deviceLookup
 
-	if api.loadInterfaces || api.lazyLoadInts {
+	if api.lazyLoadInts {
 		interfaceLookup := interfacepb.NewInterfaceServiceClient(conn)
 		api.Infof("Connected to Interface Lookup API server at %s", address)
 		api.interfaceClient = interfaceLookup
@@ -567,18 +565,6 @@ func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 			num++
 		}
 
-		// If we are loading interfaces, pull in interface data now also.
-		if api.loadInterfaces {
-			const batchSize = 100
-			for i := 0; i < len(deviceIds); i += batchSize {
-				end := min(i+batchSize, len(deviceIds))
-				err := api.getInterfaces(ctxo, deviceIds[i:end])
-				if err != nil {
-					return err
-				}
-			}
-		}
-
 		api.Infof("Loaded %d Kentik Devices via GRPC for %s", len(r.GetDevices()), info.APIEmail)
 	}
 
@@ -595,11 +581,11 @@ func (api *KentikApi) getDeviceInfoNew(ctx context.Context) error {
 	return nil
 }
 
-func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) error {
+func (api *KentikApi) getInterfaces(ctx context.Context, deviceId string, dev *kt.Device) error {
 
-	api.Debugf("Loading interfaces for %v", deviceIds)
+	api.Debugf("Loading interfaces for %s", deviceId)
 	lt := &interfacepb.ListInterfaceRequest{
-		Filters: &interfacepb.InterfaceFilter{DeviceIds: deviceIds, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
+		Filters: &interfacepb.InterfaceFilter{DeviceIds: []string{deviceId}, Text: kt.LookupEnvString(KT_INTERFACE_LOOKUP_TEXT_FILTER, "")},
 	}
 	r, err := api.interfaceClient.ListInterface(ctx, lt)
 	if err != nil {
@@ -610,26 +596,7 @@ func (api *KentikApi) getInterfaces(ctx context.Context, deviceIds []string) err
 		return err
 	}
 
-	deviceIndex := make(map[kt.DeviceID]*kt.Device)
-	for _, clist := range api.devices {
-		for did, d := range clist {
-			deviceIndex[did] = d
-		}
-	}
-
-	found := 0
-	for _, intf := range r.GetInterfaces() {
-		deviceID, err := strconv.ParseInt(intf.GetDeviceId(), 10, 64)
-		if err != nil {
-			continue
-		}
-		if dd, ok := deviceIndex[kt.DeviceID(deviceID)]; ok {
-			dd.AddInterface(intf)
-			found++
-		}
-	}
-	api.Debugf("Added %d interfaces for %d devices", found, len(deviceIds))
-
+	dev.AddInterfaces(r.GetInterfaces())
 	return nil
 }
 

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -184,35 +184,39 @@ func (d *Device) LoadedCustoms() bool {
 	return lc
 }
 
-func (d *Device) AddInterface(p *interfacepb.Interface) {
-	if p == nil {
-		return
+func (d *Device) AddInterfaces(ints []*interfacepb.Interface) {
+
+	ifaces := make([]Interface, len(ints))
+	ifacemap := map[IfaceID]Interface{}
+	for i, p := range ints {
+		snmpID, err := strconv.ParseInt(p.GetSnmpId(), 10, 64)
+		if err != nil {
+			snmpID = 0
+		}
+
+		devID, err := strconv.ParseInt(p.GetDeviceId(), 10, 64)
+		if err != nil {
+			devID = 0
+		}
+
+		iface := Interface{
+			DeviceID:         DeviceID(devID),
+			Description:      p.GetInterfaceDescription(),
+			NetworkBoundary:  ic.NameFromNBInt(int(p.GetNetworkBoundary())),
+			ConnectivityType: ic.NameFromCTInt(int(p.GetConnectivityType())),
+			Provider:         p.GetProvider(),
+			SnmpID:           IfaceID(snmpID),
+			Alias:            p.GetSnmpAlias(),
+			SnmpSpeedMbps:    int64(p.GetSnmpSpeed()),
+			Address:          p.GetInterfaceIp(),
+		}
+
+		ifaces[i] = iface
+		ifacemap[IfaceID(snmpID)] = iface
 	}
 
-	snmpID, err := strconv.ParseInt(p.GetSnmpId(), 10, 64)
-	if err != nil {
-		snmpID = 0
-	}
-
-	devID, err := strconv.ParseInt(p.GetDeviceId(), 10, 64)
-	if err != nil {
-		devID = 0
-	}
-
-	iface := Interface{
-		DeviceID:         DeviceID(devID),
-		Description:      p.GetInterfaceDescription(),
-		NetworkBoundary:  ic.NameFromNBInt(int(p.GetNetworkBoundary())),
-		ConnectivityType: ic.NameFromCTInt(int(p.GetConnectivityType())),
-		Provider:         p.GetProvider(),
-		SnmpID:           IfaceID(snmpID),
-		Alias:            p.GetSnmpAlias(),
-		SnmpSpeedMbps:    int64(p.GetSnmpSpeed()),
-		Address:          p.GetInterfaceIp(),
-	}
-
-	d.AllInterfaces = append(d.AllInterfaces, iface)
-	d.Interfaces[IfaceID(snmpID)] = iface
+	d.AllInterfaces = ifaces
+	d.Interfaces = ifacemap
 }
 
 func MapDeviceDetailedToDevice(dd *devicepb.DeviceDetailed) (*Device, error) {

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -189,6 +189,10 @@ func (d *Device) AddInterfaces(ints []*interfacepb.Interface) {
 	ifaces := make([]Interface, len(ints))
 	ifacemap := map[IfaceID]Interface{}
 	for i, p := range ints {
+		if p == nil {
+			continue
+		}
+
 		snmpID, err := strconv.ParseInt(p.GetSnmpId(), 10, 64)
 		if err != nil {
 			snmpID = 0


### PR DESCRIPTION
Using the env var `KT_API_LAZY_LOAD_INTERFACES=true`, load interfaces along with custom columns. 