### PR TITLE
Fix devices.json site IDs crashing container startup after #916

### DIFF
--- a/config/devices.json
+++ b/config/devices.json
@@ -6,11 +6,11 @@
     "device_status": "V",
     "device_description": "GCE VM kentik-vpc-flow default",
     "site": {
-      "id": 4,
+      "id": "4",
       "site_name": "Hong Kong",
       "lat": 22.3738844,
       "lon": 113.9999832,
-      "company_id": 1289
+      "company_id": "1289"
     },
     "plan": {
       "active": true,

--- a/pkg/kt/device_types.go
+++ b/pkg/kt/device_types.go
@@ -38,7 +38,7 @@ type Device struct {
 	SnmpIp        string                `json:"device_snmp_ip"`
 	SnmpV3        *V3SNMPConfig         `json:"device_snmp_v3_conf"`
 	Labels        []DeviceLabel         `json:"labels"`
-	Site          *devicepb.Site
+	Site          *devicepb.Site        `json:"site"`
 	allUserTags   map[string]string
 	FullSite      *sitepb.Site
 	IDStr         string

--- a/pkg/kt/devices_json_test.go
+++ b/pkg/kt/devices_json_test.go
@@ -1,0 +1,47 @@
+package kt
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The Docker image ENTRYPOINT always passes -api_devices /etc/ktranslate/devices.json.
+// After Site moved onto protobuf string IDs (#916), numeric site.id / site.company_id in
+// that file caused every container to fail at startup with:
+//
+//	json: cannot unmarshal number into Go struct field Site.Site.id of type string
+func TestShippedDevicesJSONUnmarshals(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	devicesFile := filepath.Join(filepath.Dir(thisFile), "..", "..", "config", "devices.json")
+
+	raw, err := os.ReadFile(devicesFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", devicesFile, err)
+	}
+
+	var devices map[string]*Device
+	if err := json.Unmarshal(raw, &devices); err != nil {
+		t.Fatalf("unmarshal shipped config/devices.json: %v", err)
+	}
+	if len(devices) == 0 {
+		t.Fatal("expected at least one device in shipped config/devices.json")
+	}
+
+	for id, d := range devices {
+		if d == nil {
+			t.Fatalf("device %q is nil", id)
+		}
+		if d.Site == nil {
+			continue
+		}
+		if d.Site.GetId() == "" {
+			t.Fatalf("device %q has site with empty id", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Quote `site.id` / `site.company_id` in shipped `config/devices.json` as strings so they match protobuf `devicepb.Site` after #916.
- Restore explicit `json:"site"` on `Device.Site`.
- Add `TestShippedDevicesJSONUnmarshals` so CI fails if the entrypoint devices file becomes unloadable again.

## Why
The Docker `ENTRYPOINT` always passes `-api_devices /etc/ktranslate/devices.json`. After #916 moved `Device.Site` to protobuf string IDs, numeric values in that stub caused every `:v2` container to fail at startup with:

```
json: cannot unmarshal number into Go struct field Site.Site.id of type string
```

## Test plan
- [x] `CGO_ENABLED=0 go test ./pkg/kt/ -run TestShippedDevicesJSONUnmarshals -v`
- [ ] Confirm a container started from this branch with default entrypoint no longer crashes on `loadDevices`
- [ ] Optional follow-up: accept numeric-or-string site IDs in unmarshal, and/or stop loading the sample devices file by default
