### PR TITLE
Sanitize invalid UTF-8 in OTEL attributes to avoid batch drops

### DIFF
--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -195,6 +195,10 @@ func (f *OtelFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 		return nil, nil
 	}
 
+	for i := range res {
+		res[i].Name = kt.SanitizeUTF8(res[i].Name)
+	}
+
 	f.mux.RLock()
 	for _, m := range res {
 		if _, ok := f.vecs[m.Name]; !ok {
@@ -273,6 +277,10 @@ func (f *OtelFormat) Rollup(rolls []rollup.Rollup) (*kt.Output, error) {
 	res := f.toOtelDataRollup(rolls)
 	if len(res) == 0 {
 		return nil, nil
+	}
+
+	for i := range res {
+		res[i].Name = kt.SanitizeUTF8(res[i].Name)
 	}
 
 	f.mux.RLock()
@@ -763,22 +771,23 @@ type OtelData struct {
 func (d *OtelData) GetTagValues() attribute.Set {
 	res := make([]attribute.KeyValue, 0, len(d.Tags))
 	for k, v := range d.Tags {
+		key := kt.SanitizeUTF8(k)
 		switch t := v.(type) {
 		case string:
-			res = append(res, attribute.String(k, t))
+			res = append(res, attribute.String(key, kt.SanitizeUTF8(t)))
 		case int64:
-			res = append(res, attribute.Int64(k, t))
+			res = append(res, attribute.Int64(key, t))
 		case int32:
-			res = append(res, attribute.Int64(k, int64(t)))
+			res = append(res, attribute.Int64(key, int64(t)))
 		case float64:
-			res = append(res, attribute.Float64(k, t))
+			res = append(res, attribute.Float64(key, t))
 		case uint32:
-			res = append(res, attribute.Int64(k, int64(t)))
+			res = append(res, attribute.Int64(key, int64(t)))
 		case uint64:
-			res = append(res, attribute.Int64(k, int64(t)))
+			res = append(res, attribute.Int64(key, int64(t)))
 		default:
 			// Convert unknown types to string representation
-			res = append(res, attribute.String(k, fmt.Sprintf("%v", t)))
+			res = append(res, attribute.String(key, kt.SanitizeUTF8(fmt.Sprintf("%v", t))))
 		}
 	}
 	s, _ := attribute.NewSetWithFiltered(res, func(kv attribute.KeyValue) bool { return true })

--- a/pkg/inputs/snmp/traps/traps.go
+++ b/pkg/inputs/snmp/traps/traps.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -274,13 +273,10 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 						dst.CustomStr[res.GetName()] = sval
 					}
 				} else { // No conversion.
-					if !utf8.ValidString(value) { // Print out value as a hex string.
-						value = fmt.Sprintf("%x", v.Value)
-					}
 					if res != nil {
-						dst.CustomStr[res.GetName()] = value
+						dst.CustomStr[res.GetName()] = kt.SanitizeUTF8(value)
 					} else {
-						dst.CustomStr[v.Name] = value
+						dst.CustomStr[v.Name] = kt.SanitizeUTF8(value)
 					}
 				}
 			}
@@ -295,9 +291,7 @@ func (s *SnmpTrap) handle(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 			if res != nil && res.Conversion != "" { // Adjust for any hard coded values here.
 				_, value, _ = snmp_util.GetFromConv(v, res.Conversion, s.log)
 			}
-			if !utf8.ValidString(value) { // Print out value as a hex string.
-				value = fmt.Sprintf("%x", v.Value)
-			}
+			value = kt.SanitizeUTF8(value)
 			if res != nil {
 				dst.CustomStr[res.GetName()] = value
 			} else {

--- a/pkg/kt/utf8.go
+++ b/pkg/kt/utf8.go
@@ -1,0 +1,26 @@
+package kt
+
+import (
+	"encoding/hex"
+	"unicode/utf8"
+)
+
+// SanitizeUTF8 returns s unchanged when it is valid UTF-8. Otherwise it
+// returns a hex encoding of the raw bytes so callers can still export the
+// value (OTLP/gRPC and JSON reject invalid UTF-8 and will drop whole batches).
+// This mirrors the SNMP trap handling of non-UTF-8 octet strings.
+func SanitizeUTF8(s string) string {
+	if s == "" || utf8.ValidString(s) {
+		return s
+	}
+	return hex.EncodeToString([]byte(s))
+}
+
+// SanitizeUTF8WithHint is like SanitizeUTF8 but also reports whether the
+// value was rewritten.
+func SanitizeUTF8WithHint(s string) (string, bool) {
+	if s == "" || utf8.ValidString(s) {
+		return s, false
+	}
+	return hex.EncodeToString([]byte(s)), true
+}

--- a/pkg/kt/utf8_test.go
+++ b/pkg/kt/utf8_test.go
@@ -1,0 +1,37 @@
+package kt
+
+import (
+	"testing"
+)
+
+func TestSanitizeUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "ascii", in: "ifAlias-ok", want: "ifAlias-ok"},
+		{name: "valid unicode", in: "café", want: "café"},
+		{name: "invalid byte", in: "bad\xffname", want: "626164ff6e616d65"},
+		{name: "only invalid", in: "\x80\xff", want: "80ff"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeUTF8(tt.in); got != tt.want {
+				t.Fatalf("SanitizeUTF8(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeUTF8WithHint(t *testing.T) {
+	got, changed := SanitizeUTF8WithHint("ok")
+	if got != "ok" || changed {
+		t.Fatalf("valid input: got=%q changed=%v", got, changed)
+	}
+	got, changed = SanitizeUTF8WithHint("x\xff")
+	if !changed || got != "78ff" {
+		t.Fatalf("invalid input: got=%q changed=%v", got, changed)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `kt.SanitizeUTF8` / `SanitizeUTF8WithHint`: leave valid UTF-8 alone; hex-encode invalid bytes (same idea as SNMP traps).
- Use it in the OTEL formatter for metric names and attribute keys/values so one bad SNMP string cannot fail the whole OTLP export.
- Point SNMP traps at the shared helper.

## Why
OTLP/gRPC marshaling rejects invalid UTF-8 and drops the entire metric batch. Commvault and similar devices often emit non-UTF-8 `ifAlias` / `sysName` / MIB strings.

## Test plan
- [x] `CGO_ENABLED=0 go test ./pkg/kt/ -run TestSanitizeUTF8 -v`
- [x] `CGO_ENABLED=0` compile of `pkg/formats/otel` and `pkg/inputs/snmp/traps`
- [ ] Run SNMP poller against a device with known bad UTF-8 aliases and confirm metrics still export (alias shows as hex)
