### PR TITLE
Fix OTLP export of internal CHF metrics with otel format and rollups

### DIFF
--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -576,11 +576,24 @@ func (kc *KTranslate) monitorMetricsInput(ctx context.Context, seri func([]*kt.J
 		select {
 		case msgs := <-kc.metricsChan:
 			// Internal jchf health metrics must not pass through rollup accumulation.
-			ser, err := seri(msgs, serBuf)
-			if err != nil {
-				kc.log.Errorf("There was an error when converting metrics: %v.", err)
-			} else if ser != nil {
-				kc.msgsc <- ser
+			// Still honor MaxFlowsPerMessage batching (same loop as handleInput export).
+			keep := len(msgs)
+			last := 0
+			for next := kc.config.MaxFlowsPerMessage; next < keep+kc.config.MaxFlowsPerMessage; next += kc.config.MaxFlowsPerMessage {
+				batch := next
+				if batch > keep {
+					batch = keep
+				}
+				ser, err := seri(msgs[last:batch], serBuf)
+				if err != nil {
+					kc.log.Errorf("There was an error when converting metrics: %v.", err)
+				} else if ser != nil {
+					kc.msgsc <- ser
+				}
+				last = next
+				if batch == keep {
+					break
+				}
 			}
 		case <-ctx.Done():
 			kc.log.Infof("monitorMetricsInput Done")

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -575,7 +575,13 @@ func (kc *KTranslate) monitorMetricsInput(ctx context.Context, seri func([]*kt.J
 	for {
 		select {
 		case msgs := <-kc.metricsChan:
-			kc.handleInput(ctx, msgs, serBuf, nil, seri)
+			// Internal jchf health metrics must not pass through rollup accumulation.
+			ser, err := seri(msgs, serBuf)
+			if err != nil {
+				kc.log.Errorf("There was an error when converting metrics: %v.", err)
+			} else if ser != nil {
+				kc.msgsc <- ser
+			}
 		case <-ctx.Done():
 			kc.log.Infof("monitorMetricsInput Done")
 			return
@@ -822,19 +828,27 @@ func (kc *KTranslate) Run(ctx context.Context) error {
 		kc.http = sh
 	}
 
-	// If we're sending self metrics via a chan to sinks. This one always get sent via nrm.
+	// If we're sending self metrics via a chan to sinks.
 	if kc.metricsChan != nil {
-		// Set up formatter
-		format := formats.Format(formats.FORMAT_NRM)
+		metricFormat := formats.Format(formats.FORMAT_NRM)
 		if kc.config.FormatMetric != "" {
-			format = formats.Format(kc.config.FormatMetric)
+			metricFormat = formats.Format(kc.config.FormatMetric)
 		}
 
-		fmtr, err := formats.NewFormat(ctx, format, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config, kc.logTee)
-		if err != nil {
-			return err
+		var metricsFmtr formats.Formatter
+		if metricFormat == format {
+			// Reuse the main formatter when metric export uses the same encoding.
+			// A second otel formatter would replace the global MeterProvider and
+			// drop internal (jchf) metrics on flow-only receivers.
+			metricsFmtr = kc.format
+		} else {
+			mf, err := formats.NewFormat(ctx, metricFormat, kc.log.GetLogger().GetUnderlyingLogger(), kc.registry, compression, kc.config, kc.logTee)
+			if err != nil {
+				return err
+			}
+			metricsFmtr = mf
 		}
-		go kc.monitorMetricsInput(ctx, fmtr.To)
+		go kc.monitorMetricsInput(ctx, metricsFmtr.To)
 	}
 
 	kc.log.Infof("System running with format %s, compression %s, max flows: %d, sample rate %d:1 after %d", kc.config.Format, kc.config.Compression, kc.config.MaxFlowsPerMessage, kc.config.SampleRate, kc.config.SampleMin)

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -577,10 +577,13 @@ func (kc *KTranslate) monitorMetricsInput(ctx context.Context, seri func([]*kt.J
 		case msgs := <-kc.metricsChan:
 			// Internal jchf health metrics must not pass through rollup accumulation.
 			// Still honor MaxFlowsPerMessage batching (same loop as handleInput export).
-			keep := len(msgs)
-			last := 0
-			for next := kc.config.MaxFlowsPerMessage; next < keep+kc.config.MaxFlowsPerMessage; next += kc.config.MaxFlowsPerMessage {
-				batch := next
+keep := len(msgs)
+last := 0
+batchSize := kc.config.MaxFlowsPerMessage
+if batchSize <= 0 {
+	batchSize = 1
+}
+for next := batchSize; next < keep+batchSize; next += batchSize {
 				if batch > keep {
 					batch = keep
 				}

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -606,7 +606,11 @@ func (kc *KTranslate) monitorMetricsInput(ctx context.Context, seri func([]*kt.J
 			// InputQ is not updated here — it tracks user-facing volume through handleInput only.
 			// When format_metric matches format we reuse kc.format.To; OtelFormat serializes
 			// gauge registration under f.mux (see pkg/formats/otel/otel.go).
-			kc.exportJchfBatches(msgs, len(msgs), serBuf, nil, seri, "metrics")
+			logLabel := kc.config.FormatMetric
+			if logLabel == "" {
+				logLabel = string(formats.FORMAT_NRM)
+			}
+			kc.exportJchfBatches(msgs, len(msgs), serBuf, nil, seri, logLabel)
 		case <-ctx.Done():
 			kc.log.Infof("monitorMetricsInput Done")
 			return

--- a/pkg/cat/kkc.go
+++ b/pkg/cat/kkc.go
@@ -463,6 +463,50 @@ func (kc *KTranslate) sendToSinks(ctx context.Context) error {
 	}
 }
 
+// effectiveMaxFlowsPerMessage returns a positive batch size. Config validation keeps
+// MaxFlowsPerMessage > 0 for most formats, but sendToSinks can shrink it dynamically
+// and a zero/negative value would otherwise stall the export loop.
+func effectiveMaxFlowsPerMessage(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	return n
+}
+
+// jchfExportSliceBounds yields [last:batch) slice pairs for splitting keep messages
+// into MaxFlowsPerMessage chunks (same loop semantics as the legacy handleInput export).
+func jchfExportSliceBounds(batchSize, keep int) [][2]int {
+	batchSize = effectiveMaxFlowsPerMessage(batchSize)
+	var bounds [][2]int
+	last := 0
+	for next := batchSize; next < keep+batchSize; next += batchSize {
+		batch := next
+		if batch > keep {
+			batch = keep
+		}
+		bounds = append(bounds, [2]int{last, batch})
+		last = next
+		if batch == keep {
+			break
+		}
+	}
+	return bounds
+}
+
+// exportJchfBatches serializes msgs and enqueues Outputs, honoring MaxFlowsPerMessage.
+// cb is attached when non-nil (flow path); internal metrics pass nil.
+func (kc *KTranslate) exportJchfBatches(msgs []*kt.JCHF, keep int, serBuf []byte, cb func(error), seri func([]*kt.JCHF, []byte) (*kt.Output, error), logLabel string) {
+	for _, span := range jchfExportSliceBounds(kc.config.MaxFlowsPerMessage, keep) {
+		ser, err := seri(msgs[span[0]:span[1]], serBuf)
+		if err != nil {
+			kc.log.Errorf("There was an error when converting to %s: %v.", logLabel, err)
+		} else if ser != nil {
+			ser.CB = cb
+			kc.msgsc <- ser
+		}
+	}
+}
+
 // This processes data from the non-kentik input sets.
 func (kc *KTranslate) handleInput(ctx context.Context, msgs []*kt.JCHF, serBuf []byte, cb func(error), seri func([]*kt.JCHF, []byte) (*kt.Output, error)) {
 	if kc.geo != nil || kc.asn != nil || kc.enricher != nil {
@@ -504,26 +548,7 @@ func (kc *KTranslate) handleInput(ctx context.Context, msgs []*kt.JCHF, serBuf [
 			kc.log.Debugf("Reduced input from %d to %d", len(msgs), keep)
 		}
 
-		// Ship all the logs out, according to max flows per message.
-		last := 0
-		for next := kc.config.MaxFlowsPerMessage; next < keep+kc.config.MaxFlowsPerMessage; next += kc.config.MaxFlowsPerMessage {
-			batch := next
-			if batch > keep {
-				batch = keep
-			}
-			ser, err := seri(msgs[last:batch], serBuf)
-			if err != nil {
-				kc.log.Errorf("There was an error when converting to native: %v.", err)
-			} else if ser != nil {
-				ser.CB = cb
-				kc.msgsc <- ser
-			}
-			last = next
-
-			if batch == keep { // We're done here, no need to send more.
-				break
-			}
-		}
+		kc.exportJchfBatches(msgs, keep, serBuf, cb, seri, "native")
 	}
 
 	kc.metrics.InputQ.Mark(int64(len(msgs)))
@@ -575,29 +600,13 @@ func (kc *KTranslate) monitorMetricsInput(ctx context.Context, seri func([]*kt.J
 	for {
 		select {
 		case msgs := <-kc.metricsChan:
-			// Internal jchf health metrics must not pass through rollup accumulation.
-			// Still honor MaxFlowsPerMessage batching (same loop as handleInput export).
-keep := len(msgs)
-last := 0
-batchSize := kc.config.MaxFlowsPerMessage
-if batchSize <= 0 {
-	batchSize = 1
-}
-for next := batchSize; next < keep+batchSize; next += batchSize {
-				if batch > keep {
-					batch = keep
-				}
-				ser, err := seri(msgs[last:batch], serBuf)
-				if err != nil {
-					kc.log.Errorf("There was an error when converting metrics: %v.", err)
-				} else if ser != nil {
-					kc.msgsc <- ser
-				}
-				last = next
-				if batch == keep {
-					break
-				}
-			}
+			// Internal jchf health metrics bypass rollup accumulation (rollup.Add never runs).
+			// With RollupAndAlpha=true, user flows still pass through rollups before export;
+			// internal CHF counters intentionally skip that path so health gauges stay raw.
+			// InputQ is not updated here — it tracks user-facing volume through handleInput only.
+			// When format_metric matches format we reuse kc.format.To; OtelFormat serializes
+			// gauge registration under f.mux (see pkg/formats/otel/otel.go).
+			kc.exportJchfBatches(msgs, len(msgs), serBuf, nil, seri, "metrics")
 		case <-ctx.Done():
 			kc.log.Infof("monitorMetricsInput Done")
 			return

--- a/pkg/cat/kkc_batches_test.go
+++ b/pkg/cat/kkc_batches_test.go
@@ -1,0 +1,48 @@
+package cat
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEffectiveMaxFlowsPerMessage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want int
+	}{
+		{0, 1},
+		{-5, 1},
+		{1, 1},
+		{100, 100},
+	}
+	for _, tc := range cases {
+		if got := effectiveMaxFlowsPerMessage(tc.in); got != tc.want {
+			t.Fatalf("effectiveMaxFlowsPerMessage(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestJchfExportSliceBounds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		batchSize int
+		keep      int
+		want      [][2]int
+	}{
+		{"single", 10000, 3, [][2]int{{0, 3}}},
+		{"exact", 4, 8, [][2]int{{0, 4}, {4, 8}}},
+		{"partial-last", 4, 10, [][2]int{{0, 4}, {4, 8}, {8, 10}}},
+		{"zero-batch-clamped", 0, 5, [][2]int{{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := jchfExportSliceBounds(tc.batchSize, tc.keep)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("jchfExportSliceBounds(%d, %d) = %v, want %v", tc.batchSize, tc.keep, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/formats/otel/otel.go
+++ b/pkg/formats/otel/otel.go
@@ -169,6 +169,9 @@ func NewFormat(ctx context.Context, log logger.Underlying, cfg *ktranslate.OtelF
 		return nil, fmt.Errorf("Invalid otel.protocol value. Currently supported: grpc,http,https,stdout")
 	}
 
+	// Process-wide global: only one otel metrics formatter should call SetMeterProvider per
+	// ktranslate process. cat reuses kc.format when format_metric matches format (see kkc.go);
+	// a second NewFormat(otel) would replace the provider and drop internal CHF metrics.
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp)))
 	otel.SetMeterProvider(meterProvider)
 	jf.exp = exp


### PR DESCRIPTION
Reuse the main otel formatter for monitorMetricsInput when FormatMetric equals Format, avoiding a second global MeterProvider.

Route metricsChan directly to the formatter in monitorMetricsInput instead of handleInput when --rollups is enabled; rollup accumulation was swallowing jchf health metrics on flow and sFlow receivers.




## Summary

Fixes internal health metrics (`--metrics=jchf`) not reaching OTLP when ktranslate uses **`--format=otel --format_metric=otel`** — the common OTLP-only deployment pattern (one process per role: SNMP poller, NetFlow, sFlow, syslog).

**File changed:** `pkg/cat/kkc.go` only (two hunks, ~30 lines).

---

## Background / who is affected

We run **four ktranslate containers** per site, all with:

```text
--format=otel --format_metric=otel --sinks=otel --metrics=jchf --tee_logs=true
```

Flow/sFlow containers also use `--rollups=…` for top-K byte rollups. Syslog uses `--flow_only=true` without rollups. SNMP poller has no `flow_only` and no rollups.

**Symptom:** Flow and sFlow rollups (`network_io_by_flow_bytes`, etc.) arrived in Grafana Cloud, but **`kentik_ktranslate_chf_kkc_*` series were missing** for those containers. Logs showed `monitorMetricsInput Starting` but never `Creating otel export for kentik.ktranslate.chf.kkc.*`. SNMP and syslog CHF partially worked (depending on which bug bit first).

This matters for anyone monitoring ktranslate container health via OTLP (queue depth, ingest rates, `baseserver_healthcheck_*`, `netflow.flows`, etc.) — see [NR ktranslate container health docs](https://docs.newrelic.com/docs/network-performance-monitoring/advanced/ktranslate-container-health/) for the metric meanings; OTLP names are `kentik_ktranslate_chf_kkc_<name>`.

---

## Root cause (two independent bugs)

### Bug 1 — Second otel formatter replaces global `MeterProvider`

**Where:** `KTranslate.Run()` when wiring `metricsChan`.

**Before:** Always called `formats.NewFormat()` for the metrics encoder, even when `FormatMetric == Format` (both `otel`).

**Why it breaks:** `OtelFormat` construction calls `otel.SetMeterProvider()` (`pkg/formats/otel/otel.go`). A second instance orphans the first provider's periodic reader. New CHF instruments register on the second provider, but export may not run as expected; syslog/flow receivers with `otel+otel` lose CHF on OTLP.

**Who hits it:** Any receiver with `--format=otel --format_metric=otel`. Not limited to `flow_only`.

### Bug 2 — `--rollups` blocks CHF export entirely

**Where:** `monitorMetricsInput` → `handleInput`.

**Before:** CHF batches from `metricsChan` went through the same `handleInput` path as NetFlow records.

**Why it breaks:** When `doRollups=true`, `handleInput` accumulates records into rollup state, then only calls the encoder when:

```go
if !kc.doRollups || kc.config.RollupAndAlpha {
    ser, err := seri(msgs, ...)
```

With default `RollupAndAlpha=false`, **`seri()` is never called** for the metrics channel. CHF data was fed into rollup accumulators (noise) and never exported. Syslog has no rollups → unaffected. Flow/sFlow → broken.

---

## What this PR changes

### Change 1 — Reuse main formatter when encodings match (`Run()`, ~line 828)

| Before | After |
|--------|-------|
| Always `NewFormat(FormatMetric)` for metrics | If `FormatMetric == Format`, reuse `kc.format`; else `NewFormat` as before |

**Intent:** One `OtelFormat` / one `MeterProvider` when data and metrics share the same encoding.

### Change 2 — Bypass `handleInput` for `metricsChan` (`monitorMetricsInput`, ~line 575)

| Before | After |
|--------|-------|
| `kc.handleInput(ctx, msgs, serBuf, nil, seri)` | Call `seri(msgs, serBuf)` directly; push result to `kc.msgsc` |

**Intent:** Internal `KTranslateMetric` events (`--metrics=jchf`) should not pass through geo enrichment, flow filters, sampling, or rollup accumulation. Same sink fan-out as before (`doSend` → all configured sinks).

---

## What does **not** change

| Area | Impact |
|------|--------|
| **NetFlow / sFlow / syslog / SNMP data path** | Unchanged — still `inputChan` → `monitorAlpha` → `handleInput` → rollups/format → `msgsc` |
| **`format != format_metric`** (e.g. `format=avro`, `format_metric=nrm`, or default NRM metrics) | Unchanged — still creates a separate metrics formatter |
| **Sink routing** | Unchanged — `msgsc` → `doSend` → every sink in `--sinks` |
| **Rollup export timing/content** | Unchanged — `formatRollup.Rollup()` on the rollup ticker is untouched |
| **Kentik SaaS / NR / Kafka / file sinks** | No code changes in sink packages; only what gets encoded for CHF |

---

## Potential impacts / risks (for review)

### Low risk — expected improvements

- **`otel+otel` deployments:** CHF metrics (`jchfq`, `inputq_len`, `netflow.flows`, `syslog_messages`, `device_metrics`, …) should appear on OTLP ~60s after start.
- **Flow/sFlow with `--rollups`:** CHF no longer incorrectly accumulated into rollup state (was never intentional export path).
- **Concurrent formatter use:** `OtelFormat.To()` already holds `sync.RWMutex`; sharing `kc.format` between flow export and CHF export is safe.

### Configurations deliberately unchanged

- **`FormatMetric != Format`:** Still allocates a dedicated metrics formatter (preserves existing split-encoding behavior).
- **`--rollup_and_alpha=true`:** Rare; previously CHF could export *and* enter rollups; now CHF exports only via metrics channel (correct for health metrics).

### Minor behavioral delta (internal bookkeeping only)

- CHF batches no longer call `handleInput`'s trailing `InputQ.Mark()`. May slightly under-report `inputq` for self-metrics only; does not affect customer flow data or sink output.

### Not in scope / not a regression concern

- Does not change HTTP `/info` or healthcheck endpoints.
- Does not change `--tee_logs` or log OTLP path.
- Does not affect receivers without `--metrics=jchf` (metrics channel unused).

---

## How we verified

Multi-container lab, all collectors on patched binary, Grafana Cloud OTLP backend:

- [x] **Flow:** logs show `Creating otel export for kentik.ktranslate.chf.kkc.netflow.flows` (+ other CHF series) ~60s after start
- [x] **sFlow:** CHF OTLP series present (`ktranslate-sflow` / `service.name`)
- [x] **Syslog:** CHF still works (`syslog_messages`, `jchfq`, …)
- [x] **SNMP poller:** CHF still works (`device_metrics`, `snmp_fail`, `jchfq`, …) alongside SNMP poll metrics
- [x] **Flow rollups:** `network_io_by_flow_bytes` unchanged (src/dst host enrichment, rates)
- [x] **Split format path:** not re-tested here; code path is explicitly preserved when `metricFormat != format`

**Minimal repro (flow container):**

```bash
ktranslate --format=otel --format_metric=otel --sinks=otel --metrics=jchf \
  --flow_only=true --nf.source=netflow9 --nf.port=9995 \
  --rollups=s_sum,bytes_by_flow,in_bytes+out_bytes,src_addr,dst_addr,device_name
```

After ~60s:

```bash
grep 'Creating otel export.*chf.kkc' <container-logs>
```

**PromQL sanity check:**

```promql
count by (service_name) ({__name__=~"kentik_ktranslate_chf_kkc_.*"})
```

Expect a series per ktranslate role (flow, sflow, snmp, syslog) when all are running with `jchf`.

---

## Reviewer checklist

1. Confirm `metricFormat == format` reuse is acceptable for non-otel format pairs (e.g. `avro+avro`) — should be equivalent to sharing one encoder instance.
2. Confirm direct `metricsChan` → `seri()` is preferable to adding a `KTranslateMetric` exception inside `handleInput` (we chose direct path to avoid filters/enrichment/rollups on health metrics).
3. Any Kentik deployments relying on CHF entering rollup accumulators? We believe that was accidental; no legitimate use case found.
