### PR TITLE
fix(formats/nrm): sanitize invalid UTF-8 strings before JSON marshaling

### DIFF
--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -125,7 +125,6 @@ func (f *NRMFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 		}
 	}
 
-
 	target, err := json.Marshal([]NRMetricSet{ms}) // Has to be an array here, no idea why.
 	if err != nil {
 		return nil, err

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -120,7 +120,7 @@ func (f *NRMFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 				}
 			}
 		}
-	if strVal, ok := ms.Metrics[i].Value.(string); ok {
+		if strVal, ok := ms.Metrics[i].Value.(string); ok {
 			ms.Metrics[i].Value = kt.SanitizeUTF8(strVal)
 		}
 	}

--- a/pkg/formats/nrm/nrm.go
+++ b/pkg/formats/nrm/nrm.go
@@ -112,6 +112,19 @@ func (f *NRMFormat) To(msgs []*kt.JCHF, serBuf []byte) (*kt.Output, error) {
 	if len(ms.Metrics) == 0 {
 		return nil, nil
 	}
+	for i := range ms.Metrics {
+		if ms.Metrics[i].Attributes != nil {
+			for k, v := range ms.Metrics[i].Attributes {
+				if strVal, ok := v.(string); ok {
+					ms.Metrics[i].Attributes[k] = kt.SanitizeUTF8(strVal)
+				}
+			}
+		}
+	if strVal, ok := ms.Metrics[i].Value.(string); ok {
+			ms.Metrics[i].Value = kt.SanitizeUTF8(strVal)
+		}
+	}
+
 
 	target, err := json.Marshal([]NRMetricSet{ms}) // Has to be an array here, no idea why.
 	if err != nil {


### PR DESCRIPTION
### Problem
When polling certain Cisco devices (e.g., ASR/ISR) with SNMP profiles, some OIDs return raw binary data instead of standard printable ASCII text inside OctetString fields. Examples include:
- `mac_address` (OID: `1.3.6.1.4.1.9.9.500.1.2.1.1.7` via `cswSwitchMacAddress`)
- `cntpPeersPeerAddress` (OID: `1.3.6.1.4.1.9.9.168.1.2.1.1.3`)

When these raw binary strings are merged into metric attributes, they bypass initial validation. However, during the serialization phase in `pkg/formats/nrm/nrm.go`, the strict UTF-8 validator (`!utf8.Valid(target)`) detects these invalid UTF-8 byte sequences in the JSON output, triggering `f.handleInvalid` and dropping the entire metrics batch. This leads to severe, intermittent data gaps in New Relic for unaffected metrics like CPU and interface traffic, depending on the batch combination.

### Solution
In `NRMFormat.To()` inside `pkg/formats/nrm/nrm.go`, we now traverse all metrics in the batch right before calling `json.Marshal`. For any string-typed value found inside `Attributes` or `Value`, we apply the existing helper `kt.SanitizeUTF8()`. 

This ensures that any raw binary strings are safely converted to hex-encoded ASCII/UTF-8 strings. It prevents the JSON marshaler/validator from rejecting the payload, completely eliminating the batch drop issue while preserving other critical metrics in the same batch.

### Verification
- Verified that standard SNMP walks do not trigger any `iconv` validation errors because net-snmp automatically formats binary bytes into hex-strings.
- Confirmed that raw packets processed through KTranslate contain raw bytes that trigger the "Invalid UTF-8" error exactly at the end of interface polling batches.
- Applied this patch locally and confirmed that the New Relic sink no longer logs "Invalid utf8 char found" errors and metrics are consistently transmitted without gaps.